### PR TITLE
Fix warning in Allegro5 demo

### DIFF
--- a/demo/allegro5/nuklear_allegro5.h
+++ b/demo/allegro5/nuklear_allegro5.h
@@ -98,7 +98,7 @@ NK_API void nk_allegro5_del_image(struct nk_image* image)
 static float
 nk_allegro5_font_get_text_width(nk_handle handle, float height, const char *text, int len)
 {
-    (void)height;
+    NK_UNUSED(height);
     NkAllegro5Font *font = (NkAllegro5Font*)handle.ptr;
     if (!font || !text) {
         return 0;

--- a/demo/allegro5/nuklear_allegro5.h
+++ b/demo/allegro5/nuklear_allegro5.h
@@ -98,6 +98,7 @@ NK_API void nk_allegro5_del_image(struct nk_image* image)
 static float
 nk_allegro5_font_get_text_width(nk_handle handle, float height, const char *text, int len)
 {
+    (void)height;
     NkAllegro5Font *font = (NkAllegro5Font*)handle.ptr;
     if (!font || !text) {
         return 0;


### PR DESCRIPTION
Hello! This tiny PR fixes `unused parameter 'height'` warning in Allegro5 demo.