### PR TITLE
demos: set style with defines

### DIFF
--- a/demo/allegro5/main.c
+++ b/demo/allegro5/main.c
@@ -116,6 +116,7 @@ int main(void)
 
     /* style.c */
     #ifdef INCLUDE_STYLE
+    /* ease regression testing during Nuklear release process; not needed for anything else */
     #ifdef STYLE_WHITE
     set_style(ctx, THEME_WHITE);
     #elif defined(STYLE_RED)

--- a/demo/allegro5/main.c
+++ b/demo/allegro5/main.c
@@ -115,10 +115,17 @@ int main(void)
     ctx = nk_allegro5_init(font, display, WINDOW_WIDTH, WINDOW_HEIGHT);
 
     /* style.c */
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    #ifdef INCLUDE_STYLE
+    #ifdef STYLE_WHITE
+    set_style(ctx, THEME_WHITE);
+    #elif defined(STYLE_RED)
+    set_style(ctx, THEME_RED);
+    #elif defined(STYLE_BLUE)
+    set_style(ctx, THEME_BLUE);
+    #elif defined(STYLE_DARK)
+    set_style(ctx, THEME_DARK);
+    #endif
+    #endif
 
     while(1)
     {

--- a/demo/d3d11/main.c
+++ b/demo/d3d11/main.c
@@ -210,10 +210,15 @@ int main(void)
 
     /* style.c */
     #ifdef INCLUDE_STYLE
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    #ifdef STYLE_WHITE
+    set_style(ctx, THEME_WHITE);
+    #elif defined(STYLE_RED)
+    set_style(ctx, THEME_RED);
+    #elif defined(STYLE_BLUE)
+    set_style(ctx, THEME_BLUE);
+    #elif defined(STYLE_DARK)
+    set_style(ctx, THEME_DARK);
+    #endif
     #endif
 
     bg.r = 0.10f, bg.g = 0.18f, bg.b = 0.24f, bg.a = 1.0f;

--- a/demo/d3d11/main.c
+++ b/demo/d3d11/main.c
@@ -210,6 +210,7 @@ int main(void)
 
     /* style.c */
     #ifdef INCLUDE_STYLE
+    /* ease regression testing during Nuklear release process; not needed for anything else */
     #ifdef STYLE_WHITE
     set_style(ctx, THEME_WHITE);
     #elif defined(STYLE_RED)

--- a/demo/d3d12/main.c
+++ b/demo/d3d12/main.c
@@ -191,7 +191,7 @@ WindowProc(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
 }
 
 int main(void)
-{  
+{
     struct nk_context *ctx;
     struct nk_colorf bg;
 
@@ -278,7 +278,7 @@ int main(void)
 
     /* GUI */
     ctx = nk_d3d12_init(device, WINDOW_WIDTH, WINDOW_HEIGHT, MAX_VERTEX_BUFFER, MAX_INDEX_BUFFER, USER_TEXTURES);
-    
+
     /* Load Fonts: if none of these are loaded a default font will be used  */
     /* Load Cursor: if you uncomment cursor loading please hide the cursor */
     {
@@ -302,10 +302,15 @@ int main(void)
 
     /* style.c */
     #ifdef INCLUDE_STYLE
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    #ifdef STYLE_WHITE
+    set_style(ctx, THEME_WHITE);
+    #elif defined(STYLE_RED)
+    set_style(ctx, THEME_RED);
+    #elif defined(STYLE_BLUE)
+    set_style(ctx, THEME_BLUE);
+    #elif defined(STYLE_DARK)
+    set_style(ctx, THEME_DARK);
+    #endif
     #endif
 
     bg.r = 0.10f, bg.g = 0.18f, bg.b = 0.24f, bg.a = 1.0f;

--- a/demo/d3d12/main.c
+++ b/demo/d3d12/main.c
@@ -302,6 +302,7 @@ int main(void)
 
     /* style.c */
     #ifdef INCLUDE_STYLE
+    /* ease regression testing during Nuklear release process; not needed for anything else */
     #ifdef STYLE_WHITE
     set_style(ctx, THEME_WHITE);
     #elif defined(STYLE_RED)

--- a/demo/d3d9/main.c
+++ b/demo/d3d9/main.c
@@ -216,10 +216,15 @@ int main(void)
 
     /* style.c */
     #ifdef INCLUDE_STYLE
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    #ifdef STYLE_WHITE
+    set_style(ctx, THEME_WHITE);
+    #elif defined(STYLE_RED)
+    set_style(ctx, THEME_RED);
+    #elif defined(STYLE_BLUE)
+    set_style(ctx, THEME_BLUE);
+    #elif defined(STYLE_DARK)
+    set_style(ctx, THEME_DARK);
+    #endif
     #endif
 
     bg.r = 0.10f, bg.g = 0.18f, bg.b = 0.24f, bg.a = 1.0f;

--- a/demo/d3d9/main.c
+++ b/demo/d3d9/main.c
@@ -216,6 +216,7 @@ int main(void)
 
     /* style.c */
     #ifdef INCLUDE_STYLE
+    /* ease regression testing during Nuklear release process; not needed for anything else */
     #ifdef STYLE_WHITE
     set_style(ctx, THEME_WHITE);
     #elif defined(STYLE_RED)

--- a/demo/gdi/main.c
+++ b/demo/gdi/main.c
@@ -115,10 +115,15 @@ int main(void)
 
     /* style.c */
     #ifdef INCLUDE_STYLE
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    #ifdef STYLE_WHITE
+    set_style(ctx, THEME_WHITE);
+    #elif defined(STYLE_RED)
+    set_style(ctx, THEME_RED);
+    #elif defined(STYLE_BLUE)
+    set_style(ctx, THEME_BLUE);
+    #elif defined(STYLE_DARK)
+    set_style(ctx, THEME_DARK);
+    #endif
     #endif
 
     while (running)

--- a/demo/gdi/main.c
+++ b/demo/gdi/main.c
@@ -115,6 +115,7 @@ int main(void)
 
     /* style.c */
     #ifdef INCLUDE_STYLE
+    /* ease regression testing during Nuklear release process; not needed for anything else */
     #ifdef STYLE_WHITE
     set_style(ctx, THEME_WHITE);
     #elif defined(STYLE_RED)

--- a/demo/gdip/main.c
+++ b/demo/gdip/main.c
@@ -111,6 +111,7 @@ int main(void)
 
     /* style.c */
     #ifdef INCLUDE_STYLE
+    /* ease regression testing during Nuklear release process; not needed for anything else */
     #ifdef STYLE_WHITE
     set_style(ctx, THEME_WHITE);
     #elif defined(STYLE_RED)

--- a/demo/gdip/main.c
+++ b/demo/gdip/main.c
@@ -111,10 +111,15 @@ int main(void)
 
     /* style.c */
     #ifdef INCLUDE_STYLE
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    #ifdef STYLE_WHITE
+    set_style(ctx, THEME_WHITE);
+    #elif defined(STYLE_RED)
+    set_style(ctx, THEME_RED);
+    #elif defined(STYLE_BLUE)
+    set_style(ctx, THEME_BLUE);
+    #elif defined(STYLE_DARK)
+    set_style(ctx, THEME_DARK);
+    #endif
     #endif
 
     while (running)

--- a/demo/glfw_opengl2/main.c
+++ b/demo/glfw_opengl2/main.c
@@ -85,7 +85,7 @@ int main(void)
     /* Platform */
     static GLFWwindow *win;
     int width = 0, height = 0;
-    
+
     /* GUI */
     struct nk_context *ctx;
     struct nk_colorf bg;
@@ -121,14 +121,19 @@ int main(void)
     /*nk_style_set_font(ctx, &droid->handle);*/}
 
     #ifdef INCLUDE_STYLE
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    #ifdef STYLE_WHITE
+    set_style(ctx, THEME_WHITE);
+    #elif defined(STYLE_RED)
+    set_style(ctx, THEME_RED);
+    #elif defined(STYLE_BLUE)
+    set_style(ctx, THEME_BLUE);
+    #elif defined(STYLE_DARK)
+    set_style(ctx, THEME_DARK);
+    #endif
     #endif
 
     bg.r = 0.10f, bg.g = 0.18f, bg.b = 0.24f, bg.a = 1.0f;
-    
+
     #ifdef INCLUDE_FILE_BROWSER
     /* icons */
     glEnable(GL_TEXTURE_2D);
@@ -219,7 +224,7 @@ int main(void)
         glfwSwapBuffers(win);
     }
 
-    #ifdef INCLUDE_FILE_BROWSER       
+    #ifdef INCLUDE_FILE_BROWSER
     glDeleteTextures(1,(const GLuint*)&media.icons.home.handle.id);
     glDeleteTextures(1,(const GLuint*)&media.icons.directory.handle.id);
     glDeleteTextures(1,(const GLuint*)&media.icons.computer.handle.id);
@@ -232,8 +237,8 @@ int main(void)
     glDeleteTextures(1,(const GLuint*)&media.icons.movie_file.handle.id);
 
     file_browser_free(&browser);
-    #endif    
-    
+    #endif
+
     nk_glfw3_shutdown();
     glfwTerminate();
     return 0;

--- a/demo/glfw_opengl2/main.c
+++ b/demo/glfw_opengl2/main.c
@@ -121,6 +121,7 @@ int main(void)
     /*nk_style_set_font(ctx, &droid->handle);*/}
 
     #ifdef INCLUDE_STYLE
+    /* ease regression testing during Nuklear release process; not needed for anything else */
     #ifdef STYLE_WHITE
     set_style(ctx, THEME_WHITE);
     #elif defined(STYLE_RED)

--- a/demo/glfw_opengl3/main.c
+++ b/demo/glfw_opengl3/main.c
@@ -126,6 +126,7 @@ int main(void)
     /*nk_style_set_font(ctx, &droid->handle);*/}
 
     #ifdef INCLUDE_STYLE
