### PR TITLE
Add Windows 95/98/ME support to the GDI demo

### DIFF
--- a/demo/d3d11/main.c
+++ b/demo/d3d11/main.c
@@ -90,7 +90,7 @@ set_swap_chain_size(int width, int height)
     if (hr == DXGI_ERROR_DEVICE_REMOVED || hr == DXGI_ERROR_DEVICE_RESET || hr == DXGI_ERROR_DRIVER_INTERNAL_ERROR)
     {
         /* to recover from this, you'll need to recreate device and all the resources */
-        MessageBoxW(NULL, L"DXGI device is removed or reset!", L"Error", 0);
+        MessageBox(NULL, TEXT("DXGI device is removed or reset!"), TEXT("Error"), 0);
         exit(0);
     }
     assert(SUCCEEDED(hr));
@@ -131,7 +131,7 @@ WindowProc(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
     if (nk_d3d11_handle_event(wnd, msg, wparam, lparam))
         return 0;
 
-    return DefWindowProcW(wnd, msg, wparam, lparam);
+    return DefWindowProc(wnd, msg, wparam, lparam);
 }
 
 int main(void)
@@ -139,7 +139,7 @@ int main(void)
     struct nk_context *ctx;
     struct nk_colorf bg;
 
-    WNDCLASSW wc;
+    WNDCLASS wc;
     RECT rect = { 0, 0, WINDOW_WIDTH, WINDOW_HEIGHT };
     DWORD style = WS_OVERLAPPEDWINDOW;
     DWORD exstyle = WS_EX_APPWINDOW;
@@ -153,15 +153,15 @@ int main(void)
     memset(&wc, 0, sizeof(wc));
     wc.style = CS_DBLCLKS;
     wc.lpfnWndProc = WindowProc;
-    wc.hInstance = GetModuleHandleW(0);
+    wc.hInstance = GetModuleHandle(0);
     wc.hIcon = LoadIcon(NULL, IDI_APPLICATION);
     wc.hCursor = LoadCursor(NULL, IDC_ARROW);
-    wc.lpszClassName = L"NuklearWindowClass";
-    RegisterClassW(&wc);
+    wc.lpszClassName = TEXT("NuklearWindowClass");
+    RegisterClass(&wc);
 
     AdjustWindowRectEx(&rect, style, FALSE, exstyle);
 
