### PR TITLE
Added main arg params in demo/sdl_opengl

### DIFF
--- a/demo/sdl_opengl2/main.c
+++ b/demo/sdl_opengl2/main.c
@@ -67,7 +67,7 @@
  *
  * ===============================================================*/
 int
-main(void)
+main(int argc, char *argv[])
 {
     /* Platform */
     SDL_Window *win;

--- a/demo/sdl_opengl3/main.c
+++ b/demo/sdl_opengl3/main.c
@@ -70,7 +70,7 @@
  *                          DEMO
  *
  * ===============================================================*/
-int main(void)
+int main(int argc, char *argv[])
 {
     /* Platform */
     SDL_Window *win;


### PR DESCRIPTION
#66 
This fixed the error: conflicting types for 'SDL_main' when using mingw