### PR TITLE
Documentation fix (using github.io)

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -25,7 +25,7 @@ render backends, it focuses only on the actual UI.
 - No global or hidden state
 - Customizable library modules (you can compile and use only what you need)
 - Optional font baker and vertex buffer output
-- [Documentation](https://riri.github.io/Nuklear/doc/nuklear.html)
+- [Documentation](https://Immediate-Mode-UI.github.io/Nuklear/doc/nuklear.html)
 
 ## Building
 

--- a/Readme.md
+++ b/Readme.md
@@ -25,7 +25,7 @@ render backends, it focuses only on the actual UI.
 - No global or hidden state
 - Customizable library modules (you can compile and use only what you need)
 - Optional font baker and vertex buffer output
-- [Documentation](https://cdn.statically.io/gh/Immediate-Mode-UI/nuklear/master/doc/nuklear.html)
+- [Documentation](doc/nuklear.html)
 
 ## Building
 

--- a/Readme.md
+++ b/Readme.md
@@ -25,7 +25,7 @@ render backends, it focuses only on the actual UI.
 - No global or hidden state
 - Customizable library modules (you can compile and use only what you need)
 - Optional font baker and vertex buffer output
-- [Documentation](doc/nuklear.html)
+- [Documentation](https://riri.github.io/Nuklear/doc/nuklear.html)
 
 ## Building
 


### PR DESCRIPTION
Here is the fix for #114 using the github pages.

Setup is really simple: on project settings, go to Github Pages section and **enable** it
![](https://i.imgur.com/ljvrffY.png)

Github then shows that the project is available on github.io, so project README and documentation page are both available on [immediate-mode-ui.github.io/Nuklear](https://immediate-mode-ui.github.io/Nuklear)

I have updated the readme to link directly to the github.io page