+    /* ease regression testing during Nuklear release process; not needed for anything else */
     #ifdef STYLE_WHITE
     set_style(ctx, THEME_WHITE);
     #elif defined(STYLE_RED)

--- a/demo/glfw_opengl3/main.c
+++ b/demo/glfw_opengl3/main.c
@@ -126,10 +126,15 @@ int main(void)
     /*nk_style_set_font(ctx, &droid->handle);*/}
 
     #ifdef INCLUDE_STYLE
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    #ifdef STYLE_WHITE
+    set_style(ctx, THEME_WHITE);
+    #elif defined(STYLE_RED)
+    set_style(ctx, THEME_RED);
+    #elif defined(STYLE_BLUE)
+    set_style(ctx, THEME_BLUE);
+    #elif defined(STYLE_DARK)
+    set_style(ctx, THEME_DARK);
+    #endif
     #endif
 
     bg.r = 0.10f, bg.g = 0.18f, bg.b = 0.24f, bg.a = 1.0f;

--- a/demo/glfw_opengl4/main.c
+++ b/demo/glfw_opengl4/main.c
@@ -126,6 +126,7 @@ int main(void)
     /*nk_style_set_font(ctx, &droid->handle);*/}
 
     #ifdef INCLUDE_STYLE
+    /* ease regression testing during Nuklear release process; not needed for anything else */
     #ifdef STYLE_WHITE
     set_style(ctx, THEME_WHITE);
     #elif defined(STYLE_RED)