-    wnd = CreateWindowExW(exstyle, wc.lpszClassName, L"Nuklear Direct3D 11 Demo",
+    wnd = CreateWindowEx(exstyle, wc.lpszClassName, TEXT("Nuklear Direct3D 11 Demo"),
         style | WS_VISIBLE, CW_USEDEFAULT, CW_USEDEFAULT,
         rect.right - rect.left, rect.bottom - rect.top,
         NULL, NULL, wc.hInstance, NULL);
@@ -228,12 +228,12 @@ int main(void)
         /* Input */
         MSG msg;
         nk_input_begin(ctx);
-        while (PeekMessageW(&msg, NULL, 0, 0, PM_REMOVE))
+        while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
         {
             if (msg.message == WM_QUIT)
                 running = 0;
             TranslateMessage(&msg);
-            DispatchMessageW(&msg);
+            DispatchMessage(&msg);
         }
         nk_input_end(ctx);
 
@@ -293,7 +293,7 @@ int main(void)
         hr = IDXGISwapChain_Present(swap_chain, 1, 0);
         if (hr == DXGI_ERROR_DEVICE_RESET || hr == DXGI_ERROR_DEVICE_REMOVED) {
             /* to recover from this, you'll need to recreate device and all the resources */
-            MessageBoxW(NULL, L"D3D11 device is lost or removed!", L"Error", 0);
+            MessageBox(NULL, TEXT("D3D11 device is lost or removed!"), TEXT("Error"), 0);
             break;
         } else if (hr == DXGI_STATUS_OCCLUDED) {
             /* window is not visible, so vsync won't work. Let's sleep a bit to reduce CPU usage */
@@ -308,6 +308,6 @@ int main(void)
     ID3D11DeviceContext_Release(context);
     ID3D11Device_Release(device);
     IDXGISwapChain_Release(swap_chain);
-    UnregisterClassW(wc.lpszClassName, wc.hInstance);
+    UnregisterClass(wc.lpszClassName, wc.hInstance);
     return 0;
 }

--- a/demo/d3d12/main.c
+++ b/demo/d3d12/main.c
@@ -187,7 +187,7 @@ WindowProc(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
     if (nk_d3d12_handle_event(wnd, msg, wparam, lparam))
         return 0;
 
-    return DefWindowProcW(wnd, msg, wparam, lparam);
+    return DefWindowProc(wnd, msg, wparam, lparam);
 }
 
 int main(void)
@@ -195,7 +195,7 @@ int main(void)
     struct nk_context *ctx;
     struct nk_colorf bg;
 
-    WNDCLASSW wc;
+    WNDCLASS wc;
     RECT rect = { 0, 0, WINDOW_WIDTH, WINDOW_HEIGHT };
     DWORD style = WS_OVERLAPPEDWINDOW;
     DWORD exstyle = WS_EX_APPWINDOW;
@@ -211,15 +211,15 @@ int main(void)
     memset(&wc, 0, sizeof(wc));
     wc.style = CS_DBLCLKS;
     wc.lpfnWndProc = WindowProc;
-    wc.hInstance = GetModuleHandleW(0);
+    wc.hInstance = GetModuleHandle(0);
     wc.hIcon = LoadIcon(NULL, IDI_APPLICATION);
     wc.hCursor = LoadCursor(NULL, IDC_ARROW);
-    wc.lpszClassName = L"NuklearWindowClass";
-    RegisterClassW(&wc);
+    wc.lpszClassName = TEXT("NuklearWindowClass");
+    RegisterClass(&wc);
 
     AdjustWindowRectEx(&rect, style, FALSE, exstyle);
 
-    wnd = CreateWindowExW(exstyle, wc.lpszClassName, L"Nuklear Direct3D 12 Demo",
+    wnd = CreateWindowEx(exstyle, wc.lpszClassName, TEXT("Nuklear Direct3D 12 Demo"),
         style | WS_VISIBLE, CW_USEDEFAULT, CW_USEDEFAULT,
         rect.right - rect.left, rect.bottom - rect.top,
         NULL, NULL, wc.hInstance, NULL);
@@ -320,12 +320,12 @@ int main(void)
         /* Input */
         MSG msg;
         nk_input_begin(ctx);
-        while (PeekMessageW(&msg, NULL, 0, 0, PM_REMOVE))
+        while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
         {
             if (msg.message == WM_QUIT)
                 running = 0;
             TranslateMessage(&msg);
-            DispatchMessageW(&msg);
+            DispatchMessage(&msg);
         }
         nk_input_end(ctx);
 
@@ -412,7 +412,7 @@ int main(void)
         rtv_index = (rtv_index + 1) % 2;
         if (hr == DXGI_ERROR_DEVICE_RESET || hr == DXGI_ERROR_DEVICE_REMOVED) {
             /* to recover from this, you'll need to recreate device and all the resources */
-            MessageBoxW(NULL, L"D3D12 device is lost or removed!", L"Error", 0);
+            MessageBox(NULL, TEXT("D3D12 device is lost or removed!"), TEXT("Error"), 0);
             break;
         } else if (hr == DXGI_STATUS_OCCLUDED) {
             /* window is not visible, so vsync won't work. Let's sleep a bit to reduce CPU usage */
@@ -439,7 +439,7 @@ int main(void)
     ID3D12Device_Release(device);
 
     /* win32 shutdown */
-    UnregisterClassW(wc.lpszClassName, wc.hInstance);
+    UnregisterClass(wc.lpszClassName, wc.hInstance);
 
     return 0;
 }

--- a/demo/d3d9/main.c
+++ b/demo/d3d9/main.c
@@ -102,7 +102,7 @@ WindowProc(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
     if (nk_d3d9_handle_event(wnd, msg, wparam, lparam))
         return 0;
 
-    return DefWindowProcW(wnd, msg, wparam, lparam);
+    return DefWindowProc(wnd, msg, wparam, lparam);
 }
 
 static void create_d3d9_device(HWND wnd)
@@ -172,7 +172,7 @@ int main(void)
     struct nk_context *ctx;
     struct nk_colorf bg;
 
-    WNDCLASSW wc;
+    WNDCLASS wc;
     RECT rect = { 0, 0, WINDOW_WIDTH, WINDOW_HEIGHT };
     DWORD style = WS_OVERLAPPEDWINDOW;
     DWORD exstyle = WS_EX_APPWINDOW;
@@ -183,15 +183,15 @@ int main(void)
     memset(&wc, 0, sizeof(wc));
     wc.style = CS_DBLCLKS;
     wc.lpfnWndProc = WindowProc;
-    wc.hInstance = GetModuleHandleW(0);
+    wc.hInstance = GetModuleHandle(0);
     wc.hIcon = LoadIcon(NULL, IDI_APPLICATION);
     wc.hCursor = LoadCursor(NULL, IDC_ARROW);
-    wc.lpszClassName = L"NuklearWindowClass";
-    RegisterClassW(&wc);
+    wc.lpszClassName = TEXT("NuklearWindowClass");
+    RegisterClass(&wc);
 
     AdjustWindowRectEx(&rect, style, FALSE, exstyle);
 
-    wnd = CreateWindowExW(exstyle, wc.lpszClassName, L"Nuklear Direct3D 9 Demo",
+    wnd = CreateWindowEx(exstyle, wc.lpszClassName, TEXT("Nuklear Direct3D 9 Demo"),
         style | WS_VISIBLE, CW_USEDEFAULT, CW_USEDEFAULT,
         rect.right - rect.left, rect.bottom - rect.top,
         NULL, NULL, wc.hInstance, NULL);
@@ -234,11 +234,11 @@ int main(void)
         /* Input */
         MSG msg;
         nk_input_begin(ctx);
-        while (PeekMessageW(&msg, NULL, 0, 0, PM_REMOVE)) {
+        while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
             if (msg.message == WM_QUIT)
                 running = 0;
             TranslateMessage(&msg);
-            DispatchMessageW(&msg);
+            DispatchMessage(&msg);
         }
         nk_input_end(ctx);
 
@@ -311,7 +311,7 @@ int main(void)
             }
             if (hr == D3DERR_DEVICELOST || hr == D3DERR_DEVICEHUNG || hr == D3DERR_DEVICEREMOVED) {
                 /* to recover from this, you'll need to recreate device and all the resources */
-                MessageBoxW(NULL, L"D3D9 device is lost or removed!", L"Error", 0);
+                MessageBox(NULL, TEXT("D3D9 device is lost or removed!"), TEXT("Error"), 0);
                 break;
             } else if (hr == S_PRESENT_OCCLUDED) {
                 /* window is not visible, so vsync won't work. Let's sleep a bit to reduce CPU usage */
@@ -323,6 +323,6 @@ int main(void)
     nk_d3d9_shutdown();
     if (deviceEx)IDirect3DDevice9Ex_Release(deviceEx);
     else IDirect3DDevice9_Release(device);
-    UnregisterClassW(wc.lpszClassName, wc.hInstance);
+    UnregisterClass(wc.lpszClassName, wc.hInstance);
     return 0;
 }

--- a/demo/gdi/main.c
+++ b/demo/gdi/main.c
@@ -74,7 +74,7 @@ WindowProc(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
     if (nk_gdi_handle_event(wnd, msg, wparam, lparam))
         return 0;
 
-    return DefWindowProcW(wnd, msg, wparam, lparam);
+    return DefWindowProc(wnd, msg, wparam, lparam);
 }
 
 int main(void)
@@ -82,7 +82,7 @@ int main(void)
     GdiFont* font;
     struct nk_context *ctx;
 
-    WNDCLASSW wc;
+    WNDCLASS wc;
     ATOM atom;
     RECT rect = { 0, 0, WINDOW_WIDTH, WINDOW_HEIGHT };
     DWORD style = WS_OVERLAPPEDWINDOW;
@@ -96,14 +96,14 @@ int main(void)
     memset(&wc, 0, sizeof(wc));
     wc.style = CS_DBLCLKS;
     wc.lpfnWndProc = WindowProc;
-    wc.hInstance = GetModuleHandleW(0);
+    wc.hInstance = GetModuleHandle(0);
     wc.hIcon = LoadIcon(NULL, IDI_APPLICATION);
     wc.hCursor = LoadCursor(NULL, IDC_ARROW);
-    wc.lpszClassName = L"NuklearWindowClass";
-    atom = RegisterClassW(&wc);
+    wc.lpszClassName = TEXT("NuklearWindowClass");
+    atom = RegisterClass(&wc);
 
     AdjustWindowRectEx(&rect, style, FALSE, exstyle);
-    wnd = CreateWindowExW(exstyle, wc.lpszClassName, L"Nuklear GDI Demo",
+    wnd = CreateWindowEx(exstyle, wc.lpszClassName, TEXT("Nuklear GDI Demo"),
         style | WS_VISIBLE, CW_USEDEFAULT, CW_USEDEFAULT,
         rect.right - rect.left, rect.bottom - rect.top,
         NULL, NULL, wc.hInstance, NULL);
@@ -133,20 +133,20 @@ int main(void)
         MSG msg;
         nk_input_begin(ctx);
         if (needs_refresh == 0) {
-            if (GetMessageW(&msg, NULL, 0, 0) <= 0)
+            if (GetMessage(&msg, NULL, 0, 0) <= 0)
                 running = 0;
             else {
                 TranslateMessage(&msg);
-                DispatchMessageW(&msg);
+                DispatchMessage(&msg);
             }
             needs_refresh = 1;
         } else needs_refresh = 0;
 
-        while (PeekMessageW(&msg, NULL, 0, 0, PM_REMOVE)) {
+        while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
             if (msg.message == WM_QUIT)
                 running = 0;
             TranslateMessage(&msg);
-            DispatchMessageW(&msg);
+            DispatchMessage(&msg);
             needs_refresh = 1;
         }
         nk_input_end(ctx);
@@ -192,7 +192,7 @@ int main(void)
 
     nk_gdifont_del(font);
     ReleaseDC(wnd, dc);
-    UnregisterClassW(wc.lpszClassName, wc.hInstance);
+    UnregisterClass(wc.lpszClassName, wc.hInstance);
     return 0;
 }
 

--- a/demo/gdi/nuklear_gdi.h
+++ b/demo/gdi/nuklear_gdi.h
@@ -196,7 +196,7 @@ nk_gdi_fill_rect(HDC dc, short x, short y, unsigned short w,
         RECT rect;
         SetRect(&rect, x, y, x + w, y + h);
         SetBkColor(dc, color);
-        ExtTextOutW(dc, 0, 0, ETO_OPAQUE, &rect, NULL, 0, NULL);
+        ExtTextOut(dc, 0, 0, ETO_OPAQUE, &rect, NULL, 0, NULL);
     } else {
         HPEN pen = NULL, old_pen = NULL;
         HBRUSH brush = NULL, old_brush = NULL;
@@ -551,7 +551,7 @@ nk_gdi_clear(HDC dc, struct nk_color col)
     SetRect(&rect, 0, 0, gdi.width, gdi.height);
     SetBkColor(dc, color);
 
-    ExtTextOutW(dc, 0, 0, ETO_OPAQUE, &rect, NULL, 0, NULL);
+    ExtTextOut(dc, 0, 0, ETO_OPAQUE, &rect, NULL, 0, NULL);
 }
 
 static void
@@ -564,14 +564,14 @@ nk_gdi_blit(HDC dc)
 GdiFont*
 nk_gdifont_create(const char *name, int size)
 {
-    TEXTMETRICW metric;
+    TEXTMETRIC metric;
     GdiFont *font = (GdiFont*)calloc(1, sizeof(GdiFont));
     if (!font)
         return NULL;
     font->dc = CreateCompatibleDC(0);
     font->handle = CreateFontA(size, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY, DEFAULT_PITCH | FF_DONTCARE, name);
     SelectObject(font->dc, font->handle);
-    GetTextMetricsW(font->dc, &metric);
+    GetTextMetrics(font->dc, &metric);
     font->height = metric.tmHeight;
     return font;
 }

--- a/demo/gdi/nuklear_gdi.h
+++ b/demo/gdi/nuklear_gdi.h
@@ -264,7 +264,7 @@ nk_gdi_rect_multi_color(HDC dc, short x, short y, unsigned short w,
     gTri[1].Vertex1 = 2;
     gTri[1].Vertex2 = 1;
     gTri[1].Vertex3 = 3;
-    GdiGradientFill(dc, vt, 4, gTri, 2 , GRADIENT_FILL_TRIANGLE);
+    GradientFill(dc, vt, 4, gTri, 2 , GRADIENT_FILL_TRIANGLE);
     AlphaBlend(gdi.window_dc,  x, y, x+w, y+h,gdi.memory_dc, x, y, x+w, y+h,alphaFunction);
 
 }

--- a/demo/gdi/nuklear_gdi.h
+++ b/demo/gdi/nuklear_gdi.h
@@ -532,15 +532,21 @@ nk_gdi_draw_text(HDC dc, short x, short y, unsigned short w, unsigned short h,
 
     if(!text || !font || !len) return;
 
-    wsize = MultiByteToWideChar(CP_UTF8, 0, text, len, NULL, 0);
-    wstr = (WCHAR*)_alloca(wsize * sizeof(wchar_t));
-    MultiByteToWideChar(CP_UTF8, 0, text, len, wstr, wsize);
-
     SetBkColor(dc, convert_color(cbg));
     SetTextColor(dc, convert_color(cfg));
 
     SelectObject(dc, font->handle);
-    ExtTextOutW(dc, x, y, ETO_OPAQUE, NULL, wstr, wsize, NULL);
+
+    wsize = MultiByteToWideChar(CP_UTF8, 0, text, len, NULL, 0);
+    if (wsize) {
+        wstr = (WCHAR*)_alloca(wsize * sizeof(wchar_t));
+        MultiByteToWideChar(CP_UTF8, 0, text, len, wstr, wsize);
+
+        ExtTextOutW(dc, x, y, ETO_OPAQUE, NULL, wstr, wsize, NULL);
+    } else {
+        /* TODO: Convert from UTF-8 to the active code page */
+        ExtTextOutA(dc, x, y, ETO_OPAQUE, NULL, text, len, NULL);
+    }
 }
 
 static void
@@ -587,10 +593,17 @@ nk_gdifont_get_text_width(nk_handle handle, float height, const char *text, int 
         return 0;
 
     wsize = MultiByteToWideChar(CP_UTF8, 0, text, len, NULL, 0);
-    wstr = (WCHAR*)_alloca(wsize * sizeof(wchar_t));
-    MultiByteToWideChar(CP_UTF8, 0, text, len, wstr, wsize);
-    if (GetTextExtentPoint32W(font->dc, wstr, wsize, &size))
-        return (float)size.cx;
+    if (wsize) {
+        wstr = (WCHAR*)_alloca(wsize * sizeof(wchar_t));
+        MultiByteToWideChar(CP_UTF8, 0, text, len, wstr, wsize);
+        if (GetTextExtentPoint32W(font->dc, wstr, wsize, &size))
+            return (float)size.cx;
+    } else {
+        /* TODO: Convert from UTF-8 to the active code page */
+        if (GetTextExtentPoint32A(font->dc, text, len, &size))
+            return (float)size.cx;
+    }
+
     return -1.0f;
 }
 

--- a/demo/gdi_native_nuklear/main.c
+++ b/demo/gdi_native_nuklear/main.c
@@ -84,10 +84,10 @@ int drawCallback(struct nk_context* ctx)
     return 1;
 }
 
-/* Main entry point - wWinMain used for UNICODE
- * (You can also use _tWinMain(...) to automaticaly use the ASCII or WIDE char entry point base on your build)  
+/* Main entry point - WinMain used for ANSI
+ * (You can also use _tWinMain(...) to automaticaly use the ANSI or UNICODE char entry point base on your build)
  */
-INT WINAPI wWinMain(HINSTANCE _In_ hInstance, HINSTANCE _In_opt_ hPrevInstance, PWSTR _In_ cmdArgs, INT _In_ cmdShow)
+INT WINAPI WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR cmdArgs, INT cmdShow)
 {
     /* Call this first to setup all required prerequisites */
     nkgdi_window_init();

--- a/demo/gdi_native_nuklear/nuklear_gdi.h
+++ b/demo/gdi_native_nuklear/nuklear_gdi.h
@@ -208,7 +208,7 @@ nk_gdi_fill_rect(HDC dc, short x, short y, unsigned short w,
         RECT rect;
         SetRect(&rect, x, y, x + w, y + h);
         SetBkColor(dc, color);
-        ExtTextOutW(dc, 0, 0, ETO_OPAQUE, &rect, NULL, 0, NULL);
+        ExtTextOut(dc, 0, 0, ETO_OPAQUE, &rect, NULL, 0, NULL);
     } else {
         HPEN pen = NULL, old_pen = NULL;
         HBRUSH brush = NULL, old_brush = NULL;
@@ -504,7 +504,7 @@ nk_gdi_clear(nk_gdi_ctx gdi, HDC dc, struct nk_color col)
     SetRect(&rect, 0, 0, gdi->width, gdi->height);
     SetBkColor(dc, color);
 
-    ExtTextOutW(dc, 0, 0, ETO_OPAQUE, &rect, NULL, 0, NULL);
+    ExtTextOut(dc, 0, 0, ETO_OPAQUE, &rect, NULL, 0, NULL);
 }
 
 static void
@@ -517,14 +517,14 @@ nk_gdi_blit(nk_gdi_ctx gdi, HDC dc)
 GdiFont*
 nk_gdifont_create(const char* name, int size)
 {
-    TEXTMETRICW metric;
+    TEXTMETRIC metric;
     GdiFont* font = (GdiFont*)calloc(1, sizeof(GdiFont));
     if (!font)
         return NULL;
     font->dc = CreateCompatibleDC(0);
     font->handle = CreateFontA(size, 0, 0, 0, FW_NORMAL, FALSE, FALSE, FALSE, DEFAULT_CHARSET, OUT_DEFAULT_PRECIS, CLIP_DEFAULT_PRECIS, CLEARTYPE_QUALITY, DEFAULT_PITCH | FF_DONTCARE, name);
     SelectObject(font->dc, font->handle);
-    GetTextMetricsW(font->dc, &metric);
+    GetTextMetrics(font->dc, &metric);
     font->height = metric.tmHeight;
     return font;
 }

--- a/demo/gdi_native_nuklear/nuklear_gdi.h
+++ b/demo/gdi_native_nuklear/nuklear_gdi.h
@@ -276,7 +276,7 @@ nk_gdi_rect_multi_color(nk_gdi_ctx gdi, HDC dc, short x, short y, unsigned short
     gTri[1].Vertex1 = 2;
     gTri[1].Vertex2 = 1;
     gTri[1].Vertex3 = 3;
-    GdiGradientFill(dc, vt, 4, gTri, 2, GRADIENT_FILL_TRIANGLE);
+    GradientFill(dc, vt, 4, gTri, 2, GRADIENT_FILL_TRIANGLE);
     AlphaBlend(gdi->window_dc, x, y, x + w, y + h, gdi->memory_dc, x, y, x + w, y + h, alphaFunction);
 
 }

--- a/demo/gdi_native_nuklear/nuklear_gdi.h
+++ b/demo/gdi_native_nuklear/nuklear_gdi.h
@@ -163,23 +163,16 @@ nk_gdi_stroke_line(HDC dc, short x0, short y0, short x1,
     short y1, unsigned int line_thickness, struct nk_color col)
 {
     COLORREF color = convert_color(col);
+    HPEN pen = NULL, old_pen = NULL;
 
-    HPEN pen = NULL;
-    if (line_thickness == 1) {
-        SetDCPenColor(dc, color);
-    }
-    else {
-        pen = CreatePen(PS_SOLID, line_thickness, color);
-        SelectObject(dc, pen);
-    }
+    pen = CreatePen(PS_SOLID, line_thickness, color);
+    old_pen = SelectObject(dc, pen);
 
     MoveToEx(dc, x0, y0, NULL);
     LineTo(dc, x1, y1);
 
-    if (pen) {
-        SelectObject(dc, GetStockObject(DC_PEN));
-        DeleteObject(pen);
-    }
+    SelectObject(dc, old_pen);
+    DeleteObject(pen);
 }
 
 static void
@@ -188,29 +181,21 @@ nk_gdi_stroke_rect(HDC dc, short x, short y, unsigned short w,
 {
     COLORREF color = convert_color(col);
     HGDIOBJ br;
-    HPEN pen = NULL;
+    HPEN pen = NULL, old_pen = NULL;
 
-    if (line_thickness == 1) {
-        SetDCPenColor(dc, color);
-    }
-    else {
-        pen = CreatePen(PS_SOLID, line_thickness, color);
-        SelectObject(dc, pen);
-    }
+    pen = CreatePen(PS_SOLID, line_thickness, color);
+    old_pen = SelectObject(dc, pen);
 
     br = SelectObject(dc, GetStockObject(NULL_BRUSH));
     if (r == 0) {
         Rectangle(dc, x, y, x + w, y + h);
-    }
-    else {
+    } else {
         RoundRect(dc, x, y, x + w, y + h, r, r);
     }
     SelectObject(dc, br);
 
-    if (pen) {
-        SelectObject(dc, GetStockObject(DC_PEN));
-        DeleteObject(pen);
-    }
+    SelectObject(dc, old_pen);
+    DeleteObject(pen);
 }
 
 static void
@@ -224,11 +209,23 @@ nk_gdi_fill_rect(HDC dc, short x, short y, unsigned short w,
         SetRect(&rect, x, y, x + w, y + h);
         SetBkColor(dc, color);
         ExtTextOutW(dc, 0, 0, ETO_OPAQUE, &rect, NULL, 0, NULL);
-    }
-    else {
-        SetDCPenColor(dc, color);
-        SetDCBrushColor(dc, color);
+    } else {
+        HPEN pen = NULL, old_pen = NULL;
+        HBRUSH brush = NULL, old_brush = NULL;
+
+        brush = CreateSolidBrush(color);
+        old_brush = SelectObject(dc, brush);
+
+        pen = CreatePen(PS_SOLID, 1, color);
+        old_pen = SelectObject(dc, pen);
+
         RoundRect(dc, x, y, x + w, y + h, r, r);
+
+        SelectObject(dc, old_pen);
+        DeleteObject(pen);
+
+        SelectObject(dc, old_brush);
+        DeleteObject(brush);
     }
 }
 static void
@@ -300,14 +297,26 @@ nk_gdi_fill_triangle(HDC dc, short x0, short y0, short x1,
 {
     COLORREF color = convert_color(col);
     POINT points[3];
+    HPEN pen = NULL, old_pen = NULL;
+    HBRUSH brush = NULL, old_brush = NULL;
 
     SetPoint(&points[0], x0, y0);
     SetPoint(&points[1], x1, y1);
     SetPoint(&points[2], x2, y2);
 
-    SetDCPenColor(dc, color);
-    SetDCBrushColor(dc, color);
+    brush = CreateSolidBrush(color);
+    old_brush = SelectObject(dc, brush);
+
+    pen = CreatePen(PS_SOLID, 1, color);
+    old_pen = SelectObject(dc, pen);
+
     Polygon(dc, points, 3);
+
+    SelectObject(dc, old_pen);
+    DeleteObject(pen);
+
+    SelectObject(dc, old_brush);
+    DeleteObject(brush);
 }
 
 static void
@@ -316,44 +325,50 @@ nk_gdi_stroke_triangle(HDC dc, short x0, short y0, short x1,
 {
     COLORREF color = convert_color(col);
     POINT points[4];
-    HPEN pen = NULL;
+    HPEN pen = NULL, old_pen = NULL;
 
     SetPoint(&points[0], x0, y0);
     SetPoint(&points[1], x1, y1);
     SetPoint(&points[2], x2, y2);
     SetPoint(&points[3], x0, y0);
 
-    if (line_thickness == 1) {
-        SetDCPenColor(dc, color);
-    }
-    else {
-        pen = CreatePen(PS_SOLID, line_thickness, color);
-        SelectObject(dc, pen);
-    }
+    pen = CreatePen(PS_SOLID, line_thickness, color);
+    old_pen = SelectObject(dc, pen);
 
     Polyline(dc, points, 4);
 
-    if (pen) {
-        SelectObject(dc, GetStockObject(DC_PEN));
-        DeleteObject(pen);
-    }
+    SelectObject(dc, old_pen);
+    DeleteObject(pen);
 }
 
 static void
 nk_gdi_fill_polygon(HDC dc, const struct nk_vec2i* pnts, int count, struct nk_color col)
 {
     int i = 0;
-#define MAX_POINTS 64
+    #define MAX_POINTS 64
     POINT points[MAX_POINTS];
     COLORREF color = convert_color(col);
-    SetDCBrushColor(dc, color);
-    SetDCPenColor(dc, color);
+    HPEN pen = NULL, old_pen = NULL;
+    HBRUSH brush = NULL, old_brush = NULL;
+
+    brush = CreateSolidBrush(color);
+    old_brush = SelectObject(dc, brush);
+
+    pen = CreatePen(PS_SOLID, 1, color);
+    old_pen = SelectObject(dc, pen);
+
     for (i = 0; i < count && i < MAX_POINTS; ++i) {
         points[i].x = pnts[i].x;
         points[i].y = pnts[i].y;
     }
     Polygon(dc, points, i);
-#undef MAX_POINTS
+
+    SelectObject(dc, old_pen);
+    DeleteObject(pen);
+
+    SelectObject(dc, old_brush);
+    DeleteObject(brush);
+    #undef MAX_POINTS
 }
 
 static void
@@ -361,14 +376,10 @@ nk_gdi_stroke_polygon(HDC dc, const struct nk_vec2i* pnts, int count,
     unsigned short line_thickness, struct nk_color col)
 {
     COLORREF color = convert_color(col);
-    HPEN pen = NULL;
-    if (line_thickness == 1) {
-        SetDCPenColor(dc, color);
-    }
-    else {
-        pen = CreatePen(PS_SOLID, line_thickness, color);
-        SelectObject(dc, pen);
-    }
+    HPEN pen = NULL, old_pen = NULL;
+
+    pen = CreatePen(PS_SOLID, line_thickness, color);
+    old_pen = SelectObject(dc, pen);
 
     if (count > 0) {
         int i;
@@ -378,10 +389,8 @@ nk_gdi_stroke_polygon(HDC dc, const struct nk_vec2i* pnts, int count,
         LineTo(dc, pnts[0].x, pnts[0].y);
     }
 
-    if (pen) {
-        SelectObject(dc, GetStockObject(DC_PEN));
-        DeleteObject(pen);
-    }
+    SelectObject(dc, old_pen);
+    DeleteObject(pen);
 }
 
 static void
@@ -389,14 +398,10 @@ nk_gdi_stroke_polyline(HDC dc, const struct nk_vec2i* pnts,
     int count, unsigned short line_thickness, struct nk_color col)
 {
     COLORREF color = convert_color(col);
-    HPEN pen = NULL;
-    if (line_thickness == 1) {
-        SetDCPenColor(dc, color);
-    }
-    else {
-        pen = CreatePen(PS_SOLID, line_thickness, color);
-        SelectObject(dc, pen);
-    }
+    HPEN pen = NULL, old_pen = NULL;
+
+    pen = CreatePen(PS_SOLID, line_thickness, color);
+    old_pen = SelectObject(dc, pen);
 
     if (count > 0) {
         int i;
@@ -405,10 +410,8 @@ nk_gdi_stroke_polyline(HDC dc, const struct nk_vec2i* pnts,
             LineTo(dc, pnts[i].x, pnts[i].y);
     }
 
-    if (pen) {
-        SelectObject(dc, GetStockObject(DC_PEN));
-        DeleteObject(pen);
-    }
+    SelectObject(dc, old_pen);
+    DeleteObject(pen);
 }
 
 static void
@@ -416,9 +419,22 @@ nk_gdi_fill_circle(HDC dc, short x, short y, unsigned short w,
     unsigned short h, struct nk_color col)
 {
     COLORREF color = convert_color(col);
-    SetDCBrushColor(dc, color);
-    SetDCPenColor(dc, color);
+    HPEN pen = NULL, old_pen = NULL;
+    HBRUSH brush = NULL, old_brush = NULL;
+
+    brush = CreateSolidBrush(color);
+    old_brush = SelectObject(dc, brush);
+
+    pen = CreatePen(PS_SOLID, 1, color);
+    old_pen = SelectObject(dc, pen);
+
     Ellipse(dc, x, y, x + w, y + h);
+
+    SelectObject(dc, old_pen);
+    DeleteObject(pen);
+
+    SelectObject(dc, old_brush);
+    DeleteObject(brush);
 }
 
 static void
@@ -426,22 +442,15 @@ nk_gdi_stroke_circle(HDC dc, short x, short y, unsigned short w,
     unsigned short h, unsigned short line_thickness, struct nk_color col)
 {
     COLORREF color = convert_color(col);
-    HPEN pen = NULL;
-    if (line_thickness == 1) {
-        SetDCPenColor(dc, color);
-    }
-    else {
-        pen = CreatePen(PS_SOLID, line_thickness, color);
-        SelectObject(dc, pen);
-    }
+    HPEN pen = NULL, old_pen = NULL;
 
-    SetDCBrushColor(dc, OPAQUE);
+    pen = CreatePen(PS_SOLID, line_thickness, color);
+    old_pen = SelectObject(dc, pen);
+
     Ellipse(dc, x, y, x + w, y + h);
 
-    if (pen) {
-        SelectObject(dc, GetStockObject(DC_PEN));
-        DeleteObject(pen);
-    }
+    SelectObject(dc, old_pen);
+    DeleteObject(pen);
 }
 
 static void
@@ -451,28 +460,20 @@ nk_gdi_stroke_curve(HDC dc, struct nk_vec2i p1,
 {
     COLORREF color = convert_color(col);
     POINT p[4];
-    HPEN pen = NULL;
+    HPEN pen = NULL, old_pen = NULL;
 
     SetPoint(&p[0], p1.x, p1.y);
     SetPoint(&p[1], p2.x, p2.y);
     SetPoint(&p[2], p3.x, p3.y);
     SetPoint(&p[3], p4.x, p4.y);
 
-    if (line_thickness == 1) {
-        SetDCPenColor(dc, color);
-    }
-    else {
-        pen = CreatePen(PS_SOLID, line_thickness, color);
-        SelectObject(dc, pen);
-    }
+    pen = CreatePen(PS_SOLID, line_thickness, color);
+    old_pen = SelectObject(dc, pen);
 
-    SetDCBrushColor(dc, OPAQUE);
     PolyBezier(dc, p, 4);
 
-    if (pen) {
-        SelectObject(dc, GetStockObject(DC_PEN));
-        DeleteObject(pen);
-    }
+    SelectObject(dc, old_pen);
+    DeleteObject(pen);
 }
 
 static void
@@ -848,8 +849,6 @@ nk_gdi_render(nk_gdi_ctx gdi, struct nk_color clear)
     const struct nk_command* cmd;
 
     HDC memory_dc = gdi->memory_dc;
-    SelectObject(memory_dc, GetStockObject(DC_PEN));
-    SelectObject(memory_dc, GetStockObject(DC_BRUSH));
     nk_gdi_clear(gdi, memory_dc, clear);
 
     nk_foreach(cmd, &gdi->ctx)

--- a/demo/gdi_native_nuklear/window.h
+++ b/demo/gdi_native_nuklear/window.h
@@ -1,7 +1,7 @@
 #ifndef NK_GDI_WINDOW
 #define NK_GDI_WINDOW
 
-#define NK_GDI_WINDOW_CLS L"WNDCLS_NkGdi"
+#define NK_GDI_WINDOW_CLS TEXT("WNDCLS_NkGdi")
 
 #include <windows.h>
 
@@ -77,7 +77,7 @@ LRESULT CALLBACK nkgdi_window_proc_run(HWND wnd, UINT msg, WPARAM wParam, LPARAM
 void nkgdi_window_init(void)
 {
     /* Describe the window class */
-    WNDCLASSEXW cls;
+    WNDCLASSEX cls;
     cls.cbSize = sizeof(WNDCLASSEXW);
     cls.style = CS_OWNDC | CS_DBLCLKS;
     cls.lpfnWndProc = &nkgdi_window_proc_setup;
@@ -92,13 +92,13 @@ void nkgdi_window_init(void)
     cls.hIconSm = NULL;
 
     /* Register the window class */
-    RegisterClassExW(&cls);
+    RegisterClassEx(&cls);
 }
 
 void nkgdi_window_shutdown(void)
 {
     /* Windows class no longer required, unregister it */
-    UnregisterClassW(NK_GDI_WINDOW_CLS, GetModuleHandle(NULL));
+    UnregisterClass(NK_GDI_WINDOW_CLS, GetModuleHandle(NULL));
 }
 
 void nkgdi_window_create(struct nkgdi_window* wnd, unsigned int width, unsigned int height, const char* name, int posX, int posY)
@@ -115,15 +115,15 @@ void nkgdi_window_create(struct nkgdi_window* wnd, unsigned int width, unsigned 
     AdjustWindowRectEx(&cr, style, FALSE, styleEx);
 
     /* Create the new window */
-    wnd->_internal.window_handle = CreateWindowExW(
+    wnd->_internal.window_handle = CreateWindowEx(
         styleEx,
         NK_GDI_WINDOW_CLS,
-        L"NkGdi",
+        TEXT("NkGdi"),
         style | WS_VISIBLE,
         posX, posY,
         cr.right - cr.left, cr.bottom - cr.top,
         NULL, NULL,
-        GetModuleHandleW(NULL),
+        GetModuleHandle(NULL),
         wnd
     );
 
@@ -183,7 +183,7 @@ int nkgdi_window_update(struct nkgdi_window* wnd)
         while (PeekMessage(&msg, wnd->_internal.window_handle, 0, 0, PM_REMOVE))
         {
             TranslateMessage(&msg);
-            DispatchMessageW(&msg);
+            DispatchMessage(&msg);
         }
         nk_input_end(wnd->_internal.nk_ctx);
 
@@ -256,7 +256,7 @@ LRESULT CALLBACK nkgdi_window_proc_setup(HWND wnd, UINT msg, WPARAM wParam, LPAR
 LRESULT CALLBACK nkgdi_window_proc_run(HWND wnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
     /* The window context is extracted from the window data */
-    struct nkgdi_window* nkwnd = (struct nkgdi_window*)GetWindowLongPtrW(wnd, GWLP_USERDATA);
+    struct nkgdi_window* nkwnd = (struct nkgdi_window*)GetWindowLongPtr(wnd, GWLP_USERDATA);
 
     /* Switch on the message code to handle all required messages */
     switch (msg)
@@ -289,7 +289,7 @@ LRESULT CALLBACK nkgdi_window_proc_run(HWND wnd, UINT msg, WPARAM wParam, LPARAM
                 HMONITOR monitor = MonitorFromWindow(wnd, MONITOR_DEFAULTTOPRIMARY);
                 MONITORINFO monitorInfo;
                 monitorInfo.cbSize = sizeof(MONITORINFO);
-                if (GetMonitorInfoW(monitor, &monitorInfo))
+                if (GetMonitorInfo(monitor, &monitorInfo))
                 {
                     /* Adjust the window size and position by the monitor working area (without taskbar) */
                     nkwnd->_internal.height = monitorInfo.rcWork.bottom - monitorInfo.rcWork.top;

--- a/demo/gdip/main.c
+++ b/demo/gdip/main.c
@@ -71,7 +71,7 @@ WindowProc(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
     }
     if (nk_gdip_handle_event(wnd, msg, wparam, lparam))
         return 0;
-    return DefWindowProcW(wnd, msg, wparam, lparam);
+    return DefWindowProc(wnd, msg, wparam, lparam);
 }
 
 int main(void)
@@ -79,7 +79,7 @@ int main(void)
     GdipFont* font;
     struct nk_context *ctx;
 
-    WNDCLASSW wc;
+    WNDCLASS wc;
     RECT rect = { 0, 0, WINDOW_WIDTH, WINDOW_HEIGHT };
     DWORD style = WS_OVERLAPPEDWINDOW;
     DWORD exstyle = WS_EX_APPWINDOW;
@@ -91,15 +91,15 @@ int main(void)
     memset(&wc, 0, sizeof(wc));
     wc.style = CS_DBLCLKS;
     wc.lpfnWndProc = WindowProc;
-    wc.hInstance = GetModuleHandleW(0);
+    wc.hInstance = GetModuleHandle(0);
     wc.hIcon = LoadIcon(NULL, IDI_APPLICATION);
     wc.hCursor = LoadCursor(NULL, IDC_ARROW);
-    wc.lpszClassName = L"NuklearWindowClass";
-    RegisterClassW(&wc);
+    wc.lpszClassName = TEXT("NuklearWindowClass");
+    RegisterClass(&wc);
 
     AdjustWindowRectEx(&rect, style, FALSE, exstyle);
 
-    wnd = CreateWindowExW(exstyle, wc.lpszClassName, L"Nuklear GDI+ Demo",
+    wnd = CreateWindowEx(exstyle, wc.lpszClassName, TEXT("Nuklear GDI+ Demo"),
         style | WS_VISIBLE, CW_USEDEFAULT, CW_USEDEFAULT,
         rect.right - rect.left, rect.bottom - rect.top,
         NULL, NULL, wc.hInstance, NULL);
@@ -129,19 +129,19 @@ int main(void)
         MSG msg;
         nk_input_begin(ctx);
         if (needs_refresh == 0) {
-            if (GetMessageW(&msg, NULL, 0, 0) <= 0)
+            if (GetMessage(&msg, NULL, 0, 0) <= 0)
                 running = 0;
             else {
                 TranslateMessage(&msg);
-                DispatchMessageW(&msg);
+                DispatchMessage(&msg);
             }
             needs_refresh = 1;
         } else needs_refresh = 0;
-        while (PeekMessageW(&msg, NULL, 0, 0, PM_REMOVE)) {
+        while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) {
             if (msg.message == WM_QUIT)
                 running = 0;
             TranslateMessage(&msg);
-            DispatchMessageW(&msg);
+            DispatchMessage(&msg);
             needs_refresh = 1;
         }
         nk_input_end(ctx);
@@ -187,6 +187,6 @@ int main(void)
 
     nk_gdipfont_del(font);
     nk_gdip_shutdown();
-    UnregisterClassW(wc.lpszClassName, wc.hInstance);
+    UnregisterClass(wc.lpszClassName, wc.hInstance);
     return 0;
 }


### PR DESCRIPTION
This mostly works, with a few caveats:
- ANSI clipboard support isn't implemented yet.
- Text rendering isn't as good as it could be.
- `nk_gdi_rect_multi_color` requires msimg32.dll which isn't always available. This can be trivially disabled if it's not needed.

Screenshot:
![Nuklear95](https://user-images.githubusercontent.com/19293424/210776900-f631fc98-c68b-4d90-b7da-4f6d5fc18108.png)
