### PR TITLE
Change NK_MEMSET to memset() in demos, to prevent compilation errors when Nuklear.h is split or NK_IMPLEMENTATION is undefined

### DIFF
--- a/demo/glfw_opengl2/nuklear_glfw_gl2.h
+++ b/demo/glfw_opengl2/nuklear_glfw_gl2.h
@@ -136,7 +136,7 @@ nk_glfw3_render(enum nk_anti_aliasing AA)
             {NK_VERTEX_COLOR, NK_FORMAT_R8G8B8A8, NK_OFFSETOF(struct nk_glfw_vertex, col)},
             {NK_VERTEX_LAYOUT_END}
         };
-        NK_MEMSET(&config, 0, sizeof(config));
+        memset(&config, 0, sizeof(config));
         config.vertex_layout = vertex_layout;
         config.vertex_size = sizeof(struct nk_glfw_vertex);
         config.vertex_alignment = NK_ALIGNOF(struct nk_glfw_vertex);

--- a/demo/glfw_opengl3/nuklear_glfw_gl3.h
+++ b/demo/glfw_opengl3/nuklear_glfw_gl3.h
@@ -262,7 +262,7 @@ nk_glfw3_render(struct nk_glfw* glfw, enum nk_anti_aliasing AA, int max_vertex_b
                 {NK_VERTEX_COLOR, NK_FORMAT_R8G8B8A8, NK_OFFSETOF(struct nk_glfw_vertex, col)},
                 {NK_VERTEX_LAYOUT_END}
             };
-            NK_MEMSET(&config, 0, sizeof(config));
+            memset(&config, 0, sizeof(config));
             config.vertex_layout = vertex_layout;
             config.vertex_size = sizeof(struct nk_glfw_vertex);
             config.vertex_alignment = NK_ALIGNOF(struct nk_glfw_vertex);

--- a/demo/glfw_opengl4/nuklear_glfw_gl4.h
+++ b/demo/glfw_opengl4/nuklear_glfw_gl4.h
@@ -403,7 +403,7 @@ nk_glfw3_render(enum nk_anti_aliasing AA)
                     {NK_VERTEX_COLOR, NK_FORMAT_R8G8B8A8, NK_OFFSETOF(struct nk_glfw_vertex, col)},
                     {NK_VERTEX_LAYOUT_END}
                 };
-                NK_MEMSET(&config, 0, sizeof(config));
+                memset(&config, 0, sizeof(config));
                 config.vertex_layout = vertex_layout;
                 config.vertex_size = sizeof(struct nk_glfw_vertex);
                 config.vertex_alignment = NK_ALIGNOF(struct nk_glfw_vertex);

--- a/demo/sdl2surface_rawfb/sdl2surface_rawfb.h
+++ b/demo/sdl2surface_rawfb/sdl2surface_rawfb.h
@@ -813,7 +813,7 @@ nk_sdlsurface_init(SDL_Surface *fb, float fontSize)
     if (!sdlsurface)
         return NULL;
 
-    NK_MEMSET(sdlsurface, 0, sizeof(struct sdlsurface_context));
+    memset(sdlsurface, 0, sizeof(struct sdlsurface_context));
 
     sdlsurface->fb = fb;
 
@@ -1001,7 +1001,7 @@ nk_sdlsurface_shutdown(struct sdlsurface_context *sdlsurface)
     if (sdlsurface) {
         SDL_FreeSurface(sdlsurface->font_tex);
         nk_free(&sdlsurface->ctx);
-        NK_MEMSET(sdlsurface, 0, sizeof(struct sdlsurface_context));
+        memset(sdlsurface, 0, sizeof(struct sdlsurface_context));
         free(sdlsurface);
     }
 }

--- a/demo/sdl_opengl2/nuklear_sdl_gl2.h
+++ b/demo/sdl_opengl2/nuklear_sdl_gl2.h
@@ -116,7 +116,7 @@ nk_sdl_render(enum nk_anti_aliasing AA)
             {NK_VERTEX_COLOR, NK_FORMAT_R8G8B8A8, NK_OFFSETOF(struct nk_sdl_vertex, col)},
             {NK_VERTEX_LAYOUT_END}
         };
