### PR TITLE
demo: Add clean to Makefiles, and don't use bin directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 demo/*/*.exe
 demo/*/*.obj
-demo/*/bin/*
+demo/*/demo*
 example/bin/*
 docs/xml
 docs/build

--- a/demo/allegro5/Makefile
+++ b/demo/allegro5/Makefile
@@ -17,6 +17,7 @@ LIBS = -lallegro -lallegro_main -lallegro_image -lallegro_font \
 #endif
 
 $(BIN):
-	@mkdir -p bin
-	rm -f bin/$(BIN) $(OBJS)
-	$(CC) $(SRC) $(CFLAGS) -o bin/$(BIN) $(LIBS)
+	$(CC) $(SRC) $(CFLAGS) -o $(BIN) $(LIBS)
+
+clean:
+	$(RM) $(BIN) $(OBJ)

--- a/demo/glfw_opengl2/Makefile
+++ b/demo/glfw_opengl2/Makefile
@@ -20,6 +20,7 @@ else
 endif
 
 $(BIN):
-	@mkdir -p bin
-	rm -f bin/$(BIN) $(OBJS)
-	$(CC) $(SRC) $(CFLAGS) -o bin/$(BIN) $(LIBS)
+	$(CC) $(SRC) $(CFLAGS) -o $(BIN) $(LIBS)
+
+clean:
+	$(RM) $(BIN) $(OBJ)

--- a/demo/glfw_opengl3/Makefile
+++ b/demo/glfw_opengl3/Makefile
@@ -21,6 +21,7 @@ else
 endif
 
 $(BIN):
-	@mkdir -p bin
-	rm -f bin/$(BIN) $(OBJS)
-	$(CC) $(SRC) $(CFLAGS) -o bin/$(BIN) $(LIBS)
+	$(CC) $(SRC) $(CFLAGS) -o $(BIN) $(LIBS)
+
+clean:
+	$(RM) $(BIN) $(OBJ)

--- a/demo/glfw_opengl4/Makefile
+++ b/demo/glfw_opengl4/Makefile
@@ -21,6 +21,7 @@ else
 endif
 
 $(BIN):
-	@mkdir -p bin
-	rm -f bin/$(BIN) $(OBJS)
-	$(CC) $(SRC) $(CFLAGS) -o bin/$(BIN) $(LIBS)
+	$(CC) $(SRC) $(CFLAGS) -o $(BIN) $(LIBS)
+
+clean:
+	$(RM) $(BIN) $(OBJ)

--- a/demo/sdl2surface_rawfb/Makefile
+++ b/demo/sdl2surface_rawfb/Makefile
@@ -1,9 +1,9 @@
-CFLAGS=`sdl2-config --cflags --libs`   -std=c89 -Wall -Wextra -pedantic -Wno-unused-function -O0 -g -fvisibility=hidden `pkg-config SDL2_ttf --cflags --libs`
+# Install
+BIN = demo
+CFLAGS = `sdl2-config --cflags --libs`   -std=c89 -Wall -Wextra -pedantic -Wno-unused-function -O0 -g -fvisibility=hidden `pkg-config SDL2_ttf --cflags --libs`
 
-.PHONY: clean
-
-demo: main.c sdl2surface_rawfb.h
-	$(CC) -o demo *.c $(CFLAGS) -lrt -lm
+$(BIN):
+	$(CC) -o $(BIN) *.c $(CFLAGS) -lrt -lm
 
 clean:
-	$(RM) demo
+	$(RM) $(BIN)

--- a/demo/sdl_opengl2/Makefile
+++ b/demo/sdl_opengl2/Makefile
@@ -20,6 +20,7 @@ else
 endif
 
 $(BIN):
-	@mkdir -p bin
-	rm -f bin/$(BIN) $(OBJS)
-	$(CC) $(SRC) $(CFLAGS) -o bin/$(BIN) $(LIBS)
+	$(CC) $(SRC) $(CFLAGS) -o $(BIN) $(LIBS)
+
+clean:
+	$(RM) $(BIN) $(OBJ)

--- a/demo/sdl_opengl3/Makefile
+++ b/demo/sdl_opengl3/Makefile
@@ -20,6 +20,7 @@ else
 endif
 
 $(BIN):
-	@mkdir -p bin
-	rm -f bin/$(BIN) $(OBJS)
-	$(CC) $(SRC) $(CFLAGS) -o bin/$(BIN) $(LIBS)
+	$(CC) $(SRC) $(CFLAGS) -o $(BIN) $(LIBS)
+
+clean:
+	$(RM) $(BIN) $(OBJ)

--- a/demo/sdl_opengles2/Makefile
+++ b/demo/sdl_opengles2/Makefile
@@ -14,15 +14,14 @@ else
 	LIBS = -lSDL2 -lGLESv2 -lm
 endif
 
-$(BIN): prepare
-	$(CC) $(SRC) $(CFLAGS) -o bin/$(BIN) $(LIBS)
+$(BIN):
+	$(CC) $(SRC) $(CFLAGS) -o $(BIN) $(LIBS)
 
-web: prepare
-	emcc $(SRC) -Os -s USE_SDL=2 -o bin/index.html
+web:
+	emcc $(SRC) -Os -s USE_SDL=2 -o index.html
 
-rpi: prepare
-	$(CC) $(SRC) $(CFLAGS) -o bin/$(BIN) `PKG_CONFIG_PATH=/opt/vc/lib/pkgconfig/ pkg-config --cflags --libs bcm_host brcmglesv2` `/usr/local/bin/sdl2-config --libs --cflags`
+rpi:
+	$(CC) $(SRC) $(CFLAGS) -o $(BIN) `PKG_CONFIG_PATH=/opt/vc/lib/pkgconfig/ pkg-config --cflags --libs bcm_host brcmglesv2` `/usr/local/bin/sdl2-config --libs --cflags`
 
-prepare:
-	@mkdir -p bin
-	rm -f bin/$(BIN) $(OBJS)
+clean:
+	$(RM) $(BIN) $(OBJ)

--- a/demo/sfml_opengl2/Makefile
+++ b/demo/sfml_opengl2/Makefile
@@ -31,3 +31,6 @@ SFML_LIB = -L $(SFML_DIR)/lib
 
 $(BIN):
 	$(CC) $(SRC) $(CFLAGS) -o $(BIN) $(SFML_INC) $(SFML_LIB) $(LIBS)
+
+clean:
+	$(RM) $(BIN) $(OBJ)

--- a/demo/sfml_opengl3/Makefile
+++ b/demo/sfml_opengl3/Makefile
@@ -35,3 +35,6 @@ GLAD_SRC = $(GLAD_DIR)/src/glad.c
 
 $(BIN):
 	$(CC) $(GLAD_SRC) $(SRC) $(CFLAGS) $(GLAD_INC) $(SFML_INC) $(SFML_LIB) $(SFML_EXT) -o $(BIN) $(LIBS)
+
+clean:
+	$(RM) $(BIN) $(OBJ)

--- a/demo/wayland_rawfb/Makefile
+++ b/demo/wayland_rawfb/Makefile
@@ -1,13 +1,15 @@
+# Install
+BIN = demo
+
+# Flags
 WAYLAND=`pkg-config wayland-client --cflags --libs`
 WAYLAND_SCANNER=wayland-scanner
 WAYLAND_PROTOCOLS_DIR=/usr/share/wayland-protocols
 
 CFLAGS?=-std=c99 -Wall -Wextra -pedantic -Wno-unused-function -O3 -fvisibility=hidden
 
-.PHONY: clean
-
-demo: main.c xdg-shell.c xdg-shell.h
-	$(CC) $(CFLAGS) -o demo *.c $(WAYLAND) -lrt -lm
+$(BIN): main.c xdg-shell.c xdg-shell.h
+	$(CC) $(CFLAGS) -o $(BIN) *.c $(WAYLAND) -lrt -lm
 
 xdg-shell.c:
 	$(WAYLAND_SCANNER) code $(WAYLAND_PROTOCOLS_DIR)/stable/xdg-shell/xdg-shell.xml xdg-shell.c
@@ -16,4 +18,4 @@ xdg-shell.h:
 	$(WAYLAND_SCANNER) client-header $(WAYLAND_PROTOCOLS_DIR)/stable/xdg-shell/xdg-shell.xml xdg-shell.h
 
 clean:
-	$(RM) demo xdg-shell.c xdg-shell.h
+	$(RM) $(BIN) xdg-shell.c xdg-shell.h

--- a/demo/x11/Makefile
+++ b/demo/x11/Makefile
@@ -1,5 +1,5 @@
 # Install
-BIN = zahnrad
+BIN = demo
 
 # Flags
 CFLAGS += -std=c89 -Wall -Wextra -pedantic -Wno-unused-function -O2
@@ -7,7 +7,8 @@ CFLAGS += -std=c89 -Wall -Wextra -pedantic -Wno-unused-function -O2
 SRC = main.c
 OBJ = $(SRC:.c=.o)
 
-$(BIN):
-	@mkdir -p bin
-	rm -f bin/$(BIN) $(OBJS)
-	$(CC) $(SRC) $(CFLAGS) -D_POSIX_C_SOURCE=200809L -o bin/$(BIN) -lX11 -lm
+$(BIN): clean bin
+	$(CC) $(SRC) $(CFLAGS) -D_POSIX_C_SOURCE=200809L -o $(BIN) -lX11 -lm
+
+clean:
+	$(RM) $(BIN) $(OBJ)

--- a/demo/x11_opengl2/Makefile
+++ b/demo/x11_opengl2/Makefile
@@ -21,6 +21,7 @@ clang: CC = clang
 clang: $(BIN)
 
 $(BIN):
-	@mkdir -p bin
-	rm -f bin/$(BIN) $(OBJS)
-	$(CC) $(SRC) $(CFLAGS) -o bin/$(BIN) -lX11 -lm -lGL -lm -lGLU
+	$(CC) $(SRC) $(CFLAGS) -o $(BIN) -lX11 -lm -lGL -lm -lGLU
+
+clean:
+	$(RM) $(BIN) $(OBJ)

--- a/demo/x11_opengl3/Makefile
+++ b/demo/x11_opengl3/Makefile
@@ -21,6 +21,7 @@ clang: CC = clang
 clang: $(BIN)
 
 $(BIN):
-	@mkdir -p bin
-	rm -f bin/$(BIN) $(OBJS)
-	$(CC) $(SRC) $(CFLAGS) -o bin/$(BIN) -lX11 -lm -lGL -lm -lGLU
+	$(CC) $(SRC) $(CFLAGS) -o $(BIN) -lX11 -lm -lGL -lm -lGLU
+
+clean:
+	$(RM) $(BIN) $(OBJ)

--- a/demo/x11_rawfb/Makefile
+++ b/demo/x11_rawfb/Makefile
@@ -1,5 +1,5 @@
 # Install
-BIN = zahnrad
+BIN = demo
 
 # Flags
 CFLAGS += -std=c89 -Wall -Wextra -pedantic -Wno-unused-function -O2
@@ -8,6 +8,7 @@ SRC = main.c
 OBJ = $(SRC:.c=.o)
 
 $(BIN):
-	@mkdir -p bin
-	rm -f bin/$(BIN) $(OBJS)
-	$(CC) $(SRC) $(CFLAGS) -D_GNU_SOURCE -D_POSIX_C_SOURCE=200809L -o bin/$(BIN) -lX11 -lXext -lm
+	$(CC) $(SRC) $(CFLAGS) -D_GNU_SOURCE -D_POSIX_C_SOURCE=200809L -o $(BIN) -lX11 -lXext -lm
+
+clean:
+	$(RM) $(BIN) $(OBJ)

--- a/demo/x11_xft/Makefile
+++ b/demo/x11_xft/Makefile
@@ -1,5 +1,5 @@
 # Install
-BIN = zahnrad
+BIN = demo
 
 # Flags
 CFLAGS += -std=c89 -Wall -Wextra -pedantic -Wno-unused-function -O2
@@ -16,6 +16,8 @@ SRC = ${wildcard *.c}
 OBJ = $(SRC:.c=.o)
 
 $(BIN):
-	@mkdir -p bin
-	rm -f bin/$(BIN) $(OBJS)
-	$(CC) $(SRC) $(CFLAGS) -D_POSIX_C_SOURCE=200809L -o bin/$(BIN) -lX11 ${LDFLAGS}
+	$(CC) $(SRC) $(CFLAGS) -D_POSIX_C_SOURCE=200809L -o $(BIN) -lX11 ${LDFLAGS}
+
+clean:
+	$(RM) $(BIN) $(OBJ)
+


### PR DESCRIPTION
This adds a `make clean` command to all the demo Makefiles, and skips the use of a `bin` directory to clean up the build. It ends up building into the same directory instead to make it a simpler build process.