### PR TITLE
Add max_pack_XXX to nk_font_atlas

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -4031,6 +4031,9 @@ struct nk_font_atlas {
     void *pixel;
     int tex_width;
     int tex_height;
+    /* Use max_pack_x to set maximum packing sizes for this atlas*/
+    nk_size max_pack_width;
+    nk_size max_pack_height;
 
     struct nk_allocator permanent;
     struct nk_allocator temporary;
@@ -16406,9 +16409,9 @@ NK_INTERN int
 nk_font_bake_pack(struct nk_font_baker *baker,
     nk_size *image_memory, int *width, int *height, struct nk_recti *custom,
     const struct nk_font_config *config_list, int count,
-    struct nk_allocator *alloc)
+        struct nk_allocator *alloc, nk_size max_pack_width, nk_size max_pack_height)
 {
-    NK_STORAGE const nk_size max_height = 1024 * 32;
+    NK_STORAGE nk_size max_height = 1024 * 16;
     const struct nk_font_config *config_iter, *it;
     int total_glyph_count = 0;
     int total_range_count = 0;
@@ -16440,7 +16443,9 @@ nk_font_bake_pack(struct nk_font_baker *baker,
         } while ((it = it->n) != config_iter);
     }
     *height = 0;
-    *width = (total_glyph_count > 1000) ? 1024 : 512;
+    if(max_pack_width) *width = max_pack_width;
+    else *width = (total_glyph_count > 1000) ? 1024 : 512;
+    if(max_pack_height) max_height = max_pack_height;
     stbtt_PackBegin(&baker->spc, 0, (int)*width, (int)max_height, 0, 1, alloc);
     {
         int input_i = 0;
@@ -17172,6 +17177,8 @@ nk_font_atlas_begin(struct nk_font_atlas *atlas)
         atlas->permanent.free(atlas->permanent.userdata, atlas->pixel);
         atlas->pixel = 0;
     }
+    atlas->max_pack_width = 0;
+    atlas->max_pack_height = 0;
 }
 NK_API struct nk_font*
 nk_font_atlas_add(struct nk_font_atlas *atlas, const struct nk_font_config *config)
@@ -17440,7 +17447,7 @@ nk_font_atlas_bake(struct nk_font_atlas *atlas, int *width, int *height,
     atlas->custom.w = (NK_CURSOR_DATA_W*2)+1;
     atlas->custom.h = NK_CURSOR_DATA_H + 1;
     if (!nk_font_bake_pack(baker, &img_size, width, height, &atlas->custom,
-        atlas->config, atlas->font_num, &atlas->temporary))
+        atlas->config, atlas->font_num, &atlas->temporary, atlas->max_pack_width, atlas->max_pack_height))
         goto failed;
 
     /* allocate memory for the baked image font atlas */
@@ -29173,6 +29180,7 @@ nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
+/// - 2021/05/15 (4.07.1) - Added max_pack_width and max_pack_height to allow changes to the otherwise hardcoded 1k*32k texture atlas size
 /// - 2021/03/17 (4.07.0) - Fix nk_property hover bug
 /// - 2021/03/15 (4.06.4) - Change nk_propertyi back to int
 /// - 2021/03/15 (4.06.3) - Update documentation for functions that now return nk_bool

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -8,6 +8,7 @@
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
+/// - 2021/05/15 (4.07.1) - Added max_pack_width and max_pack_height to allow changes to the otherwise hardcoded 1k*32k texture atlas size
 /// - 2021/03/17 (4.07.0) - Fix nk_property hover bug
 /// - 2021/03/15 (4.06.4) - Change nk_propertyi back to int
 /// - 2021/03/15 (4.06.3) - Update documentation for functions that now return nk_bool

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -3810,6 +3810,9 @@ struct nk_font_atlas {
     void *pixel;
     int tex_width;
     int tex_height;
+    /* Use max_pack_x to set maximum packing sizes for this atlas*/
+    nk_size max_pack_width;
+    nk_size max_pack_height;
 
     struct nk_allocator permanent;
     struct nk_allocator temporary;

--- a/src/nuklear_font.c
+++ b/src/nuklear_font.c
@@ -163,9 +163,9 @@ NK_INTERN int
 nk_font_bake_pack(struct nk_font_baker *baker,
     nk_size *image_memory, int *width, int *height, struct nk_recti *custom,
     const struct nk_font_config *config_list, int count,
-    struct nk_allocator *alloc)
+        struct nk_allocator *alloc, nk_size max_pack_width, nk_size max_pack_height)
 {
-    NK_STORAGE const nk_size max_height = 1024 * 32;
+    NK_STORAGE nk_size max_height = 1024 * 16;
     const struct nk_font_config *config_iter, *it;
     int total_glyph_count = 0;
     int total_range_count = 0;
@@ -197,7 +197,9 @@ nk_font_bake_pack(struct nk_font_baker *baker,
         } while ((it = it->n) != config_iter);
     }
     *height = 0;