-        NK_MEMSET(&config, 0, sizeof(config));
+        memset(&config, 0, sizeof(config));
         config.vertex_layout = vertex_layout;
         config.vertex_size = sizeof(struct nk_sdl_vertex);
         config.vertex_alignment = NK_ALIGNOF(struct nk_sdl_vertex);

--- a/demo/sdl_opengl3/nuklear_sdl_gl3.h
+++ b/demo/sdl_opengl3/nuklear_sdl_gl3.h
@@ -243,7 +243,7 @@ nk_sdl_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_b
                 {NK_VERTEX_COLOR, NK_FORMAT_R8G8B8A8, NK_OFFSETOF(struct nk_sdl_vertex, col)},
                 {NK_VERTEX_LAYOUT_END}
             };
-            NK_MEMSET(&config, 0, sizeof(config));
+            memset(&config, 0, sizeof(config));
             config.vertex_layout = vertex_layout;
             config.vertex_size = sizeof(struct nk_sdl_vertex);
             config.vertex_alignment = NK_ALIGNOF(struct nk_sdl_vertex);

--- a/demo/sdl_opengles2/nuklear_sdl_gles2.h
+++ b/demo/sdl_opengles2/nuklear_sdl_gles2.h
@@ -241,7 +241,7 @@ nk_sdl_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_b
                 {NK_VERTEX_COLOR, NK_FORMAT_R8G8B8A8, NK_OFFSETOF(struct nk_sdl_vertex, col)},
                 {NK_VERTEX_LAYOUT_END}
             };
-            NK_MEMSET(&config, 0, sizeof(config));
+            memset(&config, 0, sizeof(config));
             config.vertex_layout = vertex_layout;
             config.vertex_size = sizeof(struct nk_sdl_vertex);
             config.vertex_alignment = NK_ALIGNOF(struct nk_sdl_vertex);

--- a/demo/sfml_opengl2/nuklear_sfml_gl2.h
+++ b/demo/sfml_opengl2/nuklear_sfml_gl2.h
@@ -114,7 +114,7 @@ nk_sfml_render(enum nk_anti_aliasing AA)
             {NK_VERTEX_COLOR, NK_FORMAT_R8G8B8A8, NK_OFFSETOF(struct nk_sfml_vertex, col)},
             {NK_VERTEX_LAYOUT_END}
         };
-        NK_MEMSET(&config, 0, sizeof(config));
+        memset(&config, 0, sizeof(config));
         config.vertex_layout = vertex_layout;
         config.vertex_size = sizeof(struct nk_sfml_vertex);
         config.vertex_alignment = NK_ALIGNOF(struct nk_sfml_vertex);

--- a/demo/sfml_opengl3/nuklear_sfml_gl3.h
+++ b/demo/sfml_opengl3/nuklear_sfml_gl3.h
@@ -244,7 +244,7 @@ nk_sfml_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_
                 {NK_VERTEX_LAYOUT_END}
             };
 
-            NK_MEMSET(&config, 0, sizeof(config));
+            memset(&config, 0, sizeof(config));
             config.vertex_layout = vertex_layout;
             config.vertex_size = sizeof(struct nk_sfml_vertex);
             config.vertex_alignment = NK_ALIGNOF(struct nk_sfml_vertex);

--- a/demo/x11/nuklear_xlib.h
+++ b/demo/x11/nuklear_xlib.h
@@ -864,7 +864,7 @@ nk_xlib_shutdown(void)
     nk_xsurf_del(xlib.surf);
     nk_free(&xlib.ctx);
     XFreeCursor(xlib.dpy, xlib.cursor);
-    NK_MEMSET(&xlib, 0, sizeof(xlib));
+    memset(&xlib, 0, sizeof(xlib));
 }
 
 NK_API void

--- a/demo/x11_opengl2/nuklear_xlib_gl2.h
+++ b/demo/x11_opengl2/nuklear_xlib_gl2.h
@@ -146,7 +146,7 @@ nk_x11_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_b
             {NK_VERTEX_COLOR, NK_FORMAT_R8G8B8A8, NK_OFFSETOF(struct nk_x11_vertex, col)},
             {NK_VERTEX_LAYOUT_END}
         };
