### PR TITLE
[fix][error] C++ style comments are not allowed in ISO C90

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -29172,6 +29172,7 @@ nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
+/// - 2020/10/11 (4.06.1) - Fix C++ style comments which are not allowed in ISO C90.
 /// - 2020/10/07 (4.06.0) - Fix nk_combo return type wrongly changed to nk_bool
 /// - 2020/09/05 (4.05.0) - Use the nk_font_atlas allocator for stb_truetype memory management.
 /// - 2020/09/04 (4.04.1) - Replace every boolean int by nk_bool

--- a/nuklear.h
+++ b/nuklear.h
@@ -16576,8 +16576,10 @@ nk_font_bake(struct nk_font_baker *baker, void *image_memory, int width, int hei
                 dst_font->ascent = ((float)unscaled_ascent * font_scale);
                 dst_font->descent = ((float)unscaled_descent * font_scale);
                 dst_font->glyph_offset = glyph_n;
-                // Need to zero this, or it will carry over from a previous
-                // bake, and cause a segfault when accessing glyphs[].
+                /*
+                    Need to zero this, or it will carry over from a previous
+                    bake, and cause a segfault when accessing glyphs[].
+                */
                 dst_font->glyph_count = 0;
             }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuklear",
-  "version": "4.06.0",
+  "version": "4.06.1",
   "repo": "Immediate-Mode-UI/Nuklear",
   "description": "A small ANSI C gui toolkit",
   "keywords": ["gl", "ui", "toolkit"],

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -8,6 +8,7 @@
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
+/// - 2020/10/11 (4.06.1) - Fix C++ style comments which are not allowed in ISO C90.
 /// - 2020/10/07 (4.06.0) - Fix nk_combo return type wrongly changed to nk_bool
 /// - 2020/09/05 (4.05.0) - Use the nk_font_atlas allocator for stb_truetype memory management.
 /// - 2020/09/04 (4.04.1) - Replace every boolean int by nk_bool

--- a/src/nuklear_font.c
+++ b/src/nuklear_font.c
@@ -333,8 +333,10 @@ nk_font_bake(struct nk_font_baker *baker, void *image_memory, int width, int hei
                 dst_font->ascent = ((float)unscaled_ascent * font_scale);
                 dst_font->descent = ((float)unscaled_descent * font_scale);
                 dst_font->glyph_offset = glyph_n;
-                // Need to zero this, or it will carry over from a previous
-                // bake, and cause a segfault when accessing glyphs[].
+                /*
+                    Need to zero this, or it will carry over from a previous
+                    bake, and cause a segfault when accessing glyphs[].
+                */
                 dst_font->glyph_count = 0;
             }
 


### PR DESCRIPTION
Compiling in Ubuntu 20.04 with gcc 9.3.0 throws an error:

    ../../nuklear.h:16579:17: error: C++ style comments are not allowed in ISO C90
    16579 |                 // Need to zero this, or it will carry over from a previous
          |                 ^

What I did:

```
git clone https://github.com/Immediate-Mode-UI/Nuklear
cd demo/x11_rawfb/
make
```