### PR TITLE
introduce tiling window background, fix nk_image_is_subimage()

### DIFF
--- a/demo/common/canvas.c
+++ b/demo/common/canvas.c
@@ -13,12 +13,12 @@ canvas_begin(struct nk_context *ctx, struct nk_canvas *canvas, nk_flags flags,
     /* save style properties which will be overwritten */
     canvas->panel_padding = ctx->style.window.padding;
     canvas->item_spacing = ctx->style.window.spacing;
-    canvas->window_background = ctx->style.window.fixed_background;
+    canvas->window_background = ctx->style.window.image;
 
     /* use the complete window space and set background */
     ctx->style.window.spacing = nk_vec2(0,0);
     ctx->style.window.padding = nk_vec2(0,0);
-    ctx->style.window.fixed_background = nk_style_item_color(background_color);
+    ctx->style.window.image = nk_style_item_color(background_color);
 
     /* create/update window and set position + size */
     if (!nk_begin(ctx, "Canvas", nk_rect(x, y, width, height), NK_WINDOW_NO_SCROLLBAR|flags))
@@ -42,7 +42,7 @@ canvas_end(struct nk_context *ctx, struct nk_canvas *canvas)
     nk_end(ctx);
     ctx->style.window.spacing = canvas->panel_padding;
     ctx->style.window.padding = canvas->item_spacing;
-    ctx->style.window.fixed_background = canvas->window_background;
+    ctx->style.window.image = canvas->window_background;
 }
 
 static void

--- a/example/canvas.c
+++ b/example/canvas.c
@@ -364,12 +364,12 @@ canvas_begin(struct nk_context *ctx, struct nk_canvas *canvas, nk_flags flags,
     /* save style properties which will be overwritten */
     canvas->panel_padding = ctx->style.window.padding;
     canvas->item_spacing = ctx->style.window.spacing;
-    canvas->window_background = ctx->style.window.fixed_background;
+    canvas->window_background = ctx->style.window.image;
 
     /* use the complete window space and set background */
     ctx->style.window.spacing = nk_vec2(0,0);
     ctx->style.window.padding = nk_vec2(0,0);
-    ctx->style.window.fixed_background = nk_style_item_color(background_color);
+    ctx->style.window.image = nk_style_item_color(background_color);
 
     /* create/update window and set position + size */
     flags = flags & ~NK_WINDOW_DYNAMIC;
@@ -390,7 +390,7 @@ canvas_end(struct nk_context *ctx, struct nk_canvas *canvas)
     nk_end(ctx);
     ctx->style.window.spacing = canvas->panel_padding;
     ctx->style.window.padding = canvas->item_spacing;
-    ctx->style.window.fixed_background = canvas->window_background;
+    ctx->style.window.image = canvas->window_background;
 }
 
 int main(int argc, char *argv[])

