### PR TITLE
Arc Command Support for GDI & X + Bugfix

### DIFF
--- a/demo/gdi/nuklear_gdi.h
+++ b/demo/gdi/nuklear_gdi.h
@@ -399,6 +399,7 @@ nk_gdi_stroke_circle(HDC dc, short x, short y, unsigned short w,
         SelectObject(dc, pen);
     }
 
+    HGDIOBJ br = SelectObject(dc, GetStockObject(NULL_BRUSH));
     SetDCBrushColor(dc, OPAQUE);
     Ellipse(dc, x, y, x + w, y + h);
 

--- a/demo/gdi/nuklear_gdi.h
+++ b/demo/gdi/nuklear_gdi.h
@@ -410,6 +410,61 @@ nk_gdi_stroke_circle(HDC dc, short x, short y, unsigned short w,
 }
 
 static void
+nk_gdi_stroke_arc(HDC dc, short cx, short cy, unsigned short r, float amin, float adelta, unsigned short line_thickness, struct nk_color col)
+{
+	COLORREF color = convert_color(col);
+
+	/* setup pen */
+    HPEN pen = NULL;
+    if (line_thickness == 1)
+        SetDCPenColor(dc, color);
+    else
+    {
+    	DWORD pen_style = PS_SOLID | PS_ENDCAP_FLAT | PS_GEOMETRIC; /* without that endcap round caps are used which looks really weird for thick arcs */
+
+    	LOGBRUSH brush;
+		brush.lbStyle = BS_SOLID;
+		brush.lbColor = color;
+		brush.lbHatch = 0;
+
+    	pen = ExtCreatePen(pen_style, line_thickness, &brush, 0, NULL);
+        SelectObject(dc, pen);
+    }
+
+    /* calculate arc and draw */
+    float start_x = cx + r*nk_cos((amin+adelta)*NK_PI/180.0);
+	float start_y = cy + r*nk_sin((amin+adelta)*NK_PI/180.0);
+
+	float end_x = cx + r*nk_cos(amin*NK_PI/180.0);
+	float end_y = cy + r*nk_sin(amin*NK_PI/180.0);
+
+	SetArcDirection(dc, AD_COUNTERCLOCKWISE);
+    Arc(dc, cx-r, cy-r, cx+r, cy+r, start_x, start_y, end_x, end_y);
+
+    if (pen)
+    {
+        SelectObject(dc, GetStockObject(DC_PEN));
+        DeleteObject(pen);
+    }
+}
+
+static void
+nk_gdi_fill_arc(HDC dc, short cx, short cy, unsigned short r, float amin, float adelta, struct nk_color col)
+{
+	COLORREF color = convert_color(col);
+    SetDCBrushColor(dc, color);
+    SetDCPenColor(dc, color);
+
+    float start_x = cx + r*nk_cos((amin+adelta)*NK_PI/180.0);
+	float start_y = cy + r*nk_sin((amin+adelta)*NK_PI/180.0);
+
+    float end_x = cx + r*nk_cos(amin*NK_PI/180.0);
+    float end_y = cy + r*nk_sin(amin*NK_PI/180.0);
+
+    Pie(dc, cx-r, cy-r, cx+r, cy+r, start_x, start_y, end_x, end_y);
+}
+
+static void
 nk_gdi_stroke_curve(HDC dc, struct nk_vec2i p1,
     struct nk_vec2i p2, struct nk_vec2i p3, struct nk_vec2i p4,
     unsigned short line_thickness, struct nk_color col)
@@ -886,8 +941,16 @@ nk_gdi_render(struct nk_color clear)
             const struct nk_command_image *i = (const struct nk_command_image *)cmd;
             nk_gdi_draw_image(i->x, i->y, i->w, i->h, i->img, i->col);
         } break;
-        case NK_COMMAND_ARC:
-        case NK_COMMAND_ARC_FILLED:
+        case NK_COMMAND_ARC: {
+        	const struct nk_command_arc *q = (const struct nk_command_arc *)cmd;
+			nk_gdi_stroke_arc(memory_dc, q->cx, q->cy, q->r, q->a[0], q->a[1], q->line_thickness, q->color);
+			break;
+        }
+        case NK_COMMAND_ARC_FILLED: {
+        	const struct nk_command_arc_filled *q = (const struct nk_command_arc_filled *)cmd;
+        	nk_gdi_fill_arc(memory_dc, q->cx, q->cy, q->r, q->a[0], q->a[1], q->color);
+        	break;
+        }
         default: break;
         }
     }

--- a/demo/x11/nuklear_xlib.h
+++ b/demo/x11/nuklear_xlib.h
@@ -385,6 +385,38 @@ nk_xsurf_stroke_curve(XSurface *surf, struct nk_vec2i p1,
 }
 
 NK_INTERN void
+nk_xdraw_stroke_arc(XSurface* surf, short cx, short cy, unsigned short r, float amin, float adelta, unsigned short line_thickness, struct nk_color col)
+{
+	float ul_x = cx - r;
+	float ul_y = cy - r;
+
+	int width = 2*r;
+	int height = width;
+
+	unsigned long c = nk_color_from_byte(&col.r);
+	XSetForeground(surf->dpy, surf->gc, c);
+
+	XSetLineAttributes(surf->dpy, surf->gc, line_thickness, LineSolid, CapButt, JoinMiter);
+	XDrawArc(surf->dpy, surf->drawable, surf->gc, ul_x, ul_y, width, height, (int)(-amin*64), (int)(-adelta*64));
+	XSetLineAttributes(surf->dpy, surf->gc, 1, LineSolid, CapButt, JoinMiter);
+}
+
+NK_INTERN void
+nk_xdraw_fill_arc(XSurface* surf, short cx, short cy, unsigned short r, float amin, float adelta, struct nk_color col)
+{
+	float ul_x = cx - r;
+	float ul_y = cy - r;
+
+	int width = 2*r;
+	int height = width;
+
+	unsigned long c = nk_color_from_byte(&col.r);
+	XSetForeground(surf->dpy, surf->gc, c);
+
+	XFillArc(surf->dpy, surf->drawable, surf->gc, ul_x, ul_y, width, height, -amin*64, -adelta*64);
+}
+
+NK_INTERN void
 nk_xsurf_draw_text(XSurface *surf, short x, short y, unsigned short w, unsigned short h,
     const char *text, int len, XFont *font, struct nk_color cbg, struct nk_color cfg)
 {
@@ -947,7 +979,17 @@ nk_xlib_render(Drawable screen, struct nk_color clear)
         } break;
         case NK_COMMAND_RECT_MULTI_COLOR:
         case NK_COMMAND_ARC:
-        case NK_COMMAND_ARC_FILLED:
+		{
+			const struct nk_command_arc *q = (const struct nk_command_arc *)cmd;
+			nk_xdraw_stroke_arc(surf, q->cx, q->cy, q->r, q->a[0], q->a[1], q->line_thickness, q->color);
+			break;
+		}
+		case NK_COMMAND_ARC_FILLED:
+		{
+			const struct nk_command_arc_filled *q = (const struct nk_command_arc_filled *)cmd;
+			nk_xdraw_fill_arc(surf, q->cx, q->cy, q->r, q->a[0], q->a[1], q->color);
+			break;
+		}
         case NK_COMMAND_CUSTOM:
         default: break;
         }


### PR DESCRIPTION
This adds arc support (both stroked and filled) to the X11 and GDI backends of Nuklear. 

A bugfix is also included for the GDI backend where stroked circles used to be filled with a black background. Now only the actual stroke is drawn. Since this was fixed with just one line of code I decided to put it in this PR.