### PR TITLE
Migrate wayland demo to xdg_shell.

### DIFF
--- a/demo/wayland_rawfb/.gitignore
+++ b/demo/wayland_rawfb/.gitignore
@@ -1,0 +1,2 @@
+xdg-shell.c
+xdg-shell.h

--- a/demo/wayland_rawfb/Makefile
+++ b/demo/wayland_rawfb/Makefile
@@ -1,9 +1,19 @@
 WAYLAND=`pkg-config wayland-client --cflags --libs`
+WAYLAND_SCANNER=wayland-scanner
+WAYLAND_PROTOCOLS_DIR=/usr/share/wayland-protocols
+
 CFLAGS?=-std=c11 -Wall -Werror -O3 -fvisibility=hidden
 
-hello_wayland: main.c 
+.PHONY: clean
+
+demo: main.c xdg-shell.c xdg-shell.h
 	$(CC) -o demo *.c $(WAYLAND) -lrt -lm
 
+xdg-shell.c:
+	$(WAYLAND_SCANNER) code $(WAYLAND_PROTOCOLS_DIR)/stable/xdg-shell/xdg-shell.xml xdg-shell.c
+
+xdg-shell.h:
+	$(WAYLAND_SCANNER) client-header $(WAYLAND_PROTOCOLS_DIR)/stable/xdg-shell/xdg-shell.xml xdg-shell.h
 
 clean:
-	$(RM) demo
+	$(RM) demo xdg-shell.c xdg-shell.h

--- a/demo/wayland_rawfb/nuklear_raw_wayland.h
+++ b/demo/wayland_rawfb/nuklear_raw_wayland.h
@@ -27,12 +27,13 @@ struct nk_wayland{
     /*wayland vars*/
     struct wl_display *display;
     struct wl_compositor *compositor;
-    struct wl_shell *shell;
+    struct xdg_wm_base *xdg_wm_base;
     struct wl_shm *wl_shm;
     struct wl_seat* seat;
     struct wl_callback *frame_callback;
     struct wl_surface *surface;
-	struct wl_shell_surface *shell_surface;
+	struct xdg_surface *xdg_surface;
+	struct xdg_toplevel *xdg_toplevel;
 	struct wl_buffer *front_buffer;
 
     


### PR DESCRIPTION
The wl_shell interface it previously used is deprecated and not implemented
by some compositors, like sway.

Fixes #134