### PR TITLE
Fix 'nk_menubar' height calculation bug

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -20983,13 +20983,15 @@ nk_menubar_end(struct nk_context *ctx)
     if (layout->flags & NK_WINDOW_HIDDEN || layout->flags & NK_WINDOW_MINIMIZED)
         return;
 
-    layout->menu.h = layout->at_y - layout->menu.y;
-    layout->bounds.y += layout->menu.h + ctx->style.window.spacing.y + layout->row.height;
-    layout->bounds.h -= layout->menu.h + ctx->style.window.spacing.y + layout->row.height;
+    layout->menu.h  = layout->at_y - layout->menu.y;
+    layout->menu.h += layout->row.height + ctx->style.window.spacing.y;
+
+    layout->bounds.y += layout->menu.h;
+    layout->bounds.h -= layout->menu.h;
 
     *layout->offset_x = layout->menu.offset.x;
     *layout->offset_y = layout->menu.offset.y;
-    layout->at_y = layout->bounds.y - layout->row.height;
+    layout->at_y      = layout->bounds.y - layout->row.height;
 
     layout->clip.y = layout->bounds.y;
     layout->clip.h = layout->bounds.h;
@@ -29091,6 +29093,7 @@ nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
+/// - 2020/05/09 (4.02.3) - Fix nk_menubar height calculation bug
 /// - 2020/04/30 (4.02.2) - Fix nk_edit border drawing bug
 /// - 2020/04/09 (4.02.1) - Removed unused nk_sqrt function to fix compiler warnings
 ///                       - Fixed compiler warnings if you bring your own methods for

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuklear",
-  "version": "4.02.2",
+  "version": "4.02.3",
   "repo": "Immediate-Mode-UI/Nuklear",
   "description": "A small ANSI C gui toolkit",
   "keywords": ["gl", "ui", "toolkit"],

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -8,6 +8,7 @@
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
+/// - 2020/05/09 (4.02.3) - Fix nk_menubar height calculation bug
 /// - 2020/04/30 (4.02.2) - Fix nk_edit border drawing bug
 /// - 2020/04/09 (4.02.1) - Removed unused nk_sqrt function to fix compiler warnings
 ///                       - Fixed compiler warnings if you bring your own methods for

--- a/src/nuklear_menu.c
+++ b/src/nuklear_menu.c
@@ -62,13 +62,15 @@ nk_menubar_end(struct nk_context *ctx)
     if (layout->flags & NK_WINDOW_HIDDEN || layout->flags & NK_WINDOW_MINIMIZED)
         return;
 
-    layout->menu.h = layout->at_y - layout->menu.y;
-    layout->bounds.y += layout->menu.h + ctx->style.window.spacing.y + layout->row.height;
-    layout->bounds.h -= layout->menu.h + ctx->style.window.spacing.y + layout->row.height;
+    layout->menu.h  = layout->at_y - layout->menu.y;
+    layout->menu.h += layout->row.height + ctx->style.window.spacing.y;
+
+    layout->bounds.y += layout->menu.h;
+    layout->bounds.h -= layout->menu.h;
 
     *layout->offset_x = layout->menu.offset.x;
     *layout->offset_y = layout->menu.offset.y;
-    layout->at_y = layout->bounds.y - layout->row.height;
+    layout->at_y      = layout->bounds.y - layout->row.height;
 
     layout->clip.y = layout->bounds.y;
     layout->clip.h = layout->bounds.h;


### PR DESCRIPTION
Issues with menu bar height calculation for groups. 

Before:
![before](https://user-images.githubusercontent.com/6318132/81475611-063fc600-9216-11ea-8823-f88e042dddae.png)

After:
![after](https://user-images.githubusercontent.com/6318132/81475625-0f309780-9216-11ea-9df9-1985c99e5ace.png)

Code to reproduce:
```c++
        /* GUI */                                                                
        if (nk_begin(ctx, "Demo", nk_rect(50, 50, 200, 200),                     
                     NK_WINDOW_BORDER|NK_WINDOW_MOVABLE|NK_WINDOW_SCALABLE|      
                     NK_WINDOW_CLOSABLE|NK_WINDOW_MINIMIZABLE|NK_WINDOW_TITLE))  
        {                                                                        
                                                                                 
            nk_menubar_begin(ctx);                                               
            nk_layout_row_dynamic(ctx, 50, 1);                                   
            nk_button_label(ctx, "window nenu");                                 
            nk_layout_row_dynamic(ctx, 300, 1);                                  
                                                                                 
            if (nk_group_begin(ctx, "group", NK_WINDOW_BORDER|NK_WINDOW_TITLE))  
            {                                                                    
                nk_menubar_begin(ctx);                                           
                nk_layout_row_dynamic(ctx, 50, 1);                               
                nk_button_label(ctx, "group nenu");                              
                nk_menubar_end(ctx);                                             
                                                                                 
                nk_group_end(ctx);                                               
            }                                                                    
                                                                                 
            nk_menubar_end(ctx);                                                 
                                                                                 
        }                                                                        
        nk_end(ctx);                                                             

```
