### PR TITLE
nuklear_glfw_gl3.h without implementation

### DIFF
--- a/demo/glfw_opengl3/main.c
+++ b/demo/glfw_opengl3/main.c
@@ -75,7 +75,7 @@ static void error_callback(int e, const char *d)
 int main(void)
 {
     /* Platform */
-    struct nk_glfw glfw = {0};
+    struct nk_glfw* glfw = {0};
     static GLFWwindow *win;
     int width = 0, height = 0;
     struct nk_context *ctx;
@@ -109,14 +109,14 @@ int main(void)
     /* Load Fonts: if none of these are loaded a default font will be used  */
     /* Load Cursor: if you uncomment cursor loading please hide the cursor */
     {struct nk_font_atlas *atlas;
-    nk_glfw3_font_stash_begin(&glfw, &atlas);
+    nk_glfw3_font_stash_begin(glfw, &atlas);
     /*struct nk_font *droid = nk_font_atlas_add_from_file(atlas, "../../../extra_font/DroidSans.ttf", 14, 0);*/
     /*struct nk_font *roboto = nk_font_atlas_add_from_file(atlas, "../../../extra_font/Roboto-Regular.ttf", 14, 0);*/
     /*struct nk_font *future = nk_font_atlas_add_from_file(atlas, "../../../extra_font/kenvector_future_thin.ttf", 13, 0);*/
     /*struct nk_font *clean = nk_font_atlas_add_from_file(atlas, "../../../extra_font/ProggyClean.ttf", 12, 0);*/
     /*struct nk_font *tiny = nk_font_atlas_add_from_file(atlas, "../../../extra_font/ProggyTiny.ttf", 10, 0);*/
     /*struct nk_font *cousine = nk_font_atlas_add_from_file(atlas, "../../../extra_font/Cousine-Regular.ttf", 13, 0);*/
-    nk_glfw3_font_stash_end(&glfw);
+    nk_glfw3_font_stash_end(glfw);
     /*nk_style_load_all_cursors(ctx, atlas->cursors);*/
     /*nk_style_set_font(ctx, &droid->handle);*/}
 
@@ -132,7 +132,7 @@ int main(void)
     {
         /* Input */
         glfwPollEvents();
-        nk_glfw3_new_frame(&glfw);
+        nk_glfw3_new_frame(glfw);
 
         /* GUI */
         if (nk_begin(ctx, "Demo", nk_rect(50, 50, 230, 250),
@@ -191,10 +191,10 @@ int main(void)
          * defaults everything back into a default state.
          * Make sure to either a.) save and restore or b.) reset your own state after
          * rendering the UI. */
-        nk_glfw3_render(&glfw, NK_ANTI_ALIASING_ON, MAX_VERTEX_BUFFER, MAX_ELEMENT_BUFFER);
+        nk_glfw3_render(glfw, NK_ANTI_ALIASING_ON, MAX_VERTEX_BUFFER, MAX_ELEMENT_BUFFER);
         glfwSwapBuffers(win);
     }
-    nk_glfw3_shutdown(&glfw);
+    nk_glfw3_shutdown(glfw);
     glfwTerminate();
     return 0;
 }

