### PR TITLE
Newline fix for paq script on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,6 @@
 # Github language settings
 *.h linguist-language=c
 *.c linguist-language=c
+
+*.h text eol=auto
+*.c text eol=auto

--- a/src/build.py
+++ b/src/build.py
@@ -134,7 +134,7 @@ for f in intro_files:
     sys.stdout.write(open(f, 'r').read())
 print("*/")
 
-# print(os.linesep + "#ifndef " + macro + "_SINGLE_HEADER");
+# print("\n#ifndef " + macro + "_SINGLE_HEADER");
 # print("#define " + macro + "_SINGLE_HEADER");
 print("#ifndef NK_SINGLE_FILE");
 print("  #define NK_SINGLE_FILE");
@@ -145,7 +145,7 @@ for f in pub_files:
     sys.stdout.write(open(f, 'r').read())
 # print("#endif /* " + macro + "_SINGLE_HEADER */");
 
-print(os.linesep + "#ifdef " + macro + "_IMPLEMENTATION");
+print("\n#ifdef " + macro + "_IMPLEMENTATION");
 print("");
 
 for f in priv_files1:
@@ -160,8 +160,8 @@ for f in priv_files2:
 
 print("#endif /* " + macro + "_IMPLEMENTATION */");
 
-print(os.linesep + "/*")
+print("\n/*")
 for f in outro_files:
     sys.stdout.write(open(f, 'r').read())
-print("*/" + os.linesep)
+print("*/\n")
 


### PR DESCRIPTION
This is my attempt and fixing this very unfortunate problem. Anyone with a windows installation that wants to help test this can do the following:
```
git clone https://github.com/Hejsil/Nuklear-1.git
cd Nuklear-1/src
git checkout newline-fix
paq.bat
git diff
```

`git diff` should hopefully show that nothing changed. If @zgcrowno could test this that would be great!