### PR TITLE
Add non-owning draw api command

### DIFF
--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -4203,7 +4203,8 @@ enum nk_command_type {
     NK_COMMAND_POLYLINE,
     NK_COMMAND_TEXT,
     NK_COMMAND_IMAGE,
-    NK_COMMAND_CUSTOM
+    NK_COMMAND_CUSTOM,
+    NK_COMMAND_STROKE_BUFFER
 };
 
 /* command base and header of every command inside the buffer */
@@ -4345,6 +4346,16 @@ struct nk_command_image {
     struct nk_color col;
 };
 
+struct nk_command_stroke_buffer {
+    struct nk_command header;
+    void *vertexs;
+    int vertex_size;
+    int vertex_count;
+    void *indexs;
+    int index_size;
+    int index_count;
+};
+
 typedef void (*nk_command_custom_callback)(void *canvas, short x,short y,
     unsigned short w, unsigned short h, nk_handle callback_data);
 struct nk_command_custom {
@@ -4389,6 +4400,8 @@ NK_API void nk_stroke_arc(struct nk_command_buffer*, float cx, float cy, float r
 NK_API void nk_stroke_triangle(struct nk_command_buffer*, float, float, float, float, float, float, float line_thichness, struct nk_color);
 NK_API void nk_stroke_polyline(struct nk_command_buffer*, float *points, int point_count, float line_thickness, struct nk_color col);
 NK_API void nk_stroke_polygon(struct nk_command_buffer*, float*, int point_count, float line_thickness, struct nk_color);
+NK_API void nk_stroke_buffer(struct nk_command_buffer*, void*, int vertex_size, int vertex_count, void*, int index_size, int index_count);
+
 
 /* filled shades */
 NK_API void nk_fill_rect(struct nk_command_buffer*, struct nk_rect, float rounding, struct nk_color);

--- a/src/nuklear_draw.c
+++ b/src/nuklear_draw.c
@@ -392,6 +392,26 @@ nk_stroke_polyline(struct nk_command_buffer *b, float *points, int point_count,
     }
 }
 NK_API void
+nk_stroke_buffer(struct nk_command_buffer *b, void *vertex_buffer,
+    int vertex_size, int vertex_count,
+    void *index_buffer, int index_size, int index_count) {
+
+    nk_size size = 0;
+    struct nk_command_stroke_buffer *cmd;
+
+    NK_ASSERT(b);
+    if (!b || !vertex_buffer || !index_buffer || vertex_count <= 0 || vertex_size <= 0 || index_count <= 0 || index_size <= 0) return;
+    size = (sizeof(*cmd));
+    cmd = (struct nk_command_stroke_buffer*) nk_command_buffer_push(b, NK_COMMAND_STROKE_BUFFER, size);
+    if (!cmd) return;
+    cmd->indexs = index_buffer;
+    cmd->vertexs = vertex_buffer;
+    cmd->vertex_size = vertex_size;
+    cmd->vertex_count = vertex_count;
+    cmd->index_size = index_size;
+    cmd->index_count = index_count;
+}
+NK_API void
 nk_draw_image(struct nk_command_buffer *b, struct nk_rect r,
     const struct nk_image *img, struct nk_color col)
 {

--- a/src/nuklear_vertex.c
+++ b/src/nuklear_vertex.c
@@ -1309,6 +1309,11 @@ nk_convert(struct nk_context *ctx, struct nk_buffer *cmds,
             const struct nk_command_custom *c = (const struct nk_command_custom*)cmd;
             c->callback(&ctx->draw_list, c->x, c->y, c->w, c->h, c->callback_data);
         } break;
+        case NK_COMMAND_STROKE_BUFFER: {
+            const struct nk_command_stroke_buffer *c = (const struct nk_command_stroke_buffer*)cmd;
+            nk_draw_list_stroke_vertex_buffer(&ctx->draw_list, c->vertex_buffer, c->vertex_size, c->vertex_count,
+                c->index_buffer, c->index_size, c->index_count);
+        } break;
         default: break;
         }
     }


### PR DESCRIPTION
Rough idea of a non-owning draw call, not user friendly, expects the buffers provided are ready to draw as is.