### PR TITLE
Fix Shift + End in nk_edit

### DIFF
--- a/clib.json
+++ b/clib.json
@@ -1,6 +1,6 @@
 {
   "name": "nuklear",
-  "version": "4.9.6",
+  "version": "4.10.1",
   "repo": "Immediate-Mode-UI/Nuklear",
   "description": "A small ANSI C gui toolkit",
   "keywords": ["gl", "ui", "toolkit"],

--- a/nuklear.h
+++ b/nuklear.h
@@ -26163,6 +26163,7 @@ nk_textedit_text(struct nk_text_edit *state, const char *text, int total_len)
             {
                 nk_textedit_makeundo_insert(state, state->cursor, 1);
                 ++state->cursor;
+				state->cursor = NK_MIN(state->cursor, state->string.len);
                 state->has_preferred_x = 0;
             }
         }
@@ -26423,7 +26424,6 @@ retry:
          if (shift_mod) {
             nk_textedit_prep_selection_at_cursor(state);
             state->cursor = state->select_end = state->string.len;
-			if (state->select_start >= state->select_end) state->select_start = 0;
             state->has_preferred_x = 0;
          } else {
             state->cursor = state->string.len;
@@ -30007,3 +30007,4 @@ nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)
 /// in libraries and brought me to create some of my own. Finally Apoorva Joshi
 /// for his single header file packer.
 */
+

--- a/nuklear.h
+++ b/nuklear.h
@@ -26423,6 +26423,7 @@ retry:
          if (shift_mod) {
             nk_textedit_prep_selection_at_cursor(state);
             state->cursor = state->select_end = state->string.len;
+			if (state->select_start >= state->select_end) state->select_start = 0;
             state->has_preferred_x = 0;
          } else {
             state->cursor = state->string.len;
@@ -30006,4 +30007,3 @@ nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)
 /// in libraries and brought me to create some of my own. Finally Apoorva Joshi
 /// for his single header file packer.
 */
-

--- a/nuklear.h
+++ b/nuklear.h
@@ -26162,8 +26162,7 @@ nk_textedit_text(struct nk_text_edit *state, const char *text, int total_len)
                                         text+text_len, 1))
             {
                 nk_textedit_makeundo_insert(state, state->cursor, 1);
-                ++state->cursor;
-				state->cursor = NK_MIN(state->cursor, state->string.len);
+                state->cursor = NK_MIN(state->cursor +1, state->string.len);
                 state->has_preferred_x = 0;
             }
         }

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -7,6 +7,7 @@
 ///   - [y]: Minor version with non-breaking API and library changes
 ///   - [z]: Patch version with no direct changes to the API
 ///
+/// - 2022/08/01 (4.10.1) - Fix cursor jumping back to beginning of text when typing more than nk_edit_xxx limit
 /// - 2022/05/27 (4.10.0) - Add nk_input_has_mouse_click_in_button_rect() to fix window move bug
 /// - 2022/04/18 (4.9.7)  - Change button behavior when NK_BUTTON_TRIGGER_ON_RELEASE is defined to
 ///                         only trigger when the mouse position was inside the same button on down

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -7,7 +7,8 @@
 ///   - [y]: Minor version with non-breaking API and library changes
 ///   - [z]: Patch version with no direct changes to the API
 ///
-/// - 2022/08/01 (4.10.1) - Fix cursor jumping back to beginning of text when typing more than nk_edit_xxx limit
+/// - 2022/08/01 (4.10.1) - Fix cursor jumping back to beginning of text when typing more than
+///                         nk_edit_xxx limit
 /// - 2022/05/27 (4.10.0) - Add nk_input_has_mouse_click_in_button_rect() to fix window move bug
 /// - 2022/04/18 (4.9.7)  - Change button behavior when NK_BUTTON_TRIGGER_ON_RELEASE is defined to
 ///                         only trigger when the mouse position was inside the same button on down

--- a/src/nuklear_text_editor.c
+++ b/src/nuklear_text_editor.c
@@ -395,6 +395,7 @@ nk_textedit_text(struct nk_text_edit *state, const char *text, int total_len)
             {
                 nk_textedit_makeundo_insert(state, state->cursor, 1);
                 ++state->cursor;
+                state->cursor = NK_MIN(state->cursor, state->string.len);
                 state->has_preferred_x = 0;
             }
         }

--- a/src/nuklear_text_editor.c
+++ b/src/nuklear_text_editor.c
@@ -394,8 +394,7 @@ nk_textedit_text(struct nk_text_edit *state, const char *text, int total_len)
                                         text+text_len, 1))
             {
                 nk_textedit_makeundo_insert(state, state->cursor, 1);
-                ++state->cursor;
-                state->cursor = NK_MIN(state->cursor, state->string.len);
+                state->cursor = NK_MIN(state->cursor +1, state->string.len);
                 state->has_preferred_x = 0;
             }
         }


### PR DESCRIPTION
Cursor jumps to the beginning when the last character is entered to reach the maximum size of the editbox.

As it is visually at the beginning, it is possible to select all the text with shift + end key.

However, in fact, it is just a visual effect, in the internal state of the code, it is after the last character.

Thus, selection_begin, position obtained after testing the minimum value of the beginning and end of the selection, will always be the total size of the text, which is the only value excluded from the possibilities of being the initial position of the selection, so that no glyph is compared to this value.

Therefore, select_begin_ptr is not initialized, as the if block of line 27.201 is not satisfied

![print](https://user-images.githubusercontent.com/54485405/180906220-6786ef96-1cec-4518-9d96-1340de16a6f2.png)