--- a/demo/glfw_opengl4/main.c
+++ b/demo/glfw_opengl4/main.c
@@ -126,10 +126,15 @@ int main(void)
     /*nk_style_set_font(ctx, &droid->handle);*/}
 
     #ifdef INCLUDE_STYLE
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    #ifdef STYLE_WHITE
+    set_style(ctx, THEME_WHITE);
+    #elif defined(STYLE_RED)
+    set_style(ctx, THEME_RED);
+    #elif defined(STYLE_BLUE)
+    set_style(ctx, THEME_BLUE);
+    #elif defined(STYLE_DARK)
+    set_style(ctx, THEME_DARK);
+    #endif
     #endif
 
     /* Create bindless texture.

--- a/demo/sdl_opengl2/main.c
+++ b/demo/sdl_opengl2/main.c
@@ -117,6 +117,7 @@ main(int argc, char *argv[])
     /*nk_style_set_font(ctx, &roboto->handle)*/;}
 
     #ifdef INCLUDE_STYLE
+    /* ease regression testing during Nuklear release process; not needed for anything else */
     #ifdef STYLE_WHITE
     set_style(ctx, THEME_WHITE);
     #elif defined(STYLE_RED)

--- a/demo/sdl_opengl2/main.c
+++ b/demo/sdl_opengl2/main.c
@@ -117,10 +117,15 @@ main(int argc, char *argv[])
     /*nk_style_set_font(ctx, &roboto->handle)*/;}
 
     #ifdef INCLUDE_STYLE
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    #ifdef STYLE_WHITE
+    set_style(ctx, THEME_WHITE);
+    #elif defined(STYLE_RED)
+    set_style(ctx, THEME_RED);
+    #elif defined(STYLE_BLUE)
+    set_style(ctx, THEME_BLUE);
+    #elif defined(STYLE_DARK)
+    set_style(ctx, THEME_DARK);
+    #endif
     #endif
 
     bg.r = 0.10f, bg.g = 0.18f, bg.b = 0.24f, bg.a = 1.0f;