-    *width = (total_glyph_count > 1000) ? 1024 : 512;
+    if(max_pack_width) *width = max_pack_width;
+    else *width = (total_glyph_count > 1000) ? 1024 : 512;
+    if(max_pack_height) max_height = max_pack_height;
     stbtt_PackBegin(&baker->spc, 0, (int)*width, (int)max_height, 0, 1, alloc);
     {
         int input_i = 0;
@@ -929,6 +931,8 @@ nk_font_atlas_begin(struct nk_font_atlas *atlas)
         atlas->permanent.free(atlas->permanent.userdata, atlas->pixel);
         atlas->pixel = 0;
     }
+    atlas->max_pack_width = 0;
+    atlas->max_pack_height = 0;
 }
 NK_API struct nk_font*
 nk_font_atlas_add(struct nk_font_atlas *atlas, const struct nk_font_config *config)
@@ -1197,7 +1201,7 @@ nk_font_atlas_bake(struct nk_font_atlas *atlas, int *width, int *height,
     atlas->custom.w = (NK_CURSOR_DATA_W*2)+1;
     atlas->custom.h = NK_CURSOR_DATA_H + 1;
     if (!nk_font_bake_pack(baker, &img_size, width, height, &atlas->custom,
-        atlas->config, atlas->font_num, &atlas->temporary))
+        atlas->config, atlas->font_num, &atlas->temporary, atlas->max_pack_width, atlas->max_pack_height))
         goto failed;
 
     /* allocate memory for the baked image font atlas */


### PR DESCRIPTION
With a large number of glyphs (i.e. by including Unicode's CJK unified table for Japanese), Nuklear's default font handler produces tall but thin Texture atlases, that quickly break through the GPU's max texture size. See this texture atlas for context:
<details>
<summary>Example default texture atlas </summary>

![here](https://user-images.githubusercontent.com/60887273/118371095-42390400-b5ab-11eb-8e3f-6dd395b36942.png)
</details>
The default sizes of 1k width and 32k height are rather arbitrary as well. Specifically the atlas pack width is changed from 512 to 1024 after 1000 glyphs. This decision does not take into account oversampling for instance.

To alleviate this, this PR introduces "nk_size max_pack_width" and "nk_size max_pack_height" to the struct "nk_font_atlas".
This allows the user to override the texture atlas size limits, as used by nk_font_bake_pack(). Because those numbers have to be initialized to prevent undefined behavior in the default case, nk_font_atlas_begin() sets this value to 0. As such, the values can only be set after nk_font_atlas_begin().
Here an example for context,  which sets the pack size to the OpenGL Texture maximum, based on the GLFW_OpenGL3 demo.
```
struct nk_font * test_font;
struct nk_font_config cfg_font = nk_font_config(0);

nk_rune ranges_font[] = {
    0x0020, 0x007E,    	/* Ascii */
    0x00A1, 0x00FF,    	/* Symbols + Umlaute */
    0x0410, 0x044F,    	/* Russian */
    0x3000, 0x303F,    	/* CJK Symbols and Punctuation */
    0x3040, 0x309F,    	/* Hiragana */
    0x30A0, 0x30FF,    	/* Katakana */
    0x4E00, 0x9FFF,    	/* Kanji */
    0
}; 

struct nk_font_atlas *atlas;
nk_glfw3_font_stash_begin(&glfw, &atlas);
int texture_max;
glGetIntegerv(GL_MAX_TEXTURE_SIZE, &texture_max);
atlas->max_pack_width = texture_max;
atlas->max_pack_height = texture_max;
test_font = nk_font_atlas_add_from_memory(
    atlas, (void *)NotoSansCJKjp_Regular_otf.pnt,
    NotoSansCJKjp_Regular_otf.size, 27.5, &cfg_font);
nk_glfw3_font_stash_end(&glfw);
nk_style_set_font(ctx, &test_font->handle);
```
Now the texture atlas is more square and does not blow past the GPU's size limit with bigger fontsizes or oversampling.

- Why not use tex_width and tex_height, which is already there?
Those values are used to report the result of the atlas baking and packing operations. It would be inconstant logic, if the values are set one moment and change by themselves in the next one.
- Why not change the behavior of width and height of nk_font_atlas_bake?
Same logic, those values are just used for reporting back, also it would require users to initialize those values to zero beforehand, breaking Nuklear by default.
- Why not introduce a new argument to nk_font_atlas_bake()?
It would break the API and all demos.
- Why change the default packing max_height of 32k to 16k?
Although still arbitrary, the 16k textures are the upper limit of a big chunk of modern graphics cards. 16k textures are a sensible upper limit, if a more sensible value is not set by the user