### PR TITLE
Some improvements to alpha blending in GDI

### DIFF
--- a/demo/gdi/nuklear_gdi.h
+++ b/demo/gdi/nuklear_gdi.h
@@ -218,10 +218,10 @@ nk_gdi_fill_rect(HDC dc, short x, short y, unsigned short w,
 static void
 nk_gdi_set_vertexColor(PTRIVERTEX tri, struct nk_color col)
 {
-    tri->Red   = col.r << 8;
-    tri->Green = col.g << 8;
-    tri->Blue  = col.b << 8;
-    tri->Alpha = 0xff << 8;
+    tri->Red   = col.r * (0xffff / 0xff);
+    tri->Green = col.g * (0xffff / 0xff);
+    tri->Blue  = col.b * (0xffff / 0xff);
+    tri->Alpha = 0xffff;
 }
 
 static void


### PR DESCRIPTION
This does still not work, but it corrects a few bugs that would additionally hinder it from working.
When moving the cursor over the gradient, it does now flicker and "appear" to display a gradient (probably just a redraw effect).
At this point, I am not sure which component is not properly supporting the alpha channel and causing the gradient to not display properly. From what I gathered searching, it is probably 37-year-old GDI itself.