### PR TITLE
Fix incorrect glyph index in nk_font_bake

### DIFF
--- a/clib.json
+++ b/clib.json
@@ -1,6 +1,6 @@
 {
   "name": "nuklear",
-  "version": "4.10.5",
+  "version": "4.10.6",
   "repo": "Immediate-Mode-UI/Nuklear",
   "description": "A small ANSI C gui toolkit",
   "keywords": ["gl", "ui", "toolkit"],

--- a/nuklear.h
+++ b/nuklear.h
@@ -16779,7 +16779,6 @@ nk_font_bake(struct nk_font_baker *baker, void *image_memory, int width, int hei
 
                     /* query glyph bounds from stb_truetype */
                     const stbtt_packedchar *pc = &range->chardata_for_range[char_idx];
-                    if (!pc->x0 && !pc->x1 && !pc->y0 && !pc->y1) continue;
                     codepoint = (nk_rune)(range->first_unicode_codepoint_in_range + char_idx);
                     stbtt_GetPackedQuad(range->chardata_for_range, (int)width,
                         (int)height, char_idx, &dummy_x, &dummy_y, &q, 0);
@@ -29654,6 +29653,7 @@ nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)
 ///   - [y]: Minor version with non-breaking API and library changes
 ///   - [z]: Patch version with no direct changes to the API
 ///
+/// - 2022/12/23 (4.10.6) - Fix incorrect glyph index in nk_font_bake()
 /// - 2022/12/17 (4.10.5) - Fix nk_font_bake_pack() using TTC font offset incorrectly
 /// - 2022/10/24 (4.10.4) - Fix nk_str_{append,insert}_str_utf8 always returning 0
 /// - 2022/09/03 (4.10.3) - Renamed the `null` texture variable to `tex_null`

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -7,6 +7,7 @@
 ///   - [y]: Minor version with non-breaking API and library changes
 ///   - [z]: Patch version with no direct changes to the API
 ///
+/// - 2022/12/23 (4.10.6) - Fix incorrect glyph index in nk_font_bake()
 /// - 2022/12/17 (4.10.5) - Fix nk_font_bake_pack() using TTC font offset incorrectly
 /// - 2022/10/24 (4.10.4) - Fix nk_str_{append,insert}_str_utf8 always returning 0
 /// - 2022/09/03 (4.10.3) - Renamed the `null` texture variable to `tex_null`

--- a/src/nuklear_font.c
+++ b/src/nuklear_font.c
@@ -354,7 +354,6 @@ nk_font_bake(struct nk_font_baker *baker, void *image_memory, int width, int hei
 
                     /* query glyph bounds from stb_truetype */
                     const stbtt_packedchar *pc = &range->chardata_for_range[char_idx];
-                    if (!pc->x0 && !pc->x1 && !pc->y0 && !pc->y1) continue;
                     codepoint = (nk_rune)(range->first_unicode_codepoint_in_range + char_idx);
                     stbtt_GetPackedQuad(range->chardata_for_range, (int)width,
                         (int)height, char_idx, &dummy_x, &dummy_y, &q, 0);


### PR DESCRIPTION
In stbtt_PackFontRangesGatherRects, it skips packing when glyphs are missing. Resulting in incorrect glyphs when nk_font_bake reading these ranges rects data. Referring to the way IMGUI handles it, we skip the rect data check.

ref #399 

load font:
![image](https://user-images.githubusercontent.com/4182549/209197539-1e3622d1-b52a-4ccc-ac77-ee8959e66754.png)

before:
![image](https://user-images.githubusercontent.com/4182549/209198085-8d924cd8-87a2-46b1-a7d1-5ad4cd3f08bd.png)

after:
![image](https://user-images.githubusercontent.com/4182549/209198318-b77e4d50-6313-495d-9745-aa3b03942451.png)

