### PR TITLE
Scrollfix1

### DIFF
--- a/doc/nuklear.html
+++ b/doc/nuklear.html
@@ -702,6 +702,7 @@ as well as some other configuration values have to be configured by filling out 
 `nk_convert_config` struct.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
 nk_flags nk_convert(struct nk_context *ctx, struct nk_buffer *cmds,
+    struct nk_buffer *vertices, struct nk_buffer *elements, const struct nk_convert_config*);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Parameter   | Description
 ------------|-----------------------------------------------------------
@@ -1077,8 +1078,8 @@ void nk_window_get_scroll(struct nk_context *ctx, nk_uint *offset_x, nk_uint *of
 Parameter    | Description
 -------------|-----------------------------------------------------------
 __ctx__      | Must point to an previously initialized `nk_context` struct
-__offset_x__ | A pointer to the x offset output
-__offset_y__ | A pointer to the y offset output
+__offset_x__ | A pointer to the x offset output (or NULL to ignore)
+__offset_y__ | A pointer to the y offset output (or NULL to ignore)
 #### nk_window_has_focus
 Returns if the currently processed window is currently active
 !!! WARNING
@@ -1792,6 +1793,7 @@ while (1) {
     case ...:
         // [...]
     }
+    nk_clear(&ctx);
 }
 nk_free(&ctx);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1804,6 +1806,8 @@ nk_group_end                    | Ends a group. Should only be called if nk_grou
 nk_group_scrolled_offset_begin  | Start a new group with manual separated handling of scrollbar x- and y-offset
 nk_group_scrolled_begin         | Start a new group with manual scrollbar handling
 nk_group_scrolled_end           | Ends a group with manual scrollbar handling. Should only be called if nk_group_begin returned non-zero
+nk_group_get_scroll             | Gets the scroll offset for the given group
+nk_group_set_scroll             | Sets the scroll offset for the given group
 #### nk_group_begin
 Starts a new widget group. Requires a previous layouting function to specify a pos/size.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
@@ -1879,8 +1883,8 @@ Parameter    | Description
 -------------|-----------------------------------------------------------
 __ctx__      | Must point to an previously initialized `nk_context` struct
 __id__       | The id of the group to get the scroll position of
-__x_offset__ | A pointer to the x offset output
-__y_offset__ | A pointer to the y offset output
+__x_offset__ | A pointer to the x offset output (or NULL to ignore)
+__y_offset__ | A pointer to the y offset output (or NULL to ignore)
 #### nk_group_set_scroll
 Sets the scroll position of the given group.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
@@ -2137,6 +2141,7 @@ while (1) {
     case ...:
         // [...]
     }
+    nk_clear(&ctx);
 }
 nk_free(&ctx);
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -2307,6 +2312,7 @@ X...XXXXXXXXXXXXX...X -           "
    - [x]: Major version with API and library breaking changes
    - [yy]: Minor version with non-breaking API and library changes
    - [zz]: Bug fix version with no direct changes to API
+- 2019/10/09 (4.01.4) - Fix bug for autoscrolling in nk_do_edit
 - 2019/09/20 (4.01.3) - Fixed a bug wherein combobox cannot be closed by clicking the header
                        when NK_BUTTON_TRIGGER_ON_RELEASE is defined.
 - 2019/09/10 (4.01.2) - Fixed the nk_cos function, which deviated significantly.

--- a/nuklear.h
+++ b/nuklear.h
@@ -25475,6 +25475,7 @@ nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
+/// - 2019/10/09 (4.01.4) - Fix bug for autoscrolling in nk_do_edit
 /// - 2019/09/20 (4.01.3) - Fixed a bug wherein combobox cannot be closed by clicking the header
 ///                        when NK_BUTTON_TRIGGER_ON_RELEASE is defined.
 /// - 2019/09/10 (4.01.2) - Fixed the nk_cos function, which deviated significantly.

--- a/nuklear.h
+++ b/nuklear.h
@@ -23182,7 +23182,7 @@ nk_do_edit(nk_flags *state, struct nk_command_buffer *out,
                     if (cursor_pos.x < edit->scrollbar.x)
                         edit->scrollbar.x = (float)(int)NK_MAX(0.0f, cursor_pos.x - scroll_increment);
                     if (cursor_pos.x >= edit->scrollbar.x + area.w)
-                        edit->scrollbar.x = (float)(int)NK_MAX(0.0f, edit->scrollbar.x + scroll_increment);
+                        edit->scrollbar.x = (float)(int)NK_MAX(0.0f, cursor_pos.x - area.w + scroll_increment);
                 } else edit->scrollbar.x = 0;
 
                 if (flags & NK_EDIT_MULTILINE) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuklear",
-  "version": "4.01.3",
+  "version": "4.01.4",
   "repo": "vurtun/nuklear",
   "description": "A small ANSI C gui toolkit",
   "keywords": ["gl", "ui", "toolkit"],

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -8,6 +8,7 @@
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
+/// - 2019/10/09 (4.01.4) - Fix bug for autoscrolling in nk_do_edit
 /// - 2019/09/20 (4.01.3) - Fixed a bug wherein combobox cannot be closed by clicking the header
 ///                        when NK_BUTTON_TRIGGER_ON_RELEASE is defined.
 /// - 2019/09/10 (4.01.2) - Fixed the nk_cos function, which deviated significantly.

--- a/src/nuklear_edit.c
+++ b/src/nuklear_edit.c
@@ -461,7 +461,7 @@ nk_do_edit(nk_flags *state, struct nk_command_buffer *out,
                     if (cursor_pos.x < edit->scrollbar.x)
                         edit->scrollbar.x = (float)(int)NK_MAX(0.0f, cursor_pos.x - scroll_increment);
                     if (cursor_pos.x >= edit->scrollbar.x + area.w)
-                        edit->scrollbar.x = (float)(int)NK_MAX(0.0f, edit->scrollbar.x + scroll_increment);
+                        edit->scrollbar.x = (float)(int)NK_MAX(0.0f, cursor_pos.x - area.w + scroll_increment);
                 } else edit->scrollbar.x = 0;
 
                 if (flags & NK_EDIT_MULTILINE) {

--- a/src/nuklear_math.c
+++ b/src/nuklear_math.c
@@ -66,8 +66,8 @@ nk_sin(float x)
 NK_LIB float
 nk_cos(float x)
 {
-    // New implementation. Also generated using lolremez.
-    // Old version significantly deviated from expected results.
+    /* New implementation. Also generated using lolremez. */
+    /* Old version significantly deviated from expected results. */
     NK_STORAGE const float a0 = 9.9995999154986614e-1f;
     NK_STORAGE const float a1 = 1.2548995793001028e-3f;
     NK_STORAGE const float a2 = -5.0648546280678015e-1f;


### PR DESCRIPTION
    fix nk_do_edit autoscroll.
    
    How to test:
    Create an edit widget.
    Enter a long text into the edit widget.
    Press "home" so that widget autoscrolls to start of text.
    Press "end" so that widget now should jump to end of text.
    Previously you had to press "end" several times to jump to the end of text.
    This patch fixes that (pressing "end" once will jump to the end of text).
