### PR TITLE
Rename package.json to clib.json

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -185,7 +185,7 @@ Reviewing changes to `src/*` and `nuklear.h`:
   * Variable/function name casing.
   * Indentation.
   * Curly bracket (`{}`) placement.
-* Ensure that the contributer has bumped the appropriate version in
+* Ensure that the contributor has bumped the appropriate version in
   [clib.json](https://github.com/Immediate-Mode-UI/Nuklear/blob/master/clib.json)
   and added their changes to the
   [CHANGELOG](https://github.com/Immediate-Mode-UI/Nuklear/blob/master/src/CHANGELOG).

--- a/Readme.md
+++ b/Readme.md
@@ -186,7 +186,7 @@ Reviewing changes to `src/*` and `nuklear.h`:
   * Indentation.
   * Curly bracket (`{}`) placement.
 * Ensure that the contributer have bumped the appropriate version in
-  [package.json](https://github.com/Immediate-Mode-UI/Nuklear/blob/master/package.json)
+  [clib.json](https://github.com/Immediate-Mode-UI/Nuklear/blob/master/clib.json)
   and added their changes to the
   [CHANGELOG](https://github.com/Immediate-Mode-UI/Nuklear/blob/master/src/CHANGELOG).
 * Have at least one other person review the changes before merging.

--- a/clib.json
+++ b/clib.json
@@ -1,6 +1,6 @@
 {
   "name": "nuklear",
-  "version": "4.09.0",
+  "version": "4.09.1",
   "repo": "Immediate-Mode-UI/Nuklear",
   "description": "A small ANSI C gui toolkit",
   "keywords": ["gl", "ui", "toolkit"],

--- a/clib.json
+++ b/clib.json
@@ -1,6 +1,6 @@
 {
   "name": "nuklear",
-  "version": "4.09.1",
+  "version": "4.09.0",
   "repo": "Immediate-Mode-UI/Nuklear",
   "description": "A small ANSI C gui toolkit",
   "keywords": ["gl", "ui", "toolkit"],

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -8,7 +8,6 @@
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
-/// - 2021/11/16 (4.09.1) - Renamed package.json to clib.json
 /// - 2021/10/16 (4.09.0) - Added nk_spacer() widget
 /// - 2021/09/22 (4.08.6) - Fix "may be used uninitialized" warnings in nk_widget
 /// - 2021/09/22 (4.08.5) - GCC __builtin_offsetof only exists in version 4 and later

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -8,6 +8,7 @@
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
+/// - 2021/11/16 (4.09.1) - Renamed package.json to clib.json
 /// - 2021/10/16 (4.09.0) - Added nk_spacer() widget
 /// - 2021/09/22 (4.08.6) - Fix "may be used uninitialized" warnings in nk_widget
 /// - 2021/09/22 (4.08.5) - GCC __builtin_offsetof only exists in version 4 and later


### PR DESCRIPTION
The clib package manager has deprecated package.json in favor of clib.json (probably to reduce confusion between clib and other package managers, e.g. npm). As far as I can tell, there's no difference in file format, only in name.