--- a/demo/sdl_opengl3/main.c
+++ b/demo/sdl_opengl3/main.c
@@ -128,10 +128,15 @@ int main(int argc, char *argv[])
 
     /* style.c */
     #ifdef INCLUDE_STYLE
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    #ifdef STYLE_WHITE
+    set_style(ctx, THEME_WHITE);
+    #elif defined(STYLE_RED)
+    set_style(ctx, THEME_RED);
+    #elif defined(STYLE_BLUE)
+    set_style(ctx, THEME_BLUE);
+    #elif defined(STYLE_DARK)
+    set_style(ctx, THEME_DARK);
+    #endif
     #endif
 
     bg.r = 0.10f, bg.g = 0.18f, bg.b = 0.24f, bg.a = 1.0f;

--- a/demo/sdl_opengl3/main.c
+++ b/demo/sdl_opengl3/main.c
@@ -128,6 +128,7 @@ int main(int argc, char *argv[])
 
     /* style.c */
     #ifdef INCLUDE_STYLE
+    /* ease regression testing during Nuklear release process; not needed for anything else */
     #ifdef STYLE_WHITE
     set_style(ctx, THEME_WHITE);
     #elif defined(STYLE_RED)

--- a/demo/sdl_opengles2/main.c
+++ b/demo/sdl_opengles2/main.c
@@ -209,6 +209,8 @@ int main(int argc, char* argv[])
     /*nk_style_set_font(ctx, &roboto->handle)*/;}
 
     /* style.c */
+    #ifdef INCLUDE_STYLE
+    /* ease regression testing during Nuklear release process; not needed for anything else */
     #ifdef STYLE_WHITE
     set_style(ctx, THEME_WHITE);
     #elif defined(STYLE_RED)
@@ -217,6 +219,7 @@ int main(int argc, char* argv[])
     set_style(ctx, THEME_BLUE);
     #elif defined(STYLE_DARK)
     set_style(ctx, THEME_DARK);
+    #endif
     #endif
 
 #if defined(__EMSCRIPTEN__)

--- a/demo/sdl_opengles2/main.c
+++ b/demo/sdl_opengles2/main.c
@@ -209,10 +209,15 @@ int main(int argc, char* argv[])
     /*nk_style_set_font(ctx, &roboto->handle)*/;}
 
     /* style.c */
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    #ifdef STYLE_WHITE
+    set_style(ctx, THEME_WHITE);
+    #elif defined(STYLE_RED)
+    set_style(ctx, THEME_RED);
+    #elif defined(STYLE_BLUE)
+    set_style(ctx, THEME_BLUE);
+    #elif defined(STYLE_DARK)
+    set_style(ctx, THEME_DARK);
+    #endif
 
 #if defined(__EMSCRIPTEN__)
     #include <emscripten.h>

--- a/demo/sdl_renderer/main.c
+++ b/demo/sdl_renderer/main.c
@@ -155,10 +155,15 @@ main(int argc, char *argv[])
     }
 
     #ifdef INCLUDE_STYLE
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    #ifdef STYLE_WHITE
+    set_style(ctx, THEME_WHITE);
+    #elif defined(STYLE_RED)
+    set_style(ctx, THEME_RED);
+    #elif defined(STYLE_BLUE)
+    set_style(ctx, THEME_BLUE);
+    #elif defined(STYLE_DARK)
+    set_style(ctx, THEME_DARK);
+    #endif
     #endif
 
     bg.r = 0.10f, bg.g = 0.18f, bg.b = 0.24f, bg.a = 1.0f;

--- a/demo/sdl_renderer/main.c
+++ b/demo/sdl_renderer/main.c
@@ -155,6 +155,7 @@ main(int argc, char *argv[])
     }
 
     #ifdef INCLUDE_STYLE
+    /* ease regression testing during Nuklear release process; not needed for anything else */
     #ifdef STYLE_WHITE
     set_style(ctx, THEME_WHITE);
     #elif defined(STYLE_RED)

--- a/demo/sfml_opengl2/main.cpp
+++ b/demo/sfml_opengl2/main.cpp
@@ -98,10 +98,15 @@ int main(void)
 
     /* style.c */
     #ifdef INCLUDE_STYLE
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    #ifdef STYLE_WHITE
+    set_style(ctx, THEME_WHITE);
+    #elif defined(STYLE_RED)
+    set_style(ctx, THEME_RED);
+    #elif defined(STYLE_BLUE)
+    set_style(ctx, THEME_BLUE);
+    #elif defined(STYLE_DARK)
+    set_style(ctx, THEME_DARK);
+    #endif
     #endif
 
     struct nk_colorf bg;

