### PR TITLE
Fixed naming bug in allegro5 backend image support

### DIFF
--- a/demo/allegro5/nuklear_allegro5.h
+++ b/demo/allegro5/nuklear_allegro5.h
@@ -67,7 +67,7 @@ static struct nk_allegro5 {
 } allegro5;
 
 
-NK_API struct nk_image* nk_create_image(const char* file_name)
+NK_API struct nk_image* nk_allegro5_create_image(const char* file_name)
 {
     if (!al_init_image_addon()) {
         fprintf(stdout, "Unable to initialize required allegro5 image addon\n");


### PR DESCRIPTION
Hello!
This is follow-up to #139 . I am so very sorry, I messed up the function name to load the bitmap, so it is not exported when Nuklear is built as dynamic library (and hence is unusable). This PR fixes it.