### PR TITLE
Fix C89 compilation errors

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -6053,9 +6053,9 @@ nk_stbtt_free(void *ptr, void *user_data) {
 #define STBTT_malloc(x,u)  nk_stbtt_malloc(x,u)
 #define STBTT_free(x,u)    nk_stbtt_free(x,u)
 
-#endif // STBTT_malloc
+#endif /* STBTT_malloc */
 
-#endif // NK_INCLUDE_FONT_BAKING
+#endif /* NK_INCLUDE_FONT_BAKING */
 
 #endif
 
@@ -16432,8 +16432,8 @@ nk_font_bake_pack(struct nk_font_baker *baker,
     }
     /* setup font baker from temporary memory */
     for (config_iter = config_list; config_iter; config_iter = config_iter->next) {
-        it = config_iter;
         struct stbtt_fontinfo *font_info = &baker->build[i++].info;
+        it = config_iter;
         font_info->userdata = alloc;
         do {if (!stbtt_InitFont(font_info, (const unsigned char*)it->ttf_blob, 0))
             return nk_false;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuklear",
-  "version": "4.06.1",
+  "version": "4.06.2",
   "repo": "Immediate-Mode-UI/Nuklear",
   "description": "A small ANSI C gui toolkit",
   "keywords": ["gl", "ui", "toolkit"],

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -8,6 +8,7 @@
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
+/// - 2020/12/19 (4.06.2) - Fix additional C++ style comments which are not allowed in ISO C90.
 /// - 2020/10/11 (4.06.1) - Fix C++ style comments which are not allowed in ISO C90.
 /// - 2020/10/07 (4.06.0) - Fix nk_combo return type wrongly changed to nk_bool
 /// - 2020/09/05 (4.05.0) - Use the nk_font_atlas allocator for stb_truetype memory management.

--- a/src/nuklear_font.c
+++ b/src/nuklear_font.c
@@ -189,8 +189,8 @@ nk_font_bake_pack(struct nk_font_baker *baker,
     }
     /* setup font baker from temporary memory */
     for (config_iter = config_list; config_iter; config_iter = config_iter->next) {
-        it = config_iter;
         struct stbtt_fontinfo *font_info = &baker->build[i++].info;
+        it = config_iter;
         font_info->userdata = alloc;
         do {if (!stbtt_InitFont(font_info, (const unsigned char*)it->ttf_blob, 0))
             return nk_false;

--- a/src/nuklear_internal.h
+++ b/src/nuklear_internal.h
@@ -346,9 +346,9 @@ nk_stbtt_free(void *ptr, void *user_data) {
 #define STBTT_malloc(x,u)  nk_stbtt_malloc(x,u)
 #define STBTT_free(x,u)    nk_stbtt_free(x,u)
 
-#endif // STBTT_malloc
+#endif /* STBTT_malloc */
 
-#endif // NK_INCLUDE_FONT_BAKING
+#endif /* NK_INCLUDE_FONT_BAKING */
 
 #endif
 


### PR DESCRIPTION
This PR seeks to resolve issue #231 ISO ansi pedantic compilation error (gcc).

It makes changes to src/nuklear_internal.h and to src/nuklear_font.h to allow them to compile w/ gcc flags '-std=c89 -pedantic'