--- a/demo/sfml_opengl2/main.cpp
+++ b/demo/sfml_opengl2/main.cpp
@@ -98,6 +98,7 @@ int main(void)
 
     /* style.c */
     #ifdef INCLUDE_STYLE
+    /* ease regression testing during Nuklear release process; not needed for anything else */
     #ifdef STYLE_WHITE
     set_style(ctx, THEME_WHITE);
     #elif defined(STYLE_RED)

--- a/demo/sfml_opengl3/main.cpp
+++ b/demo/sfml_opengl3/main.cpp
@@ -104,10 +104,15 @@ int main(void)
 
     /* style.c */
     #ifdef INCLUDE_STYLE
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    #ifdef STYLE_WHITE
+    set_style(ctx, THEME_WHITE);
+    #elif defined(STYLE_RED)
+    set_style(ctx, THEME_RED);
+    #elif defined(STYLE_BLUE)
+    set_style(ctx, THEME_BLUE);
+    #elif defined(STYLE_DARK)
+    set_style(ctx, THEME_DARK);
+    #endif
     #endif
 
     struct nk_colorf bg;

--- a/demo/sfml_opengl3/main.cpp
+++ b/demo/sfml_opengl3/main.cpp
@@ -104,6 +104,7 @@ int main(void)
 
     /* style.c */
     #ifdef INCLUDE_STYLE
+    /* ease regression testing during Nuklear release process; not needed for anything else */
     #ifdef STYLE_WHITE
     set_style(ctx, THEME_WHITE);
     #elif defined(STYLE_RED)

--- a/demo/x11/main.c
+++ b/demo/x11/main.c
@@ -153,10 +153,15 @@ main(void)
     ctx = nk_xlib_init(xw.font, xw.dpy, xw.screen, xw.win, xw.width, xw.height);
 
     #ifdef INCLUDE_STYLE
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    #ifdef STYLE_WHITE
+    set_style(ctx, THEME_WHITE);
+    #elif defined(STYLE_RED)
+    set_style(ctx, THEME_RED);
+    #elif defined(STYLE_BLUE)
+    set_style(ctx, THEME_BLUE);
+    #elif defined(STYLE_DARK)
+    set_style(ctx, THEME_DARK);
+    #endif
     #endif
 
     while (running)

--- a/demo/x11/main.c
+++ b/demo/x11/main.c
@@ -153,6 +153,7 @@ main(void)
     ctx = nk_xlib_init(xw.font, xw.dpy, xw.screen, xw.win, xw.width, xw.height);
 
     #ifdef INCLUDE_STYLE
+    /* ease regression testing during Nuklear release process; not needed for anything else */
     #ifdef STYLE_WHITE
     set_style(ctx, THEME_WHITE);
     #elif defined(STYLE_RED)

--- a/demo/x11_opengl2/main.c
+++ b/demo/x11_opengl2/main.c
@@ -257,6 +257,7 @@ int main(void)
     /*nk_style_set_font(ctx, &droid->handle);*/}
 
     #ifdef INCLUDE_STYLE
+    /* ease regression testing during Nuklear release process; not needed for anything else */
     #ifdef STYLE_WHITE
     set_style(ctx, THEME_WHITE);
     #elif defined(STYLE_RED)

--- a/demo/x11_opengl2/main.c
+++ b/demo/x11_opengl2/main.c
@@ -257,10 +257,15 @@ int main(void)
     /*nk_style_set_font(ctx, &droid->handle);*/}
 
     #ifdef INCLUDE_STYLE
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    #ifdef STYLE_WHITE
+    set_style(ctx, THEME_WHITE);
+    #elif defined(STYLE_RED)
+    set_style(ctx, THEME_RED);
+    #elif defined(STYLE_BLUE)
+    set_style(ctx, THEME_BLUE);
+    #elif defined(STYLE_DARK)
+    set_style(ctx, THEME_DARK);
+    #endif
     #endif
 
     bg.r = 0.10f, bg.g = 0.18f, bg.b = 0.24f, bg.a = 1.0f;

