### PR TITLE
Display the path of the selected file in CL

### DIFF
--- a/demo/common/file_browser.c
+++ b/demo/common/file_browser.c
@@ -468,6 +468,7 @@ file_browser_run(struct file_browser *browser, struct nk_context *ctx)
                                 strncpy(browser->file, browser->directory, MAX_PATH_LEN);
                                 n = strlen(browser->file);
                                 strncpy(browser->file + n, browser->files[fileIndex], MAX_PATH_LEN - n);
+                                puts(browser->file);                                
                                 ret = 1;
                             }
                         }


### PR DESCRIPTION
For convenience only, display the path in the terminal of the file clicked by the user. 
At least this helps me remembering which variable holds the file path