### PR TITLE
Added working filled and outlined arc drawing to GDI binding

### DIFF
--- a/demo/gdi/nuklear_gdi.h
+++ b/demo/gdi/nuklear_gdi.h
@@ -15,6 +15,7 @@
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
+#include <wingdi.h>
 
 typedef struct GdiFont GdiFont;
 NK_API struct nk_context* nk_gdi_init(GdiFont *font, HDC window_dc, unsigned int width, unsigned int height);

--- a/demo/gdi/nuklear_gdi.h
+++ b/demo/gdi/nuklear_gdi.h
@@ -771,6 +771,13 @@ nk_gdi_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
         case VK_PRIOR:
             nk_input_key(&gdi.ctx, NK_KEY_SCROLL_UP, down);
             return 1;
+                
+        case 'A':
+            if (ctrl) {
+                nk_input_key(&gdi.ctx, NK_KEY_TEXT_SELECT_ALL, down);
+                return 1;
+            }
+            break;
 
         case 'C':
             if (ctrl) {

--- a/demo/gdi/nuklear_gdi.h
+++ b/demo/gdi/nuklear_gdi.h
@@ -421,8 +421,10 @@ nk_gdi_stroke_arc(HDC dc, short cx, short cy, unsigned short r, float amin, floa
         end_x = cx + (int) ((float)r*nk_cos(amin)),
         end_y = cy + (int) ((float)r*nk_sin(amin));
 
+    HGDIOBJ br = SelectObject(dc, GetStockObject(NULL_BRUSH));
     SetArcDirection(dc, AD_COUNTERCLOCKWISE);
     Pie(dc, cx-r, cy-r, cx+r, cy+r, start_x, start_y, end_x, end_y);
+    SelectObject(dc, br);
 
     if (pen)
     {
@@ -468,10 +470,11 @@ nk_gdi_stroke_circle(HDC dc, short x, short y, unsigned short w,
         pen = CreatePen(PS_SOLID, line_thickness, color);
         SelectObject(dc, pen);
     }
-
-    SelectObject(dc, GetStockObject(NULL_BRUSH));
+    
+    HGDIOBJ br = SelectObject(dc, GetStockObject(NULL_BRUSH));
     SetDCBrushColor(dc, OPAQUE);
     Ellipse(dc, x, y, x + w, y + h);
+    SelectObject(dc, br);
 
     if (pen) {
         SelectObject(dc, GetStockObject(DC_PEN));

--- a/demo/gdi/nuklear_gdi.h
+++ b/demo/gdi/nuklear_gdi.h
@@ -921,6 +921,14 @@ nk_gdi_render(struct nk_color clear)
             const struct nk_command_circle_filled *c = (const struct nk_command_circle_filled *)cmd;
             nk_gdi_fill_circle(memory_dc, c->x, c->y, c->w, c->h, c->color);
         } break;
+        case NK_COMMAND_ARC: {
+            const struct nk_command_arc *q = (const struct nk_command_arc *)cmd;
+            nk_gdi_stroke_arc(memory_dc, q->cx, q->cy, q->r, q->a[0], q->a[1], q->line_thickness, q->color);
+        } break;
+        case NK_COMMAND_ARC_FILLED: {
+            const struct nk_command_arc_filled *q = (const struct nk_command_arc_filled *)cmd;
+            nk_gdi_fill_arc(memory_dc, q->cx, q->cy, q->r, q->a[0], q->a[1], q->color);
+        } break;
         case NK_COMMAND_TRIANGLE: {
             const struct nk_command_triangle*t = (const struct nk_command_triangle*)cmd;
             nk_gdi_stroke_triangle(memory_dc, t->a.x, t->a.y, t->b.x, t->b.y,
@@ -963,8 +971,7 @@ nk_gdi_render(struct nk_color clear)
             const struct nk_command_image *i = (const struct nk_command_image *)cmd;
             nk_gdi_draw_image(i->x, i->y, i->w, i->h, i->img, i->col);
         } break;
-        case NK_COMMAND_ARC:
-        case NK_COMMAND_ARC_FILLED:
+        case NK_COMMAND_CUSTOM:
         default: break;
         }
     }


### PR DESCRIPTION
This PR is based on #385 and correctly implements (filled) arc drawing, as well as circle stroke drawing in GDI.
It also adds the select all keyboard shortcut.