### PR TITLE
Revert "Fix layout bounds not accounting for padding"

### DIFF
--- a/clib.json
+++ b/clib.json
@@ -1,6 +1,6 @@
 {
   "name": "nuklear",
-  "version": "4.09.3",
+  "version": "4.09.1",
   "repo": "Immediate-Mode-UI/Nuklear",
   "description": "A small ANSI C gui toolkit",
   "keywords": ["gl", "ui", "toolkit"],

--- a/nuklear.h
+++ b/nuklear.h
@@ -19547,8 +19547,6 @@ nk_panel_begin(struct nk_context *ctx, const char *title, enum nk_panel_type pan
     layout->bounds = win->bounds;
     layout->bounds.x += panel_padding.x;
     layout->bounds.w -= 2*panel_padding.x;
-    layout->bounds.y += panel_padding.y;
-    layout->bounds.h -= 2*panel_padding.y;
     if (win->flags & NK_WINDOW_BORDER) {
         layout->border = nk_panel_get_border(style, win->flags, panel_type);
         layout->bounds = nk_shrink_rect(layout->bounds, layout->border);
@@ -22226,7 +22224,7 @@ nk_layout_peek(struct nk_rect *bounds, struct nk_context *ctx)
     layout->at_y = y;
     layout->row.index = index;
 }
-NK_API void 
+NK_API void
 nk_spacer(struct nk_context *ctx )
 {
     struct nk_rect dummy_rect = { 0, 0, 0, 0 };
@@ -29623,7 +29621,6 @@ nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
-/// - 2021/12/22 (4.09.3) - Fix layout bounds not accounting for padding.
 /// - 2021/12/19 (4.09.2) - Update to stb_rect_pack.h v1.01 and stb_truetype.h v1.26
 /// - 2021/12/16 (4.09.1) - Fix the majority of GCC warnings
 /// - 2021/10/16 (4.09.0) - Added nk_spacer() widget

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -8,7 +8,6 @@
 ///    - [yy]: Minor version with non-breaking API and library changes
 ///    - [zz]: Bug fix version with no direct changes to API
 ///
-/// - 2021/12/22 (4.09.3) - Fix layout bounds not accounting for padding.
 /// - 2021/12/19 (4.09.2) - Update to stb_rect_pack.h v1.01 and stb_truetype.h v1.26
 /// - 2021/12/16 (4.09.1) - Fix the majority of GCC warnings
 /// - 2021/10/16 (4.09.0) - Added nk_spacer() widget

--- a/src/nuklear_panel.c
+++ b/src/nuklear_panel.c
@@ -156,8 +156,6 @@ nk_panel_begin(struct nk_context *ctx, const char *title, enum nk_panel_type pan
     layout->bounds = win->bounds;
     layout->bounds.x += panel_padding.x;
     layout->bounds.w -= 2*panel_padding.x;
-    layout->bounds.y += panel_padding.y;
-    layout->bounds.h -= 2*panel_padding.y;
     if (win->flags & NK_WINDOW_BORDER) {
         layout->border = nk_panel_get_border(style, win->flags, panel_type);
         layout->bounds = nk_shrink_rect(layout->bounds, layout->border);


### PR DESCRIPTION
Reverts Immediate-Mode-UI/Nuklear#156

@aganm @Hejsil This change reverts the layout bounds change. May be worth considering removing the change until we fix it for good. What do you think?