### PR TITLE
Add separate padding for progress bar background

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -5009,6 +5009,7 @@ struct nk_style_progress {
     float cursor_border;
     float cursor_rounding;
     struct nk_vec2 padding;
+    struct nk_vec2 padding_outer;
 
     /* optional user callbacks */
     nk_handle userdata;
@@ -25274,25 +25275,33 @@ nk_do_progress(nk_flags *state,
     float prog_scale;
     nk_size prog_value;
     struct nk_rect cursor;
+    struct nk_rect outer;
 
     NK_ASSERT(style);
     NK_ASSERT(out);
     if (!out || !style) return 0;
 
+    /* calculate progressbar outer rect */
+    outer.w = NK_MAX(bounds.w, 2 * (style->padding_outer.x + style->border ) );
+    outer.h = NK_MAX(bounds.h, 2 * (style->padding_outer.y + style->border ) );
+    outer = nk_pad_rect(bounds, nk_vec2(style->padding_outer.x + style->border, 
+                                        style->padding_outer.y + style->border));
+
     /* calculate progressbar cursor */
-    cursor.w = NK_MAX(bounds.w, 2 * style->padding.x + 2 * style->border);
-    cursor.h = NK_MAX(bounds.h, 2 * style->padding.y + 2 * style->border);
-    cursor = nk_pad_rect(bounds, nk_vec2(style->padding.x + style->border, style->padding.y + style->border));
+    cursor.w = NK_MAX(bounds.w, 2 * (style->padding.x + style->padding_outer.x + style->border ) );
+    cursor.h = NK_MAX(bounds.h, 2 * (style->padding.y + style->padding_outer.y + style->border ) );
+    cursor = nk_pad_rect(bounds, nk_vec2(style->padding.x + style->padding_outer.x + style->border, 
+                                         style->padding.y + style->padding_outer.y + style->border));
     prog_scale = (float)value / (float)max;
 
     /* update progressbar */
     prog_value = NK_MIN(value, max);
-    prog_value = nk_progress_behavior(state, in, bounds, cursor,max, prog_value, modifiable);
+    prog_value = nk_progress_behavior(state, in, outer, cursor,max, prog_value, modifiable);
     cursor.w = cursor.w * prog_scale;
 
     /* draw progressbar */
     if (style->draw_begin) style->draw_begin(out, style->userdata);
-    nk_draw_progress(out, *state, style, &bounds, &cursor, value, max);
+    nk_draw_progress(out, *state, style, &outer, &cursor, value, max);
     if (style->draw_end) style->draw_end(out, style->userdata);
     return prog_value;
 }

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -4788,6 +4788,7 @@ struct nk_style_progress {
     float cursor_border;
     float cursor_rounding;
     struct nk_vec2 padding;
+    struct nk_vec2 padding_outer;
 
     /* optional user callbacks */
     nk_handle userdata;

--- a/src/nuklear_progress.c
+++ b/src/nuklear_progress.c
@@ -96,25 +96,33 @@ nk_do_progress(nk_flags *state,
     float prog_scale;
     nk_size prog_value;
     struct nk_rect cursor;
+    struct nk_rect outer;
 
     NK_ASSERT(style);
     NK_ASSERT(out);
     if (!out || !style) return 0;
 
+    /* calculate progressbar outer rect */
+    outer.w = NK_MAX(bounds.w, 2 * (style->padding_outer.x + style->border ) );
+    outer.h = NK_MAX(bounds.h, 2 * (style->padding_outer.y + style->border ) );
+    outer = nk_pad_rect(bounds, nk_vec2(style->padding_outer.x + style->border, 
+                                        style->padding_outer.y + style->border));
+
     /* calculate progressbar cursor */
-    cursor.w = NK_MAX(bounds.w, 2 * style->padding.x + 2 * style->border);
-    cursor.h = NK_MAX(bounds.h, 2 * style->padding.y + 2 * style->border);
-    cursor = nk_pad_rect(bounds, nk_vec2(style->padding.x + style->border, style->padding.y + style->border));
+    cursor.w = NK_MAX(bounds.w, 2 * (style->padding.x + style->padding_outer.x + style->border ) );
+    cursor.h = NK_MAX(bounds.h, 2 * (style->padding.y + style->padding_outer.y + style->border ) );
+    cursor = nk_pad_rect(bounds, nk_vec2(style->padding.x + style->padding_outer.x + style->border, 
+                                         style->padding.y + style->padding_outer.y + style->border));
     prog_scale = (float)value / (float)max;
 
     /* update progressbar */
     prog_value = NK_MIN(value, max);
-    prog_value = nk_progress_behavior(state, in, bounds, cursor,max, prog_value, modifiable);
+    prog_value = nk_progress_behavior(state, in, outer, cursor,max, prog_value, modifiable);
     cursor.w = cursor.w * prog_scale;
 
     /* draw progressbar */
     if (style->draw_begin) style->draw_begin(out, style->userdata);
-    nk_draw_progress(out, *state, style, &bounds, &cursor, value, max);
+    nk_draw_progress(out, *state, style, &outer, &cursor, value, max);
     if (style->draw_end) style->draw_end(out, style->userdata);
     return prog_value;
 }


### PR DESCRIPTION
Added a separate outer padding for progress bars. This is useful when you need some padding for your background image as well as for the inner filled progress image. I named this `padding_outer` rather than calling it `padding` and renaming the existing one to `padding_cursor` or something like that so that this will be backwards compatible if people are already using padding on progress bar, but I'd be happy to rename it.

<img width="500" alt="progress_bar" src="https://user-images.githubusercontent.com/24752/133553264-7aa33537-2ed3-4c54-ac7a-c4caf24f0194.png">
