### PR TITLE
Add command to draw polyline from float*

### DIFF
--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -4203,7 +4203,8 @@ enum nk_command_type {
     NK_COMMAND_POLYLINE,
     NK_COMMAND_TEXT,
     NK_COMMAND_IMAGE,
-    NK_COMMAND_CUSTOM
+    NK_COMMAND_CUSTOM,
+    NK_COMMAND_POLYLINE_FLOAT
 };
 
 /* command base and header of every command inside the buffer */
@@ -4335,6 +4336,14 @@ struct nk_command_polyline {
     unsigned short line_thickness;
     unsigned short point_count;
     struct nk_vec2i points[1];
+};
+
+struct nk_command_polyline_float {
+    struct nk_command header;
+    struct nk_color color;
+    unsigned short line_thickness;
+    unsigned short point_count;
+    struct nk_vec2 *points;
 };
 
 struct nk_command_image {

--- a/src/nuklear_draw.c
+++ b/src/nuklear_draw.c
@@ -392,6 +392,23 @@ nk_stroke_polyline(struct nk_command_buffer *b, float *points, int point_count,
     }
 }
 NK_API void
+nk_stroke_polyline_float(struct nk_command_buffer *b, float *points, int point_count,
+    float line_thickness, struct nk_color col)
+{
+    nk_size size = 0;
+    struct nk_command_polyline_float *cmd;
+
+    NK_ASSERT(b);
+    if (!b || col.a == 0 || line_thickness <= 0) return;
+    size = sizeof(*cmd);
+    cmd = (struct nk_command_polyline_float*) nk_command_buffer_push(b, NK_COMMAND_POLYLINE_FLOAT, size);
+    if (!cmd) return;
+    cmd->color = col;
+    cmd->point_count = (unsigned short)point_count;
+    cmd->line_thickness = (unsigned short)line_thickness;
+    cmd->points = (struct nk_vec2*)points;
+}
+NK_API void
 nk_draw_image(struct nk_command_buffer *b, struct nk_rect r,
     const struct nk_image *img, struct nk_color col)
 {

--- a/src/nuklear_vertex.c
+++ b/src/nuklear_vertex.c
@@ -1309,6 +1309,11 @@ nk_convert(struct nk_context *ctx, struct nk_buffer *cmds,
             const struct nk_command_custom *c = (const struct nk_command_custom*)cmd;
             c->callback(&ctx->draw_list, c->x, c->y, c->w, c->h, c->callback_data);
         } break;
+        case NK_COMMAND_POLYLINE_FLOAT: {
+            const struct nk_command_polyline_float* p = (const struct nk_command_polyline_float*)cmd;
+            nk_draw_list_stroke_poly_line(&ctx->draw_list,
+                p->points, p->point_count, p->color, NK_STROKE_OPEN, p->line_thickness, (&ctx->draw_list)->config.line_AA);
+        } break;
         default: break;
         }
     }


### PR DESCRIPTION
Adds a command which passes a pointer to use for a polyline. Skips pushing data to buffer as an array of shorts and back.

Note: Assumes pointer is user managed and lives until frame is complete*
Usage: When an array of floats is already in memory as an array of `nk_vec2{x,y}`, same call signature as `nk_stroke_polyline()`

Can improve on programs which have a smaller fixed buffer for commands.
Names and enum values tentative, feel free to edit. Similar functions could be added for polygons.