### PR TITLE
Added nk_spacer to help adjusting layout

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -2577,6 +2577,21 @@ NK_API struct nk_rect nk_layout_space_rect_to_screen(struct nk_context*, struct 
 /// Returns transformed `nk_rect` in layout space coordinates
 */
 NK_API struct nk_rect nk_layout_space_rect_to_local(struct nk_context*, struct nk_rect);
+
+/*/// #### nk_spacer
+/// Spacer is a dummy widget that consumes space as usual but doesn't draw anything
+/// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
+/// void nk_spacer(struct nk_context* );
+/// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+///
+/// Parameter   | Description
+/// ------------|-----------------------------------------------------------
+/// __ctx__     | Must point to an previously initialized `nk_context` struct after call `nk_layout_space_begin`
+///
+*/
+NK_API void nk_spacer(struct nk_context* );
+
+
 /* =============================================================================
  *
  *                                  GROUP
@@ -22145,6 +22160,12 @@ nk_layout_peek(struct nk_rect *bounds, struct nk_context *ctx)
     }
     layout->at_y = y;
     layout->row.index = index;
+}
+NK_API void 
+nk_spacer(struct nk_context *ctx )
+{
+    struct nk_rect dummy_rect = {0};
+    nk_panel_alloc_space( &dummy_rect, ctx );
 }
 
 

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -2356,6 +2356,21 @@ NK_API struct nk_rect nk_layout_space_rect_to_screen(struct nk_context*, struct 
 /// Returns transformed `nk_rect` in layout space coordinates
 */
 NK_API struct nk_rect nk_layout_space_rect_to_local(struct nk_context*, struct nk_rect);
+
+/*/// #### nk_spacer
+/// Spacer is a dummy widget that consumes space as usual but doesn't draw anything
+/// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
+/// void nk_spacer(struct nk_context* );
+/// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+///
+/// Parameter   | Description
+/// ------------|-----------------------------------------------------------
+/// __ctx__     | Must point to an previously initialized `nk_context` struct after call `nk_layout_space_begin`
+///
+*/
+NK_API void nk_spacer(struct nk_context* );
+
+
 /* =============================================================================
  *
  *                                  GROUP

--- a/src/nuklear_layout.c
+++ b/src/nuklear_layout.c
@@ -758,4 +758,10 @@ nk_layout_peek(struct nk_rect *bounds, struct nk_context *ctx)
     layout->at_y = y;
     layout->row.index = index;
 }
+NK_API void 
+nk_spacer(struct nk_context *ctx )
+{
+    struct nk_rect dummy_rect = {0};
+    nk_panel_alloc_space( &dummy_rect, ctx );
+}
 


### PR DESCRIPTION
I'm working on a fork of nuklear with some customizations for theming. I'll submit PRs for changes I make that I think will be generally useful. But feel free to ignore or reject if it doesn't fit.

This is a tiny little fix I use all over the place, `nk_spacer(ctx)` will allocate space like any other widget, but not do anything with it. It's useful for adding space between rows or between widgets in a row.