### PR TITLE
Fix "'num_len' may be used uninitialized" in nk_do_property

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -27621,7 +27621,7 @@ nk_do_property(nk_flags *ws,
         nk_filter_float
     };
     nk_bool active, old;
-    int num_len, name_len;
+    int num_len = 0, name_len;
     char string[NK_MAX_NUMBER_BUFFER];
     float size;
 
@@ -29537,6 +29537,7 @@ nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
+/// - 2021/09/15 (4.08.4) - Fix "'num_len' may be used uninitialized" in nk_do_property
 /// - 2021/09/15 (4.08.3) - Fix "Templates cannot be declared to have 'C' Linkage"
 /// - 2021/09/08 (4.08.2) - Fix warnings in C89 builds
 /// - 2021/09/08 (4.08.1) - Use compiler builtins for NK_OFFSETOF when possible

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuklear",
-  "version": "4.08.3",
+  "version": "4.08.4",
   "repo": "Immediate-Mode-UI/Nuklear",
   "description": "A small ANSI C gui toolkit",
   "keywords": ["gl", "ui", "toolkit"],

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -8,6 +8,7 @@
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
+/// - 2021/09/15 (4.08.4) - Fix "'num_len' may be used uninitialized" in nk_do_property
 /// - 2021/09/15 (4.08.3) - Fix "Templates cannot be declared to have 'C' Linkage"
 /// - 2021/09/08 (4.08.2) - Fix warnings in C89 builds
 /// - 2021/09/08 (4.08.1) - Use compiler builtins for NK_OFFSETOF when possible

--- a/src/nuklear_property.c
+++ b/src/nuklear_property.c
@@ -122,7 +122,7 @@ nk_do_property(nk_flags *ws,
         nk_filter_float
     };
     nk_bool active, old;
-    int num_len, name_len;
+    int num_len = 0, name_len;
     char string[NK_MAX_NUMBER_BUFFER];
     float size;
 


### PR DESCRIPTION
Re-created PR#27 (not me) since this is still an issue, gcc 11.1 on Linux here.