--- a/demo/glfw_opengl3/main.c
+++ b/demo/glfw_opengl3/main.c
@@ -75,7 +75,7 @@ static void error_callback(int e, const char *d)
 int main(void)
 {
     /* Platform */
-    struct nk_glfw* glfw = {0};
+    struct nk_glfw glfw = {0};
     static GLFWwindow *win;
     int width = 0, height = 0;
     struct nk_context *ctx;
@@ -109,14 +109,14 @@ int main(void)
     /* Load Fonts: if none of these are loaded a default font will be used  */
     /* Load Cursor: if you uncomment cursor loading please hide the cursor */
     {struct nk_font_atlas *atlas;
-    nk_glfw3_font_stash_begin(glfw, &atlas);
+    nk_glfw3_font_stash_begin(&glfw, &atlas);
     /*struct nk_font *droid = nk_font_atlas_add_from_file(atlas, "../../../extra_font/DroidSans.ttf", 14, 0);*/
     /*struct nk_font *roboto = nk_font_atlas_add_from_file(atlas, "../../../extra_font/Roboto-Regular.ttf", 14, 0);*/
     /*struct nk_font *future = nk_font_atlas_add_from_file(atlas, "../../../extra_font/kenvector_future_thin.ttf", 13, 0);*/
     /*struct nk_font *clean = nk_font_atlas_add_from_file(atlas, "../../../extra_font/ProggyClean.ttf", 12, 0);*/
     /*struct nk_font *tiny = nk_font_atlas_add_from_file(atlas, "../../../extra_font/ProggyTiny.ttf", 10, 0);*/
     /*struct nk_font *cousine = nk_font_atlas_add_from_file(atlas, "../../../extra_font/Cousine-Regular.ttf", 13, 0);*/
-    nk_glfw3_font_stash_end(glfw);
+    nk_glfw3_font_stash_end(&glfw);
     /*nk_style_load_all_cursors(ctx, atlas->cursors);*/
     /*nk_style_set_font(ctx, &droid->handle);*/}
 
@@ -132,7 +132,7 @@ int main(void)
     {
         /* Input */
         glfwPollEvents();
-        nk_glfw3_new_frame(glfw);
+        nk_glfw3_new_frame(&glfw);
 
         /* GUI */
         if (nk_begin(ctx, "Demo", nk_rect(50, 50, 230, 250),
@@ -191,10 +191,10 @@ int main(void)
          * defaults everything back into a default state.
          * Make sure to either a.) save and restore or b.) reset your own state after
          * rendering the UI. */
-        nk_glfw3_render(glfw, NK_ANTI_ALIASING_ON, MAX_VERTEX_BUFFER, MAX_ELEMENT_BUFFER);
+        nk_glfw3_render(&glfw, NK_ANTI_ALIASING_ON, MAX_VERTEX_BUFFER, MAX_ELEMENT_BUFFER);
         glfwSwapBuffers(win);
     }
-    nk_glfw3_shutdown(glfw);
+    nk_glfw3_shutdown(&glfw);
     glfwTerminate();
     return 0;
 }

--- a/demo/glfw_opengl3/nuklear_glfw_gl3.h
+++ b/demo/glfw_opengl3/nuklear_glfw_gl3.h
@@ -20,7 +20,40 @@ enum nk_glfw_init_state{
     NK_GLFW3_INSTALL_CALLBACKS
 };
 
-struct nk_glfw;
+#ifndef NK_GLFW_TEXT_MAX
+#define NK_GLFW_TEXT_MAX 256
+#endif
+
+struct nk_glfw_device {
+    struct nk_buffer cmds;
+    struct nk_draw_null_texture null;
+    GLuint vbo, vao, ebo;
+    GLuint prog;
+    GLuint vert_shdr;
+    GLuint frag_shdr;
+    GLint attrib_pos;
+    GLint attrib_uv;
+    GLint attrib_col;
+    GLint uniform_tex;
+    GLint uniform_proj;
+    GLuint font_tex;
+};
+
+struct nk_glfw {
+    GLFWwindow *win;
+    int width, height;
+    int display_width, display_height;
+    struct nk_glfw_device ogl;
+    struct nk_context ctx;
+    struct nk_font_atlas atlas;
+    struct nk_vec2 fb_scale;
+    unsigned int text[NK_GLFW_TEXT_MAX];
+    int text_len;
+    struct nk_vec2 scroll;
+    double last_button_click;
+    int is_double_click_down;
+    struct nk_vec2 double_click_pos;
+};
 
 NK_API struct nk_context*   nk_glfw3_init(struct nk_glfw* glfw, GLFWwindow *win, enum nk_glfw_init_state);
 NK_API void                 nk_glfw3_shutdown(struct nk_glfw* glfw);
