### PR TITLE
Made D3D11 implementation work when using NK_UINT_DRAW_INDEX

### DIFF
--- a/demo/d3d11/nuklear_d3d11.h
+++ b/demo/d3d11/nuklear_d3d11.h
@@ -85,10 +85,15 @@ nk_d3d11_render(ID3D11DeviceContext *context, enum nk_anti_aliasing AA)
     const float blend_factor[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
     const UINT stride = sizeof(struct nk_d3d11_vertex);
     const UINT offset = 0;
+#ifdef NK_UINT_DRAW_INDEX
+    DXGI_FORMAT index_buffer_format = DXGI_FORMAT_R32_UINT;
+#else
+    DXGI_FORMAT index_buffer_format = DXGI_FORMAT_R16_UINT;
+#endif
 
     ID3D11DeviceContext_IASetInputLayout(context, d3d11.input_layout);
     ID3D11DeviceContext_IASetVertexBuffers(context, 0, 1, &d3d11.vertex_buffer, &stride, &offset);
-    ID3D11DeviceContext_IASetIndexBuffer(context, d3d11.index_buffer, DXGI_FORMAT_R16_UINT, 0);
+    ID3D11DeviceContext_IASetIndexBuffer(context, d3d11.index_buffer, index_buffer_format, 0);
     ID3D11DeviceContext_IASetPrimitiveTopology(context, D3D11_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 
     ID3D11DeviceContext_VSSetShader(context, d3d11.vertex_shader, NULL, 0);


### PR DESCRIPTION
Issue #236 

When defining NK_UINT_DRAW_INDEX to increase the size of nk_draw_index from ushort to a uint to allow drawing a lot more on a window, the D3D11 implementation doesn't handle the change properly and exhibits the behavior explained in the Issue. 

This Pull Request implements a change that allows the D3D11 implementation to work regardless if you have the NK_UINT_DRAW_INDEX defined or not. 