### PR TITLE
GCC __printf__ format attribute only exists in version 3.2 and later

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -314,8 +314,8 @@ extern "C" {
     #define NK_PRINTF_FORMAT_STRING
   #endif
   #if defined(__GNUC__)
-    #define NK_PRINTF_VARARG_FUNC(fmtargnumber) __attribute__((format(__printf__, fmtargnumber, fmtargnumber+1)))
-    #define NK_PRINTF_VALIST_FUNC(fmtargnumber) __attribute__((format(__printf__, fmtargnumber, 0)))
+    #define NK_PRINTF_VARARG_FUNC(fmtargnumber) __attribute__((format(printf, fmtargnumber, fmtargnumber+1)))
+    #define NK_PRINTF_VALIST_FUNC(fmtargnumber) __attribute__((format(printf, fmtargnumber, 0)))
   #else
     #define NK_PRINTF_VARARG_FUNC(fmtargnumber)
     #define NK_PRINTF_VALIST_FUNC(fmtargnumber)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nuklear",
-  "version": "4.08.5",
+  "version": "4.08.6",
   "repo": "Immediate-Mode-UI/Nuklear",
   "description": "A small ANSI C gui toolkit",
   "keywords": ["gl", "ui", "toolkit"],

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -8,6 +8,7 @@
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
+/// - 2021/09/25 (4.08.6) - GCC __printf__ format attribute only exists in version 3.2 and later
 /// - 2021/09/22 (4.08.5) - GCC __builtin_offsetof only exists in version 4 and later
 /// - 2021/09/15 (4.08.4) - Fix "'num_len' may be used uninitialized" in nk_do_property
 /// - 2021/09/15 (4.08.3) - Fix "Templates cannot be declared to have 'C' Linkage"

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -93,8 +93,8 @@ extern "C" {
     #define NK_PRINTF_FORMAT_STRING
   #endif
   #if defined(__GNUC__)
-    #define NK_PRINTF_VARARG_FUNC(fmtargnumber) __attribute__((format(__printf__, fmtargnumber, fmtargnumber+1)))
-    #define NK_PRINTF_VALIST_FUNC(fmtargnumber) __attribute__((format(__printf__, fmtargnumber, 0)))
+    #define NK_PRINTF_VARARG_FUNC(fmtargnumber) __attribute__((format(printf, fmtargnumber, fmtargnumber+1)))
+    #define NK_PRINTF_VALIST_FUNC(fmtargnumber) __attribute__((format(printf, fmtargnumber, 0)))
   #else
     #define NK_PRINTF_VARARG_FUNC(fmtargnumber)
     #define NK_PRINTF_VALIST_FUNC(fmtargnumber)


### PR DESCRIPTION
The format attribute `__printf__` is equivalent to `printf` but the latter works in gcc versions older than 3.2.