### PR TITLE
Fix memory leak in demo and example code.

### DIFF
--- a/demo/d3d11/nuklear_d3d11.h
+++ b/demo/d3d11/nuklear_d3d11.h
@@ -161,7 +161,8 @@ nk_d3d11_render(ID3D11DeviceContext *context, enum nk_anti_aliasing AA)
         ID3D11DeviceContext_DrawIndexed(context, (UINT)cmd->elem_count, offset, 0);
         offset += cmd->elem_count;
     }
-    nk_clear(&d3d11.ctx);}
+    nk_clear(&d3d11.ctx);
+    nk_buffer_clear(&d3d11.cmds);}
 }
 
 static void

--- a/demo/d3d9/nuklear_d3d9.h
+++ b/demo/d3d9/nuklear_d3d9.h
@@ -190,6 +190,7 @@ nk_d3d9_render(enum nk_anti_aliasing AA)
     }
 
     nk_clear(&d3d9.ctx);
+    nk_buffer_clear(&d3d9.cmds);
 
     IDirect3DStateBlock9_Apply(d3d9.state);
     IDirect3DStateBlock9_Release(d3d9.state);

--- a/demo/glfw_opengl2/nuklear_glfw_gl2.h
+++ b/demo/glfw_opengl2/nuklear_glfw_gl2.h
@@ -174,6 +174,7 @@ nk_glfw3_render(enum nk_anti_aliasing AA)
             offset += cmd->elem_count;
         }
         nk_clear(&glfw.ctx);
+        nk_buffer_clear(&dev->cmds);
         nk_buffer_free(&vbuf);
         nk_buffer_free(&ebuf);
     }

--- a/demo/glfw_opengl3/nuklear_glfw_gl3.h
+++ b/demo/glfw_opengl3/nuklear_glfw_gl3.h
@@ -295,6 +295,7 @@ nk_glfw3_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element
             offset += cmd->elem_count;
         }
         nk_clear(&glfw.ctx);
+        nk_buffer_clear(&dev->cmds);
     }
 
     /* default OpenGL state */

--- a/demo/glfw_opengl4/nuklear_glfw_gl4.h
+++ b/demo/glfw_opengl4/nuklear_glfw_gl4.h
@@ -446,6 +446,7 @@ nk_glfw3_render(enum nk_anti_aliasing AA)
             offset += cmd->elem_count;
         }
         nk_clear(&glfw.ctx);
+        nk_buffer_clear(&dev->cmds);
     }
     /* default OpenGL state */
     glUseProgram(0);

--- a/demo/sdl_opengl2/nuklear_sdl_gl2.h
+++ b/demo/sdl_opengl2/nuklear_sdl_gl2.h
@@ -154,6 +154,7 @@ nk_sdl_render(enum nk_anti_aliasing AA)
             offset += cmd->elem_count;
         }
         nk_clear(&sdl.ctx);
+        nk_buffer_clear(&dev->cmds);
         nk_buffer_free(&vbuf);
         nk_buffer_free(&ebuf);
     }

--- a/demo/sdl_opengl3/nuklear_sdl_gl3.h
+++ b/demo/sdl_opengl3/nuklear_sdl_gl3.h
@@ -275,6 +275,7 @@ nk_sdl_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_b
             offset += cmd->elem_count;
         }
         nk_clear(&sdl.ctx);
+        nk_buffer_clear(&dev->cmds);
     }
 
     glUseProgram(0);

--- a/demo/sdl_opengles2/nuklear_sdl_gles2.h
+++ b/demo/sdl_opengles2/nuklear_sdl_gles2.h
@@ -276,6 +276,7 @@ nk_sdl_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_b
             offset += cmd->elem_count;
         }
         nk_clear(&sdl.ctx);
+        nk_buffer_clear(&dev->cmds);
     }
 
     glUseProgram(0);

--- a/demo/sfml_opengl2/nuklear_sfml_gl2.h
+++ b/demo/sfml_opengl2/nuklear_sfml_gl2.h
@@ -152,6 +152,7 @@ nk_sfml_render(enum nk_anti_aliasing AA)
             offset += cmd->elem_count;
         }
         nk_clear(&sfml.ctx);
+        nk_buffer_clear(&dev->cmds);
         nk_buffer_free(&vbuf);
         nk_buffer_free(&ebuf);
     }

--- a/demo/sfml_opengl3/nuklear_sfml_gl3.h
+++ b/demo/sfml_opengl3/nuklear_sfml_gl3.h
@@ -279,6 +279,7 @@ nk_sfml_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_
             offset += cmd->elem_count;
         }
         nk_clear(&sfml.ctx);
+        nk_buffer_clear(&dev->cmds);
     }
     glUseProgram(0);
     glBindBuffer(GL_ARRAY_BUFFER, 0);

--- a/demo/x11_opengl2/nuklear_xlib_gl2.h
+++ b/demo/x11_opengl2/nuklear_xlib_gl2.h
@@ -184,6 +184,7 @@ nk_x11_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_b
             offset += cmd->elem_count;
         }
         nk_clear(&x11.ctx);
+        nk_buffer_clear(&dev->cmds);
         nk_buffer_free(&vbuf);
         nk_buffer_free(&ebuf);
     }

--- a/demo/x11_opengl3/nuklear_xlib_gl3.h
+++ b/demo/x11_opengl3/nuklear_xlib_gl3.h
@@ -566,6 +566,7 @@ nk_x11_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_b
             offset += cmd->elem_count;
         }
         nk_clear(&x11.ctx);
+        nk_buffer_clear(&dev->cmds);
     }
 
     /* default OpenGL state */

--- a/example/canvas.c
+++ b/example/canvas.c
@@ -293,6 +293,7 @@ device_draw(struct device *dev, struct nk_context *ctx, int width, int height,
             offset += cmd->elem_count;
         }
         nk_clear(ctx);
+        nk_buffer_clear(&dev->cmds);
     }
 
     /* default OpenGL state */

--- a/example/extended.c
+++ b/example/extended.c
@@ -717,6 +717,7 @@ device_draw(struct device *dev, struct nk_context *ctx, int width, int height,
             offset += cmd->elem_count;
         }
         nk_clear(ctx);
+        nk_buffer_clear(&dev->cmds);
     }
 
     /* default OpenGL state */

--- a/example/file_browser.c
+++ b/example/file_browser.c
@@ -747,6 +747,7 @@ device_draw(struct device *dev, struct nk_context *ctx, int width, int height,
             offset += cmd->elem_count;
         }
         nk_clear(ctx);
+        nk_buffer_clear(&dev->cmds);
     }
 
     /* default OpenGL state */

--- a/example/skinning.c
+++ b/example/skinning.c
@@ -317,6 +317,7 @@ device_draw(struct device *dev, struct nk_context *ctx, int width, int height,
             offset += cmd->elem_count;
         }
         nk_clear(ctx);
+        nk_buffer_clear(&dev->cmds);
     }
 
     /* default OpenGL state */


### PR DESCRIPTION
As mentioned in #97 

This change adds an `nk_buffer_clear` on the cmds buffer after each frame to stop it growing over time.