--- a/example/extended.c
+++ b/example/extended.c
@@ -84,8 +84,8 @@ ui_piemenu(struct nk_context *ctx, struct nk_vec2 pos, float radius,
 
     /* pie menu popup */
     struct nk_color border = ctx->style.window.border_color;
-    struct nk_style_item background = ctx->style.window.fixed_background;
-    ctx->style.window.fixed_background = nk_style_item_hide();
+    struct nk_style_item background = ctx->style.window.image;
+    ctx->style.window.image = nk_style_item_hide();
     ctx->style.window.border_color = nk_rgba(0,0,0,0);
 
     total_space  = nk_window_get_content_region(ctx);
@@ -167,7 +167,7 @@ ui_piemenu(struct nk_context *ctx, struct nk_vec2 pos, float radius,
     ctx->style.window.padding = nk_vec2(8,8);
     nk_popup_end(ctx);
 
-    ctx->style.window.fixed_background = background;
+    ctx->style.window.image = background;
     ctx->style.window.border_color = border;
     return ret;
 }

--- a/example/skinning.c
+++ b/example/skinning.c
@@ -415,7 +415,7 @@ int main(int argc, char *argv[])
 
         /* window */
         ctx.style.window.background = nk_rgb(204,204,204);
-        ctx.style.window.fixed_background = nk_style_item_image(media.window);
+        ctx.style.window.image = nk_style_item_image(media.window);
         ctx.style.window.border_color = nk_rgb(67,67,67);
         ctx.style.window.combo_border_color = nk_rgb(67,67,67);
         ctx.style.window.contextual_border_color = nk_rgb(67,67,67);

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -7,6 +7,8 @@
 ///   - [y]: Minor version with non-breaking API and library changes
 ///   - [z]: Patch version with no direct changes to the API
 ///
+/// - 2022/04/07 (5.0.0)  - tiling window backgrounds, nk_style_window.fixed_background
+///                         renamed to nk_style_window.image
 /// - 2022/02/03 (4.9.6)  - Allow overriding the NK_INV_SQRT function, similar to NK_SIN and NK_COS
 /// - 2021/12/22 (4.9.5)  - Revert layout bounds not accounting for padding due to regressions
 /// - 2021/12/22 (4.9.4)  - Fix checking hovering when window is minimized

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -4619,6 +4619,7 @@ NK_API void nk_draw_list_fill_poly_convex(struct nk_draw_list*, const struct nk_
 
 /* misc */
 NK_API void nk_draw_list_add_image(struct nk_draw_list*, struct nk_image texture, struct nk_rect rect, struct nk_color);
+NK_API void nk_draw_list_add_image_tiled(struct nk_draw_list*, struct nk_image texture, struct nk_rect rect, struct nk_color);
 NK_API void nk_draw_list_add_text(struct nk_draw_list*, const struct nk_user_font*, struct nk_rect, const char *text, int len, float font_height, struct nk_color);
 #ifdef NK_INCLUDE_COMMAND_USERDATA
 NK_API void nk_draw_list_push_userdata(struct nk_draw_list*, nk_handle userdata);
@@ -5005,7 +5006,7 @@ struct nk_style_window_header {
 
 struct nk_style_window {
     struct nk_style_window_header header;
-    struct nk_style_item fixed_background;
+    struct nk_style_item image;
     struct nk_color background;
 
     struct nk_color border_color;
@@ -5025,6 +5026,7 @@ struct nk_style_window {
     float tooltip_border;
     float popup_border;
     float min_row_height_padding;
+    NK_BOOL tiled_background;
 
     float rounding;
     struct nk_vec2 spacing;

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -4218,6 +4218,7 @@ enum nk_command_type {
     NK_COMMAND_POLYLINE,
     NK_COMMAND_TEXT,
     NK_COMMAND_IMAGE,
+    NK_COMMAND_IMAGE_TILED,    
     NK_COMMAND_CUSTOM
 };
 
@@ -4415,6 +4416,7 @@ NK_API void nk_fill_polygon(struct nk_command_buffer*, float*, int point_count, 
 
 /* misc */
 NK_API void nk_draw_image(struct nk_command_buffer*, struct nk_rect, const struct nk_image*, struct nk_color);
+NK_API void nk_draw_image_tiled(struct nk_command_buffer*, struct nk_rect, const struct nk_image*, struct nk_color);
 NK_API void nk_draw_nine_slice(struct nk_command_buffer*, struct nk_rect, const struct nk_nine_slice*, struct nk_color);
 NK_API void nk_draw_text(struct nk_command_buffer*, struct nk_rect, const char *text, int len, const struct nk_user_font*, struct nk_color, struct nk_color);
 NK_API void nk_push_scissor(struct nk_command_buffer*, struct nk_rect);

--- a/src/nuklear_draw.c
+++ b/src/nuklear_draw.c
@@ -415,6 +415,29 @@ nk_draw_image(struct nk_command_buffer *b, struct nk_rect r,
     cmd->col = col;
 }
 NK_API void
+nk_draw_image_tiled(struct nk_command_buffer *b, struct nk_rect r,
+    const struct nk_image *img, struct nk_color col)
+{
+    struct nk_command_image *cmd;
+    NK_ASSERT(b);
+    if (!b) return;
+    if (b->use_clipping) {
+        const struct nk_rect *c = &b->clip;
+        if (c->w == 0 || c->h == 0 || !NK_INTERSECT(r.x, r.y, r.w, r.h, c->x, c->y, c->w, c->h))
+            return;
+    }
+    
+    cmd = (struct nk_command_image*)
+        nk_command_buffer_push(b, NK_COMMAND_IMAGE_TILED, sizeof(*cmd));
+    if (!cmd) return;
+    cmd->x = (short)r.x;
+    cmd->y = (short)r.y;
+    cmd->w = (unsigned short)NK_MAX(0, r.w);
+    cmd->h = (unsigned short)NK_MAX(0, r.h);
+    cmd->img = *img;
+    cmd->col = col;
+}
+NK_API void
 nk_draw_nine_slice(struct nk_command_buffer *b, struct nk_rect r,
     const struct nk_nine_slice *slc, struct nk_color col)
 {

--- a/src/nuklear_image.c
+++ b/src/nuklear_image.c
@@ -104,7 +104,8 @@ NK_API nk_bool
 nk_image_is_subimage(const struct nk_image* img)
 {
     NK_ASSERT(img);
-    return !(img->w == 0 && img->h == 0);
+    return !(img->region[0] == 0 && img->region[1] == 0 &&
+	     img->region[2] == 0 && img->region[3] == 0);
 }
 NK_API void
 nk_image(struct nk_context *ctx, struct nk_image img)

--- a/src/nuklear_panel.c
+++ b/src/nuklear_panel.c
@@ -303,7 +303,10 @@ nk_panel_begin(struct nk_context *ctx, const char *title, enum nk_panel_type pan
 
         switch(style->window.image.type) {
             case NK_STYLE_ITEM_IMAGE:
-                nk_draw_image(out, body, &style->window.image.data.image, nk_white);
+		 if(ctx->style.window.tiled_background)
+		     nk_draw_image_tiled(out, body, &style->window.image.data.image, nk_white);
+		 else 
+		     nk_draw_image(out, body, &style->window.image.data.image, nk_white);
                 break;
             case NK_STYLE_ITEM_NINE_SLICE:
                 nk_draw_nine_slice(out, body, &style->window.image.data.slice, nk_white);

--- a/src/nuklear_panel.c
+++ b/src/nuklear_panel.c
@@ -301,15 +301,15 @@ nk_panel_begin(struct nk_context *ctx, const char *title, enum nk_panel_type pan
         body.y = (win->bounds.y + layout->header_height);
         body.h = (win->bounds.h - layout->header_height);
 
-        switch(style->window.fixed_background.type) {
+        switch(style->window.image.type) {
             case NK_STYLE_ITEM_IMAGE:
-                nk_draw_image(out, body, &style->window.fixed_background.data.image, nk_white);
+                nk_draw_image(out, body, &style->window.image.data.image, nk_white);
                 break;
             case NK_STYLE_ITEM_NINE_SLICE:
-                nk_draw_nine_slice(out, body, &style->window.fixed_background.data.slice, nk_white);
+                nk_draw_nine_slice(out, body, &style->window.image.data.slice, nk_white);
                 break;
             case NK_STYLE_ITEM_COLOR:
-                nk_fill_rect(out, body, 0, style->window.fixed_background.data.color);
+                nk_fill_rect(out, body, 0, style->window.image.data.color);
                 break;
         }
     }

--- a/src/nuklear_style.c
+++ b/src/nuklear_style.c
@@ -598,7 +598,7 @@ nk_style_from_table(struct nk_context *ctx, const struct nk_color *table)
 
     /* window */
     win->background = table[NK_COLOR_WINDOW];
-    win->fixed_background = nk_style_item_color(table[NK_COLOR_WINDOW]);
+    win->image = nk_style_item_color(table[NK_COLOR_WINDOW]);
     win->border_color = table[NK_COLOR_BORDER];
     win->popup_border_color = table[NK_COLOR_BORDER];
     win->combo_border_color = table[NK_COLOR_BORDER];

--- a/src/nuklear_vertex.c
+++ b/src/nuklear_vertex.c
@@ -1316,11 +1316,12 @@ nk_convert(struct nk_context *ctx, struct nk_buffer *cmds,
         } break;
         case NK_COMMAND_IMAGE: {
             const struct nk_command_image *i = (const struct nk_command_image*)cmd;
-	     if(ctx->style.window.tiled_background)
-		 nk_draw_list_add_image_tiled(&ctx->draw_list, i->img, nk_rect(i->x, i->y, i->w, i->h), i->col);
-	     else
-		 nk_draw_list_add_image(&ctx->draw_list, i->img, nk_rect(i->x, i->y, i->w, i->h), i->col);
-        } break;
+	     nk_draw_list_add_image(&ctx->draw_list, i->img, nk_rect(i->x, i->y, i->w, i->h), i->col);
+	 } break;
+	 case NK_COMMAND_IMAGE_TILED: {
+	    const struct nk_command_image *i = (const struct nk_command_image*)cmd;
+	    nk_draw_list_add_image_tiled(&ctx->draw_list, i->img, nk_rect(i->x, i->y, i->w, i->h), i->col);
+	 } break;
         case NK_COMMAND_CUSTOM: {
             const struct nk_command_custom *c = (const struct nk_command_custom*)cmd;
             c->callback(&ctx->draw_list, c->x, c->y, c->w, c->h, c->callback_data);

--- a/src/nuklear_vertex.c
+++ b/src/nuklear_vertex.c
@@ -1126,6 +1126,19 @@ nk_draw_list_add_image(struct nk_draw_list *list, struct nk_image texture,
             nk_vec2(0.0f, 0.0f), nk_vec2(1.0f, 1.0f),color);
 }
 NK_API void
+nk_draw_list_add_image_tiled(struct nk_draw_list *list, struct nk_image texture,
+    struct nk_rect rect, struct nk_color color)
+{
+    NK_ASSERT(list);
+    if (!list) return;
+    /* push new command with given texture */
+    nk_draw_list_push_image(list, texture.handle);
+    /* No support for tiled subimages, texture.region is ignored */
+    nk_draw_list_push_rect_uv(list, nk_vec2(rect.x, rect.y),
+            nk_vec2(rect.x + rect.w, rect.y + rect.h), nk_vec2(0.0f, 0.0f),
+            nk_vec2(rect.w/(float)texture.w, rect.h/(float)texture.h), color);
+}
+NK_API void
 nk_draw_list_add_text(struct nk_draw_list *list, const struct nk_user_font *font,
     struct nk_rect rect, const char *text, int len, float font_height,
     struct nk_color fg)
@@ -1303,7 +1316,10 @@ nk_convert(struct nk_context *ctx, struct nk_buffer *cmds,
         } break;
         case NK_COMMAND_IMAGE: {
             const struct nk_command_image *i = (const struct nk_command_image*)cmd;
-            nk_draw_list_add_image(&ctx->draw_list, i->img, nk_rect(i->x, i->y, i->w, i->h), i->col);
+	     if(ctx->style.window.tiled_background)
+		 nk_draw_list_add_image_tiled(&ctx->draw_list, i->img, nk_rect(i->x, i->y, i->w, i->h), i->col);
+	     else
+		 nk_draw_list_add_image(&ctx->draw_list, i->img, nk_rect(i->x, i->y, i->w, i->h), i->col);
         } break;
         case NK_COMMAND_CUSTOM: {
             const struct nk_command_custom *c = (const struct nk_command_custom*)cmd;


### PR DESCRIPTION
![grafik](https://user-images.githubusercontent.com/60887273/162108935-14c2f052-f7e4-492a-822a-886f8bef7d4b.png)
This works by modifying the UVs to sample the texture at 1:1 pixel size. It also assumes, that the backend will repeat the texture, instead of Nuklear drawing a bunch of repeated nk_images. As such, for the instance with OpenGL, you should configured the texture with 
```
glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_REPEAT);
glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_REPEAT);
```
which is OpenGL's default behaviour anyway.
By sampling outside the texture, this makes it impossible to support Nuklear's subimage feature, without rebaking the texture. I am depending on settings outside of Nuklear (OpenGL's or DirectX's texture repeat) and am not sure if I'm thus breaking Nuklear's philosophy of being backend agnostic. If yes, then this PR should propably stay unmerged. I'm unsure, feedback very welcome here.

Now there is the bool `nk_style_window.tiled_background` to switch between stretched and tiled.
I have thought about whether it's worth breaking the API by renaming `struct nk_style_item fixed_background` to `struct nk_style_item image` or whether to introduce a second `struct nk_style_item tiled_background`. But that just seemed weird, how you would be able to assign 2 images to the same `nk_style_window`, even though only one is shown. Not user-friendly IMO.

So I settled on renaming, breaking the API and introducing a bool switch instead. Maybe this should even be an enum to support more than just streched and tiled? Any feedback to my API approach is very welcome, as this doesn't feel worthy of a 5.0.0 version bump.

Moreover, for the tiling to work, Nuklear *needs* to know the image dimensions. This has *not* been the default so far, as I found out. This needs to change IMO, to better support styling image elements. For instance, nk_button_image still needs to be sized correctly with hacky layouting, because it stretches the image across the button, totally ignoring its aspect ratio. Another PR should tackle this. Also, simply setting nk_image.w and nk_image.h causes Nuklear to misinterpret images as subimages. nk_image_is_subimage() just checks `img->w == 0 && img->h == 0`, which breaks image drawing if Nuklear is provided with image dimensions, but not a subimage region. So the function has been changed to specifically check for `!(img->region[0] == 0 && img->region[1] == 0 && img->region[2] == 0 && img->region[3] == 0);` instead.

Finally, it's weird how we use nk_rect for all box defining stuff, but nk_image uses an ushort array to specify the sub image, maybe another TODO as well. 