### PR TITLE
Added ability to use user fonts after initialization in allegro5 backend

### DIFF
--- a/demo/allegro5/nuklear_allegro5.h
+++ b/demo/allegro5/nuklear_allegro5.h
@@ -33,7 +33,8 @@ NK_API void                   nk_allegro5_del_image(struct nk_image* image);
 /* Fonts. We wrap normal allegro fonts in some nuklear book keeping */
 NK_API NkAllegro5Font*        nk_allegro5_font_create_from_file(const char *file_name, int font_size, int flags);
 NK_API void                   nk_allegro5_font_del(NkAllegro5Font *font);
-NK_API struct nk_user_font*   nk_allegro5_font(NkAllegro5Font *allegro5font);
+/* NOTE : just use NkAllegro5Font instead of nk_user_font,
+    since the former just extends the latter*/
 NK_API void                   nk_allegro5_font_set_font(NkAllegro5Font *font);
 
 #endif
@@ -53,7 +54,6 @@ NK_API void                   nk_allegro5_font_set_font(NkAllegro5Font *font);
 
 struct NkAllegro5Font {
     struct nk_user_font nk;
-    int height;
     ALLEGRO_FONT *font;
 };
 
@@ -95,6 +95,23 @@ NK_API void nk_allegro5_del_image(struct nk_image* image)
     free(image);
 }
 
+static float
+nk_allegro5_font_get_text_width(nk_handle handle, float height, const char *text, int len)
+{
+    NkAllegro5Font *font = (NkAllegro5Font*)handle.ptr;
+    if (!font || !text) {
+        return 0;
+    }
+    /* We must copy into a new buffer with exact length null-terminated
+       as nuklear uses variable size buffers and al_get_text_width doesn't
+       accept a length, it infers length from null-termination
+       (which is unsafe API design by allegro devs!) */
+    char strcpy[len+1];
+    strncpy((char*)&strcpy, text, len);
+    strcpy[len] = '\0';
+    return al_get_text_width(font->font, strcpy);
+}
+
 /* Flags are identical to al_load_font() flags argument */
 NK_API NkAllegro5Font*
 nk_allegro5_font_create_from_file(const char *file_name, int font_size, int flags)
@@ -118,34 +135,9 @@ nk_allegro5_font_create_from_file(const char *file_name, int font_size, int flag
         fprintf(stdout, "Unable to load font file: %s\n", file_name);
         return NULL;
     }
-    font->height = al_get_font_line_height(font->font);
-    return font;
-}
-
-static float
-nk_allegro5_font_get_text_width(nk_handle handle, float height, const char *text, int len)
-{
-    NkAllegro5Font *font = (NkAllegro5Font*)handle.ptr;
-    if (!font || !text) {
-        return 0;
-    }
-    /* We must copy into a new buffer with exact length null-terminated
-       as nuklear uses variable size buffers and al_get_text_width doesn't
-       accept a length, it infers length from null-termination
-       (which is unsafe API design by allegro devs!) */
-    char strcpy[len+1];
-    strncpy((char*)&strcpy, text, len);
-    strcpy[len] = '\0';
-    return al_get_text_width(font->font, strcpy);
-}
-
-NK_API struct nk_user_font*
-nk_allegro5_font(NkAllegro5Font *allegro5font)
-{
-    struct nk_user_font *font = &allegro5font->nk;
-    font->userdata = nk_handle_ptr(allegro5font);
-    font->height = (float)allegro5font->height;
-    font->width = nk_allegro5_font_get_text_width;
+    font->nk.userdata = nk_handle_ptr(font);
+    font->nk.height = (float)al_get_font_line_height(font->font);
+    font->nk.width = nk_allegro5_font_get_text_width;
     return font;
 }
 
@@ -153,9 +145,6 @@ NK_API void
 nk_allegro5_font_set_font(NkAllegro5Font *allegro5font)
 {
     struct nk_user_font *font = &allegro5font->nk;
-    font->userdata = nk_handle_ptr(allegro5font);
-    font->height = (float)allegro5font->height;
-    font->width = nk_allegro5_font_get_text_width;
     nk_style_set_font(&allegro5.ctx, font);
 }
 
@@ -475,9 +464,6 @@ nk_allegro5_init(NkAllegro5Font *allegro5font, ALLEGRO_DISPLAY *dsp,
     }
 
     struct nk_user_font *font = &allegro5font->nk;
-    font->userdata = nk_handle_ptr(allegro5font);
-    font->height = (float)allegro5font->height;
-    font->width = nk_allegro5_font_get_text_width;
 
     allegro5.dsp = dsp;
     allegro5.width = width;

--- a/demo/allegro5/nuklear_allegro5.h
+++ b/demo/allegro5/nuklear_allegro5.h
@@ -33,6 +33,7 @@ NK_API void                   nk_allegro5_del_image(struct nk_image* image);
 /* Fonts. We wrap normal allegro fonts in some nuklear book keeping */
 NK_API NkAllegro5Font*        nk_allegro5_font_create_from_file(const char *file_name, int font_size, int flags);
 NK_API void                   nk_allegro5_font_del(NkAllegro5Font *font);
+NK_API struct nk_user_font*   nk_allegro5_font(NkAllegro5Font *allegro5font);
 NK_API void                   nk_allegro5_font_set_font(NkAllegro5Font *font);
 
 #endif
@@ -136,6 +137,16 @@ nk_allegro5_font_get_text_width(nk_handle handle, float height, const char *text
     strncpy((char*)&strcpy, text, len);
     strcpy[len] = '\0';
     return al_get_text_width(font->font, strcpy);
+}
+
+NK_API struct nk_user_font*
+nk_allegro5_font(NkAllegro5Font *allegro5font)
+{
+    struct nk_user_font *font = &allegro5font->nk;
+    font->userdata = nk_handle_ptr(allegro5font);
+    font->height = (float)allegro5font->height;
+    font->width = nk_allegro5_font_get_text_width;
+    return font;
 }
 
 NK_API void


### PR DESCRIPTION
Hello!
Currently Allegro5 backend allows to set custom font on initialization using [`nk_allegro5_font_create_from_file`](https://github.com/Immediate-Mode-UI/Nuklear/blob/bffe1037b2de63bd05f040f58b32bfca9877689e/demo/allegro5/nuklear_allegro5.h#L34) that wraps `nk_user_font` struct into [`NkAllegro5Font`](https://github.com/Immediate-Mode-UI/Nuklear/blob/bffe1037b2de63bd05f040f58b32bfca9877689e/demo/allegro5/nuklear_allegro5.h#L53) custom bookkeeping struct, but after that the font only could be set globally using [`nk_allegro5_font_set_font`](https://github.com/Immediate-Mode-UI/Nuklear/blob/bffe1037b2de63bd05f040f58b32bfca9877689e/demo/allegro5/nuklear_allegro5.h#L36) (which [wraps `nk_style_set_font`](https://github.com/Immediate-Mode-UI/Nuklear/blob/bffe1037b2de63bd05f040f58b32bfca9877689e/demo/allegro5/nuklear_allegro5.h#L142-L148)). This small PR adds helper function that allows to get `nk_user_font` struct from that `NkAllegro5Font` bookkeeping struct to use it in different contexts, e.g. in `nk_style_push_font`.