-        NK_MEMSET(&config, 0, sizeof(config));
+        memset(&config, 0, sizeof(config));
         config.vertex_layout = vertex_layout;
         config.vertex_size = sizeof(struct nk_x11_vertex);
         config.vertex_alignment = NK_ALIGNOF(struct nk_x11_vertex);

--- a/demo/x11_opengl3/nuklear_xlib_gl3.h
+++ b/demo/x11_opengl3/nuklear_xlib_gl3.h
@@ -532,7 +532,7 @@ nk_x11_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_b
                 {NK_VERTEX_COLOR, NK_FORMAT_R8G8B8A8, NK_OFFSETOF(struct nk_x11_vertex, col)},
                 {NK_VERTEX_LAYOUT_END}
             };
-            NK_MEMSET(&config, 0, sizeof(config));
+            memset(&config, 0, sizeof(config));
             config.vertex_layout = vertex_layout;
             config.vertex_size = sizeof(struct nk_x11_vertex);
             config.vertex_alignment = NK_ALIGNOF(struct nk_x11_vertex);

--- a/demo/x11_rawfb/nuklear_rawfb.h
+++ b/demo/x11_rawfb/nuklear_rawfb.h
@@ -821,7 +821,7 @@ nk_rawfb_init(void *fb, void *tex_mem, const unsigned int w, const unsigned int 
     if (!rawfb)
         return NULL;
 
-    NK_MEMSET(rawfb, 0, sizeof(struct rawfb_context));
+    memset(rawfb, 0, sizeof(struct rawfb_context));
     rawfb->font_tex.pixels = tex_mem;
     rawfb->font_tex.format = NK_FONT_ATLAS_ALPHA8;
     rawfb->font_tex.w = rawfb->font_tex.h = 0;
@@ -1015,7 +1015,7 @@ nk_rawfb_shutdown(struct rawfb_context *rawfb)
 {
     if (rawfb) {
 	nk_free(&rawfb->ctx);
-	NK_MEMSET(rawfb, 0, sizeof(struct rawfb_context));
+	memset(rawfb, 0, sizeof(struct rawfb_context));
 	free(rawfb);
     }
 }

--- a/demo/x11_rawfb/nuklear_xlib.h
+++ b/demo/x11_rawfb/nuklear_xlib.h
@@ -287,7 +287,7 @@ nk_xlib_shutdown(void)
         XDestroyImage(xlib.ximg);
         shmdt(xlib.xsi.shmaddr);
         shmctl(xlib.xsi.shmid, IPC_RMID, NULL);
-    } NK_MEMSET(&xlib, 0, sizeof(xlib));
+    } memset(&xlib, 0, sizeof(xlib));
 }
 
 NK_API void

--- a/demo/x11_xft/nuklear_xlib.h
+++ b/demo/x11_xft/nuklear_xlib.h
@@ -942,7 +942,7 @@ nk_xlib_shutdown(void)
     nk_xsurf_del(xlib.surf);
     nk_free(&xlib.ctx);
     XFreeCursor(xlib.dpy, xlib.cursor);
-    NK_MEMSET(&xlib, 0, sizeof(xlib));
+    memset(&xlib, 0, sizeof(xlib));
 }
 
 NK_API void


### PR DESCRIPTION
All the backend implementations demos make use of the NK_MEMSET macro.
However NK_MEMSET is not defined in Nuklear's public header, but in it's private implemenation. Specifically in nuklear_internal.h As the name suggests, NK_MEMSET is meant for nuklear's internal implementation.
Even the single header build file makes this obvious: nuklear.h is --pub, but nuklear_internal.h is --priv1 .

- But why change it?
Although Nuklear is a single header library, it sometimes makes sense to split it for faster compilation. The Implementation can be precompiled into an object file and the header can be precompiled into a precompiled header object file. This allows blazing fast recompilation and instant response from linting. However, because the backend implementations mix public and internal definitions, it breaks compilation after the split occurs.
- Why not make use of internal definitions for consistency with Nuklear?
Because it is not consitent in the first place. The backend implementations use malloc(), which is not internal, but NK_MEMSET, which is.

Also it straight up contradicts:

> The implementation mode requires to define  the preprocessor macro NK_IMPLEMENTATION in * one * .c/.cpp file before #includeing this file