### PR TITLE
Fix canvas example not rendering fully on macOS

### DIFF
--- a/example/canvas.c
+++ b/example/canvas.c
@@ -477,7 +477,7 @@ int main(int argc, char *argv[])
         canvas_end(&ctx, &canvas);}
 
         /* Draw */
-        glfwGetWindowSize(win, &width, &height);
+        glfwGetFramebufferSize(win, &width, &height);
         glViewport(0, 0, width, height);
         glClear(GL_COLOR_BUFFER_BIT);
         glClearColor(0.2f, 0.2f, 0.2f, 1.0f);

--- a/example/canvas.c
+++ b/example/canvas.c
@@ -477,6 +477,9 @@ int main(int argc, char *argv[])
         canvas_end(&ctx, &canvas);}
 
         /* Draw */
+        /* Framebuffer size is used instead of window size because the window size is in screen coordinates instead of pixels.
+         * See https://www.glfw.org/docs/latest/window_guide.html#window_size for more info
+         */
         glfwGetFramebufferSize(win, &width, &height);
         glViewport(0, 0, width, height);
         glClear(GL_COLOR_BUFFER_BIT);


### PR DESCRIPTION
On macOS (or just retina/hi-dpi displays), the window size is not necessarily the render size so, glfwGetFramebufferSize must be used instead of glfwGetWindowSize in the render loop.

So originally it would look like this:
<img width="1312" alt="Screen Shot 2021-04-29 at 9 01 08 AM" src="https://user-images.githubusercontent.com/54418727/116558579-923a7a00-a8cd-11eb-9fcc-4b1efe99f23c.png">

But with my change it now looks like this:
<img width="1312" alt="Screen Shot 2021-04-29 at 9 04 39 AM" src="https://user-images.githubusercontent.com/54418727/116558635-a2eaf000-a8cd-11eb-843d-e6578599b09c.png">