### PR TITLE
Fix warning about unused parameter

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -21311,6 +21311,8 @@ nk_layout_row_calculate_usable_space(const struct nk_style *style, enum nk_panel
 
     struct nk_vec2 spacing;
 
+    NK_UNUSED(type);
+
     spacing = style->window.spacing;
 
     /* calculate the usable panel space */

--- a/src/nuklear_layout.c
+++ b/src/nuklear_layout.c
@@ -49,6 +49,8 @@ nk_layout_row_calculate_usable_space(const struct nk_style *style, enum nk_panel
 
     struct nk_vec2 spacing;
 
+    NK_UNUSED(type);
+
     spacing = style->window.spacing;
 
     /* calculate the usable panel space */


### PR DESCRIPTION
Solves #208.
I got warning 'Unused parameter' when I tried to compile this library with `-Wextra` gcc flag. I suppressed this warning in this pull request, but maybe this parameter should be removed from function?