@@ -46,9 +79,6 @@ NK_API void                 nk_glfw3_mouse_button_callback(GLFWwindow *win, int 
  */
 #ifdef NK_GLFW_GL3_IMPLEMENTATION
 
-#ifndef NK_GLFW_TEXT_MAX
-#define NK_GLFW_TEXT_MAX 256
-#endif
 #ifndef NK_GLFW_DOUBLE_CLICK_LO
 #define NK_GLFW_DOUBLE_CLICK_LO 0.02
 #endif
@@ -56,41 +86,10 @@ NK_API void                 nk_glfw3_mouse_button_callback(GLFWwindow *win, int 
 #define NK_GLFW_DOUBLE_CLICK_HI 0.2
 #endif
 
-struct nk_glfw_device {
-    struct nk_buffer cmds;
-    struct nk_draw_null_texture null;
-    GLuint vbo, vao, ebo;
-    GLuint prog;
-    GLuint vert_shdr;
-    GLuint frag_shdr;
-    GLint attrib_pos;
-    GLint attrib_uv;
-    GLint attrib_col;
-    GLint uniform_tex;
-    GLint uniform_proj;
-    GLuint font_tex;
-};
-
 struct nk_glfw_vertex {
     float position[2];
     float uv[2];
     nk_byte col[4];
-};
-
-struct nk_glfw {
-    GLFWwindow *win;
-    int width, height;
-    int display_width, display_height;
-    struct nk_glfw_device ogl;
-    struct nk_context ctx;
-    struct nk_font_atlas atlas;
-    struct nk_vec2 fb_scale;
-    unsigned int text[NK_GLFW_TEXT_MAX];
-    int text_len;
-    struct nk_vec2 scroll;
-    double last_button_click;
-    int is_double_click_down;
-    struct nk_vec2 double_click_pos;
 };
 
 #ifdef __APPLE__

--- a/demo/glfw_opengl3/nuklear_glfw_gl3.h
+++ b/demo/glfw_opengl3/nuklear_glfw_gl3.h
@@ -15,57 +15,13 @@
 
 #include <GLFW/glfw3.h>
 
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 enum nk_glfw_init_state{
     NK_GLFW3_DEFAULT=0,
     NK_GLFW3_INSTALL_CALLBACKS
 };
 
-struct nk_glfw;
-
-NK_API struct nk_context*   nk_glfw3_init(struct nk_glfw** glfw, GLFWwindow *win, enum nk_glfw_init_state);
-NK_API void                 nk_glfw3_shutdown(struct nk_glfw* glfw);
-NK_API void                 nk_glfw3_font_stash_begin(struct nk_glfw* glfw, struct nk_font_atlas **atlas);
-NK_API void                 nk_glfw3_font_stash_end(struct nk_glfw* glfw);
-NK_API void                 nk_glfw3_new_frame(struct nk_glfw* glfw);
-NK_API void                 nk_glfw3_render(struct nk_glfw* glfw, enum nk_anti_aliasing, int max_vertex_buffer, int max_element_buffer);
-
-NK_API void                 nk_glfw3_device_destroy(struct nk_glfw* glfw);
-NK_API void                 nk_glfw3_device_create(struct nk_glfw* glfw);
-
-NK_API void                 nk_glfw3_char_callback(GLFWwindow *win, unsigned int codepoint);
-NK_API void                 nk_gflw3_scroll_callback(GLFWwindow *win, double xoff, double yoff);
-NK_API void                 nk_glfw3_mouse_button_callback(GLFWwindow *win, int button, int action, int mods);
-
-#ifdef __cplusplus
-}
-#endif
-
-#endif
-/*
- * ==============================================================
- *
- *                          IMPLEMENTATION
- *
- * ===============================================================
- */
-#ifdef NK_GLFW_GL3_IMPLEMENTATION
-
 #ifndef NK_GLFW_TEXT_MAX
 #define NK_GLFW_TEXT_MAX 256
-#endif
-#ifndef NK_GLFW_DOUBLE_CLICK_LO
-#define NK_GLFW_DOUBLE_CLICK_LO 0.02
-#endif
-#ifndef NK_GLFW_DOUBLE_CLICK_HI
-#define NK_GLFW_DOUBLE_CLICK_HI 0.2
-#endif
-
-#ifndef STBTT_malloc
-static nk_handle fictional_handle = {0};
 #endif
 
 struct nk_glfw_device {
@@ -83,12 +39,6 @@ struct nk_glfw_device {
     GLuint font_tex;
 };
 
-struct nk_glfw_vertex {
-    float position[2];
-    float uv[2];
-    nk_byte col[4];
-};
-
 struct nk_glfw {
     GLFWwindow *win;
     int width, height;
@@ -103,6 +53,43 @@ struct nk_glfw {
     double last_button_click;
     int is_double_click_down;
     struct nk_vec2 double_click_pos;
+};
+
+NK_API struct nk_context*   nk_glfw3_init(struct nk_glfw* glfw, GLFWwindow *win, enum nk_glfw_init_state);
+NK_API void                 nk_glfw3_shutdown(struct nk_glfw* glfw);
+NK_API void                 nk_glfw3_font_stash_begin(struct nk_glfw* glfw, struct nk_font_atlas **atlas);
+NK_API void                 nk_glfw3_font_stash_end(struct nk_glfw* glfw);
+NK_API void                 nk_glfw3_new_frame(struct nk_glfw* glfw);
+NK_API void                 nk_glfw3_render(struct nk_glfw* glfw, enum nk_anti_aliasing, int max_vertex_buffer, int max_element_buffer);
+
+NK_API void                 nk_glfw3_device_destroy(struct nk_glfw* glfw);
+NK_API void                 nk_glfw3_device_create(struct nk_glfw* glfw);
+
+NK_API void                 nk_glfw3_char_callback(GLFWwindow *win, unsigned int codepoint);
+NK_API void                 nk_gflw3_scroll_callback(GLFWwindow *win, double xoff, double yoff);
+NK_API void                 nk_glfw3_mouse_button_callback(GLFWwindow *win, int button, int action, int mods);
+
+#endif
+/*
+ * ==============================================================
+ *
+ *                          IMPLEMENTATION
+ *
+ * ===============================================================
+ */
+#ifdef NK_GLFW_GL3_IMPLEMENTATION
+
+#ifndef NK_GLFW_DOUBLE_CLICK_LO
+#define NK_GLFW_DOUBLE_CLICK_LO 0.02
+#endif
+#ifndef NK_GLFW_DOUBLE_CLICK_HI
+#define NK_GLFW_DOUBLE_CLICK_HI 0.2
+#endif
+
+struct nk_glfw_vertex {
+    float position[2];
+    float uv[2];
+    nk_byte col[4];
 };
 
 #ifdef __APPLE__
@@ -379,10 +366,8 @@ nk_glfw3_clipboard_copy(nk_handle usr, const char *text, int len)
 }
 
 NK_API struct nk_context*
-nk_glfw3_init(struct nk_glfw** new_glfw, GLFWwindow *win, enum nk_glfw_init_state init_state)
+nk_glfw3_init(struct nk_glfw* glfw, GLFWwindow *win, enum nk_glfw_init_state init_state)
 {
-    struct nk_glfw* glfw = nk_malloc(fictional_handle, 0, sizeof(struct nk_glfw));
-    NK_ASSERT(glfw);
     glfwSetWindowUserPointer(win, glfw);
     glfw->win = win;
     if (init_state == NK_GLFW3_INSTALL_CALLBACKS) {
@@ -400,7 +385,6 @@ nk_glfw3_init(struct nk_glfw** new_glfw, GLFWwindow *win, enum nk_glfw_init_stat
     glfw->is_double_click_down = nk_false;
     glfw->double_click_pos = nk_vec2(0, 0);
 
-    *new_glfw = glfw;
     return &glfw->ctx;
 }
 
@@ -508,7 +492,7 @@ void nk_glfw3_shutdown(struct nk_glfw* glfw)
     nk_font_atlas_clear(&glfw->atlas);
     nk_free(&glfw->ctx);
     nk_glfw3_device_destroy(glfw);
-    nk_mfree(fictional_handle, glfw);
+    memset(glfw, 0, sizeof(glfw));
 }
 
 #endif


### PR DESCRIPTION
Using this header without the implementation is not possible because needed structs are not defined in the header only part. This PR solves this problem by making `struct nk_glfw` and `struct nk_glfw_device` public.

Note that a source implementing this backend still needs to include nuklear implementation too, because it uses some macros defined only in the implementation part of nuklear (i.e. `NK_MEMSET`). I have not been as deep as reviewing that part (not being sure of what should be done).