--- a/demo/x11_opengl3/main.c
+++ b/demo/x11_opengl3/main.c
@@ -254,6 +254,7 @@ int main(void)
     /*nk_style_set_font(ctx, &droid->handle);*/}
 
     #ifdef INCLUDE_STYLE
+    /* ease regression testing during Nuklear release process; not needed for anything else */
     #ifdef STYLE_WHITE
     set_style(ctx, THEME_WHITE);
     #elif defined(STYLE_RED)

--- a/demo/x11_opengl3/main.c
+++ b/demo/x11_opengl3/main.c
@@ -254,10 +254,15 @@ int main(void)
     /*nk_style_set_font(ctx, &droid->handle);*/}
 
     #ifdef INCLUDE_STYLE
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    #ifdef STYLE_WHITE
+    set_style(ctx, THEME_WHITE);
+    #elif defined(STYLE_RED)
+    set_style(ctx, THEME_RED);
+    #elif defined(STYLE_BLUE)
+    set_style(ctx, THEME_BLUE);
+    #elif defined(STYLE_DARK)
+    set_style(ctx, THEME_DARK);
+    #endif
     #endif
 
     bg.r = 0.10f, bg.g = 0.18f, bg.b = 0.24f, bg.a = 1.0f;

--- a/demo/x11_rawfb/main.c
+++ b/demo/x11_rawfb/main.c
@@ -194,10 +194,15 @@ main(void)
     if (!rawfb) running = 0;
 
     #ifdef INCLUDE_STYLE
-    /*set_style(&rawfb->ctx, THEME_WHITE);*/
-    /*set_style(&rawfb->ctx, THEME_RED);*/
-    /*set_style(&rawfb->ctx, THEME_BLUE);*/
-    /*set_style(&rawfb->ctx, THEME_DARK);*/
+    #ifdef STYLE_WHITE
+    set_style(&rawfb->ctx, THEME_WHITE);
+    #elif defined(STYLE_RED)
+    set_style(&rawfb->ctx, THEME_RED);
+    #elif defined(STYLE_BLUE)
+    set_style(&rawfb->ctx, THEME_BLUE);
+    #elif defined(STYLE_DARK)
+    set_style(&rawfb->ctx, THEME_DARK);
+    #endif
     #endif
 
     while (running) {

--- a/demo/x11_rawfb/main.c
+++ b/demo/x11_rawfb/main.c
@@ -194,6 +194,7 @@ main(void)
     if (!rawfb) running = 0;
 
     #ifdef INCLUDE_STYLE
+    /* ease regression testing during Nuklear release process; not needed for anything else */
     #ifdef STYLE_WHITE
     set_style(&rawfb->ctx, THEME_WHITE);
     #elif defined(STYLE_RED)

--- a/demo/x11_xft/main.c
+++ b/demo/x11_xft/main.c
@@ -157,10 +157,15 @@ main(void)
                     xw.width, xw.height);
 
     #ifdef INCLUDE_STYLE
-    /*set_style(ctx, THEME_WHITE);*/
-    /*set_style(ctx, THEME_RED);*/
-    /*set_style(ctx, THEME_BLUE);*/
-    /*set_style(ctx, THEME_DARK);*/
+    #ifdef STYLE_WHITE
+    set_style(ctx, THEME_WHITE);
+    #elif defined(STYLE_RED)
+    set_style(ctx, THEME_RED);
+    #elif defined(STYLE_BLUE)
+    set_style(ctx, THEME_BLUE);
+    #elif defined(STYLE_DARK)
+    set_style(ctx, THEME_DARK);
+    #endif
     #endif
 
     while (running)

--- a/demo/x11_xft/main.c
+++ b/demo/x11_xft/main.c
@@ -157,6 +157,7 @@ main(void)
                     xw.width, xw.height);
 
     #ifdef INCLUDE_STYLE
+    /* ease regression testing during Nuklear release process; not needed for anything else */
     #ifdef STYLE_WHITE
     set_style(ctx, THEME_WHITE);
     #elif defined(STYLE_RED)


### PR DESCRIPTION
Not a big deal, but it's annoying to have to modify the demos code to see the effect of styles, then revert to keep on the upstream commit.

It's already possible to use defines to select which demos to include, for example:
```
CFLAGS='-DINCLUDE_CANVAS' make
```

This PR adds the possibility to select the used style when `INCLUDE_STYLE` is defined:
```
CFLAGS='-DINCLUDE_OVERVIEW -DINCLUDE_STYLE -DSTYLE_WHITE` make
```

All demos using the `set_style()` function have been updated, and that does not change the default behavior.