### PR TITLE
Use a shared makefile to set the compile flags and enable more warnings

### DIFF
--- a/demo/Makefile.inc
+++ b/demo/Makefile.inc
@@ -1,0 +1,2 @@
+# Flags
+CFLAGS += -std=c99 -pedantic -Wall -Wextra -O2

--- a/demo/allegro5/Makefile
+++ b/demo/allegro5/Makefile
@@ -1,8 +1,8 @@
 # Install
 BIN = demo
 
-# Flags
-CFLAGS += -std=c99 -pedantic -O2
+PARENT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
+include $(PARENT_DIR)/Makefile.inc
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/demo/glfw_opengl2/Makefile
+++ b/demo/glfw_opengl2/Makefile
@@ -1,8 +1,8 @@
 # Install
 BIN = demo
 
-# Flags
-CFLAGS += -std=c99 -pedantic -O2
+PARENT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
+include $(PARENT_DIR)/Makefile.inc
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/demo/glfw_opengl3/Makefile
+++ b/demo/glfw_opengl3/Makefile
@@ -1,8 +1,8 @@
 # Install
 BIN = demo
 
-# Flags
-CFLAGS += -std=c99 -pedantic -O2
+PARENT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
+include $(PARENT_DIR)/Makefile.inc
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/demo/glfw_opengl4/Makefile
+++ b/demo/glfw_opengl4/Makefile
@@ -1,8 +1,8 @@
 # Install
 BIN = demo
 
-# Flags
-CFLAGS += -std=c99 -pedantic -O2
+PARENT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
+include $(PARENT_DIR)/Makefile.inc
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/demo/sdl_opengl2/Makefile
+++ b/demo/sdl_opengl2/Makefile
@@ -1,8 +1,8 @@
 # Install
 BIN = demo
 
-# Flags
-CFLAGS += -std=c99 -pedantic -O2
+PARENT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
+include $(PARENT_DIR)/Makefile.inc
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/demo/sdl_opengl3/Makefile
+++ b/demo/sdl_opengl3/Makefile
@@ -1,8 +1,8 @@
 # Install
 BIN = demo
 
-# Flags
-CFLAGS += -std=c99 -pedantic -O2
+PARENT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
+include $(PARENT_DIR)/Makefile.inc
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/demo/sdl_opengles2/Makefile
+++ b/demo/sdl_opengles2/Makefile
@@ -1,8 +1,8 @@
 # Install
 BIN = demo
 
-# Flags
-CFLAGS += -std=c99 -pedantic -O2
+PARENT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
+include $(PARENT_DIR)/Makefile.inc
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/demo/x11/Makefile
+++ b/demo/x11/Makefile
@@ -1,8 +1,8 @@
 # Install
 BIN = zahnrad
 
-# Flags
-CFLAGS += -std=c89 -pedantic -O2
+PARENT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
+include $(PARENT_DIR)/Makefile.inc
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/demo/x11_opengl2/Makefile
+++ b/demo/x11_opengl2/Makefile
@@ -5,8 +5,8 @@ BIN = demo
 CC = clang
 DCC = gcc
 
-# Flags
-CFLAGS += -std=c99 -pedantic -O2
+PARENT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
+include $(PARENT_DIR)/Makefile.inc
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/demo/x11_opengl3/Makefile
+++ b/demo/x11_opengl3/Makefile
@@ -5,8 +5,8 @@ BIN = demo
 CC = clang
 DCC = gcc
 
-# Flags
-CFLAGS += -std=c99 -pedantic -O2
+PARENT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
+include $(PARENT_DIR)/Makefile.inc
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/demo/x11_rawfb/Makefile
+++ b/demo/x11_rawfb/Makefile
@@ -1,8 +1,8 @@
 # Install
 BIN = zahnrad
 
-# Flags
-CFLAGS += -std=c89 -pedantic -O2 -Wunused
+PARENT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
+include $(PARENT_DIR)/Makefile.inc
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/demo/x11_xft/Makefile
+++ b/demo/x11_xft/Makefile
@@ -1,8 +1,8 @@
 # Install
 BIN = zahnrad
 
-# Flags
-CFLAGS += -std=c89 -pedantic -O2
+PARENT_DIR := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/..)
+include $(PARENT_DIR)/Makefile.inc
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/example/Makefile
+++ b/example/Makefile
@@ -1,5 +1,5 @@
 # Flags
-CFLAGS += -std=c99 -pedantic -O2
+CFLAGS += -std=c99 -pedantic -Wall -Wextra -O2
 LIBS :=
 
 ifeq ($(OS),Windows_NT)


### PR DESCRIPTION
projects that are using the library might have enabled compiler flags that would spam them with
warnings - so we should try to keep the warnings as low as possible