### PR TITLE
[New feature] Add ability to change text color/background color via (optional) inline code; should be backward compatible

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -48,6 +48,7 @@
 /// - No global or hidden state
 /// - Customizable library modules (you can compile and use only what you need)
 /// - Optional font baker and vertex buffer output
+/// - [Code available on github](https://github.com/Immediate-Mode-UI/Nuklear/)
 ///
 /// ## Features
 /// - Absolutely no platform dependent code
@@ -1406,7 +1407,7 @@ NK_API const struct nk_draw_command* nk__draw_next(const struct nk_draw_command*
 /// Function                            | Description
 /// ------------------------------------|----------------------------------------
 /// nk_begin                            | Starts a new window; needs to be called every frame for every window (unless hidden) or otherwise the window gets removed
-/// nk_begin_titled                     | Extended window start with separated title and identifier to allow multiple windows with same name but not title
+/// nk_begin_titled                     | Extended window start with separated title and identifier to allow multiple windows with same title but not name
 /// nk_end                              | Needs to be called at the end of the window building process to process scaling, scrollbars and general cleanup
 //
 /// nk_window_find                      | Finds and returns the window with give name
@@ -4614,6 +4615,7 @@ struct nk_command_buffer {
     int use_clipping;
     nk_handle userdata;
     nk_size begin, end, last;
+    struct nk_draw_config *draw_config;
 };
 
 /* shape outlines */
@@ -4638,6 +4640,7 @@ NK_API void nk_fill_polygon(struct nk_command_buffer*, float*, int point_count, 
 NK_API void nk_draw_image(struct nk_command_buffer*, struct nk_rect, const struct nk_image*, struct nk_color);
 NK_API void nk_draw_nine_slice(struct nk_command_buffer*, struct nk_rect, const struct nk_nine_slice*, struct nk_color);
 NK_API void nk_draw_text(struct nk_command_buffer*, struct nk_rect, const char *text, int len, const struct nk_user_font*, struct nk_color, struct nk_color);
+NK_API int nk_draw_raw_text(struct nk_command_buffer*, struct nk_rect, const char *text, int len, const struct nk_user_font*, struct nk_color, struct nk_color, float *w);
 NK_API void nk_push_scissor(struct nk_command_buffer*, struct nk_rect);
 NK_API void nk_push_custom(struct nk_command_buffer*, struct nk_rect, nk_command_custom_callback, nk_handle usr);
 
@@ -4856,6 +4859,10 @@ NK_API void nk_draw_list_push_userdata(struct nk_draw_list*, nk_handle userdata)
  *                          GUI
  *
  * ===============================================================*/
+#ifndef NK_NAME_COLOR_MAX_NAME
+#define NK_NAME_COLOR_MAX_NAME 32
+#endif
+
 enum nk_style_item_type {
     NK_STYLE_ITEM_COLOR,
     NK_STYLE_ITEM_IMAGE,
@@ -5291,10 +5298,44 @@ struct nk_style {
     struct nk_style_window window;
 };
 
+struct nk_name_color {
+    nk_hash name;
+    char name_string[NK_NAME_COLOR_MAX_NAME];
+    struct nk_color color;
+};
+
+struct nk_map_name_color {
+    struct nk_buffer buffer;
+    int count;
+};
+
+enum nk_color_inline_type {
+    NK_COLOR_INLINE_NONE,
+    NK_COLOR_INLINE_TAG,
+    NK_COLOR_INLINE_ESCAPE_TAG,
+    NK_COLOR_INLINE_MAX
+};
+
 NK_API struct nk_style_item nk_style_item_color(struct nk_color);
 NK_API struct nk_style_item nk_style_item_image(struct nk_image img);
 NK_API struct nk_style_item nk_style_item_nine_slice(struct nk_nine_slice slice);
 NK_API struct nk_style_item nk_style_item_hide(void);
+
+NK_API void nk_name_color_init(struct nk_name_color *, const char *, struct nk_color);
+
+#ifdef NK_INCLUDE_DEFAULT_ALLOCATOR
+NK_API void nk_map_name_color_init_default(struct nk_map_name_color *);
+#endif
+NK_API void nk_map_name_color_init(struct nk_map_name_color *, const struct nk_allocator *, const struct nk_name_color *, int count);
+NK_API void nk_map_name_color_init_colors(struct nk_map_name_color *, const struct nk_allocator *, const char **, struct nk_color *, int count);
+NK_API void nk_map_name_color_init_map_name_color(struct nk_map_name_color *, const struct nk_allocator *, const struct nk_map_name_color *, const char **filter_out, int count);
+NK_API void nk_map_name_color_init_fixed(struct nk_map_name_color *, struct nk_name_color *, int count, int capacity);
+NK_API void nk_map_name_color_free(struct nk_map_name_color *);
+NK_API void nk_map_name_color_push(struct nk_map_name_color *, const struct nk_name_color *, int count);
+NK_API void nk_map_name_color_push_colors(struct nk_map_name_color *, const char **, struct nk_color *, int count);
+NK_API void nk_map_name_color_push_map_name_color(struct nk_map_name_color *, const struct nk_map_name_color *);
+NK_API void nk_map_name_color_delete(struct nk_map_name_color *, const char **, int count);
+NK_API void nk_map_name_color_clear(struct nk_map_name_color *);
 
 /*==============================================================
  *                          PANEL
@@ -5511,9 +5552,10 @@ struct nk_window {
  *      nk_style_pop_vec2(ctx);
  *
  * Nuklear has a stack for style_items, float properties, vector properties,
- * flags, colors, fonts and for button_behavior. Each has it's own fixed size stack
+ * flags, colors, fonts, button_behavior, color_inline, and map_name_color. Each has it's own fixed size stack
  * which can be changed at compile time.
  */
+
 #ifndef NK_BUTTON_BEHAVIOR_STACK_SIZE
 #define NK_BUTTON_BEHAVIOR_STACK_SIZE 8
 #endif
@@ -5542,6 +5584,10 @@ struct nk_window {
 #define NK_COLOR_STACK_SIZE 32
 #endif
 
+#ifndef NK_COLOR_INLINE_STACK_SIZE
+#define NK_COLOR_INLINE_STACK_SIZE 8
+#endif
+
 #define NK_CONFIGURATION_STACK_TYPE(prefix, name, type)\
     struct nk_config_stack_##name##_element {\
         prefix##_##type *address;\
@@ -5561,6 +5607,9 @@ NK_CONFIGURATION_STACK_TYPE(nk ,flags, flags);
 NK_CONFIGURATION_STACK_TYPE(struct nk, color, color);
 NK_CONFIGURATION_STACK_TYPE(const struct nk, user_font, user_font*);
 NK_CONFIGURATION_STACK_TYPE(enum nk, button_behavior, button_behavior);
+struct nk_config_stack_color_inline_element {
+    enum nk_color_inline_type old_value;
+};
 
 NK_CONFIG_STACK(style_item, NK_STYLE_ITEM_STACK_SIZE);
 NK_CONFIG_STACK(float, NK_FLOAT_STACK_SIZE);
@@ -5569,6 +5618,7 @@ NK_CONFIG_STACK(flags, NK_FLAGS_STACK_SIZE);
 NK_CONFIG_STACK(color, NK_COLOR_STACK_SIZE);
 NK_CONFIG_STACK(user_font, NK_FONT_STACK_SIZE);
 NK_CONFIG_STACK(button_behavior, NK_BUTTON_BEHAVIOR_STACK_SIZE);
+NK_CONFIG_STACK(color_inline, NK_COLOR_INLINE_STACK_SIZE);
 
 struct nk_configuration_stacks {
     struct nk_config_stack_style_item style_items;
@@ -5578,6 +5628,7 @@ struct nk_configuration_stacks {
     struct nk_config_stack_color colors;
     struct nk_config_stack_user_font fonts;
     struct nk_config_stack_button_behavior button_behaviors;
+    struct nk_config_stack_color_inline color_inline;
 };
 
 /*==============================================================
@@ -5623,6 +5674,20 @@ struct nk_pool {
     nk_size cap;
 };
 
+#ifndef NK_MAP_NAME_COLOR_STACK_SIZE
+#define NK_MAP_NAME_COLOR_STACK_SIZE 32
+#endif
+
+struct nk_map_name_color_stack {
+    int head;
+    struct nk_map_name_color *elements[NK_MAP_NAME_COLOR_STACK_SIZE];
+};
+
+struct nk_draw_config {
+    enum nk_color_inline_type color_inline;
+    struct nk_map_name_color_stack map_name_color;
+};
+
 struct nk_context {
 /* public: can be accessed freely */
     struct nk_input input;
@@ -5631,6 +5696,7 @@ struct nk_context {
     struct nk_clipboard clip;
     nk_flags last_widget_state;
     enum nk_button_behavior button_behavior;
+    struct nk_draw_config draw_config;
     struct nk_configuration_stacks stacks;
     float delta_time_seconds;
 
@@ -5664,6 +5730,15 @@ struct nk_context {
     unsigned int seq;
 };
 
+NK_API void nk_draw_set_color_inline(struct nk_context*, enum nk_color_inline_type);
+NK_API nk_bool nk_draw_push_color_inline(struct nk_context*, enum nk_color_inline_type);
+NK_API nk_bool nk_draw_pop_color_inline(struct nk_context*);
+NK_API nk_bool nk_draw_push_map_name_color(struct nk_context*, struct nk_map_name_color *); /* map is held by reference, not copied */
+NK_API struct nk_map_name_color *nk_draw_get_map_name_color(struct nk_context*, int index); /* 0-index for most-recently pushed */
+NK_API int nk_draw_get_map_name_color_index_range(struct nk_context*); /* one past the max index */
+NK_API struct nk_map_name_color *nk_draw_pop_map_name_color(struct nk_context*);
+NK_API struct nk_name_color *nk_draw_get_name_color(struct nk_map_name_color_stack *stack, const char *name, int len);
+
 /* ==============================================================
  *                          MATH
  * =============================================================== */
@@ -5683,6 +5758,8 @@ struct nk_context {
     (y1 < (y0 + h0)) && (y0 < (y1 + h1)))
 #define NK_CONTAINS(x, y, w, h, bx, by, bw, bh)\
     (NK_INBOX(x,y, bx, by, bw, bh) && NK_INBOX(x+w,y+h, bx, by, bw, bh))
+#define NK_CHAR_IS_HEX_DIGIT(c)\
+    (((c) >= '0' && (c) <= '9') || ((c) >= 'a' && (c) <= 'f') || ((c) >= 'A' && (c) <= 'F'))
 
 #define nk_vec2_sub(a, b) nk_vec2((a).x - (b).x, (a).y - (b).y)
 #define nk_vec2_add(a, b) nk_vec2((a).x + (b).x, (a).y + (b).y)
@@ -5759,6 +5836,10 @@ template<typename T> struct nk_alignof{struct Big {T x; char c;}; enum {
 
 #ifndef NK_BUFFER_DEFAULT_INITIAL_SIZE
 #define NK_BUFFER_DEFAULT_INITIAL_SIZE (4*1024)
+#endif
+
+#ifndef NK_DEFAULT_MAP_NAME_COLOR_BUFFER_SIZE
+#define NK_DEFAULT_MAP_NAME_COLOR_BUFFER_SIZE (4*sizeof(struct nk_name_color))
 #endif
 
 /* standard library headers */
@@ -7949,6 +8030,353 @@ nk_color_hsv_bv(nk_byte *out, struct nk_color in)
     out[2] = (nk_byte)tmp[2];
 }
 
+NK_API void nk_name_color_init(struct nk_name_color *cn, const char *n, struct nk_color c)
+{
+    int len;
+
+    NK_ASSERT(cn);
+    NK_ASSERT(n);
+
+    if (!cn || !n)
+        return;
+
+    len = NK_MIN(nk_strlen(n), NK_NAME_COLOR_MAX_NAME - 1);
+    cn->name = nk_murmur_hash(n, len, NK_COLOR_INLINE_TAG);
+    NK_MEMCPY(cn->name_string, n, len);
+    cn->name_string[len] = '\0';
+    cn->color = c;
+}
+
+#ifdef NK_INCLUDE_DEFAULT_ALLOCATOR
+NK_API void nk_map_name_color_init_default(struct nk_map_name_color *c)
+{
+    struct nk_allocator alloc;
+
+    NK_ASSERT(c);
+
+    if (!c)
+        return;
+
+    alloc.userdata.ptr = 0;
+    alloc.alloc = nk_malloc;
+    alloc.free = nk_mfree;
+    nk_buffer_init(&c->buffer, &alloc, NK_DEFAULT_MAP_NAME_COLOR_BUFFER_SIZE);
+    c->count = 0;
+}
+
+#endif
+
+NK_API void nk_map_name_color_init(struct nk_map_name_color *c, const struct nk_allocator *a, const struct nk_name_color *cv, int cc)
+{
+    nk_size size;
+
+    NK_ASSERT(c);
+    NK_ASSERT(a);
+
+    if (!c || !a)
+        return;
+
+    if (cc == 0) {
+        nk_buffer_init(&c->buffer, a, NK_DEFAULT_MAP_NAME_COLOR_BUFFER_SIZE);
+        c->count = 0;
+        return;
+    }
+
+    NK_ASSERT(cv);
+    if (!cv)
+        return;
+
+    size = sizeof(struct nk_name_color) * cc;
+    nk_buffer_init(&c->buffer, a, size);
+    nk_buffer_push(&c->buffer, NK_BUFFER_FRONT, cv, size, sizeof(nk_hash));
+    c->count = cc;
+}
+
+NK_API void nk_map_name_color_init_colors(struct nk_map_name_color *c, const struct nk_allocator *a, const char **nv, struct nk_color *cv, int cc)
+{
+    nk_size size;
+    struct nk_name_color ct;
+    struct nk_name_color *m;
+    int i;
+
+    NK_ASSERT(c);
+    NK_ASSERT(a);
+
+    if (!c || !a)
+        return;
+
+    if (cc == 0) {
+        nk_buffer_init(&c->buffer, a, NK_DEFAULT_MAP_NAME_COLOR_BUFFER_SIZE);
+        c->count = 0;
+        return;
+    }
+
+    NK_ASSERT(nv);
+    NK_ASSERT(cv);
+    if (!nv || !cv)
+        return;
+
+    size = sizeof(struct nk_name_color) * cc;
+    nk_buffer_init(&c->buffer, a, size);
+    nk_buffer_alloc(&c->buffer, NK_BUFFER_FRONT, size, sizeof(nk_hash));
+    m = c->buffer.memory.ptr;
+    for (i = 0; i < cc; ++i) {
+        nk_name_color_init(&ct, nv[i], cv[i]);
+        NK_MEMCPY(&m[i], &ct, sizeof(struct nk_name_color));
+    }
+    c->count = cc;
+}
+
+NK_API void nk_map_name_color_init_map_name_color(struct nk_map_name_color *c0, const struct nk_allocator *a, const struct nk_map_name_color *c1, const char **filter_out, int count)
+{
+    nk_size size;
+    struct nk_name_color *cv1;
+    int i, j, len, hashes_count;
+    nk_bool filtered;
+    nk_hash hashes[32];
+
+    NK_ASSERT(c0);
+    NK_ASSERT(a);
+    NK_ASSERT(c1);
+
+    if (!c0 || !a || !c1)
+        return;
+
+    if (c1->count == 0) {
+        nk_buffer_init(&c0->buffer, a, NK_DEFAULT_MAP_NAME_COLOR_BUFFER_SIZE);
+        c0->count = 0;
+        return;
+    }
+
+    size = sizeof(struct nk_name_color) * c1->count;
+    cv1 = c1->buffer.memory.ptr;
+
+    if (count == 0) {
+        nk_buffer_init(&c0->buffer, a, size);
+        nk_buffer_push(&c0->buffer, NK_BUFFER_FRONT, cv1, size, sizeof(nk_hash));
+        c0->count = c1->count;
+        return;
+    }
+
+    NK_ASSERT(filter_out);
+    if (!filter_out)
+        return;
+
+    nk_buffer_init(&c0->buffer, a, size);
+
+    c0->count = 0;
+    hashes_count = NK_MIN((int)NK_LEN(hashes), count);
+    for (j = 0; j < hashes_count; ++j) {
+        len = NK_MIN(nk_strlen(filter_out[j]), NK_NAME_COLOR_MAX_NAME - 1);
+        hashes[j] = nk_murmur_hash(filter_out[j], len, NK_COLOR_INLINE_TAG);
+    }
+
+    for (i = 0; i < c1->count; ++i) {
+        filtered = 0;
+        for (j = 0; j < hashes_count; ++j) {
+            if (hashes[j] == cv1[i].name) {
+                if (nk_stricmpn(cv1[i].name_string, filter_out[j], NK_NAME_COLOR_MAX_NAME - 1) == 0) {
+                    filtered = 1;
+                    break;
+                }
+            }
+        }
+        if (!filtered) {
+            nk_buffer_push(&c0->buffer, NK_BUFFER_FRONT, &cv1[i], sizeof(struct nk_name_color), sizeof(nk_hash));
+            ++c0->count;
+        }
+    }
+
+    if (count > hashes_count)
+        nk_map_name_color_delete(c0, filter_out + hashes_count, count - hashes_count);
+}
+
+NK_API void nk_map_name_color_init_fixed(struct nk_map_name_color *c, struct nk_name_color *cv, int count, int capacity)
+{
+    NK_ASSERT(c);
+    NK_ASSERT(cv);
+    NK_ASSERT(count <= capacity);
+    NK_ASSERT(capacity != 0);
+
+    if (!c || !cv || count > capacity || capacity == 0)
+        return;
+
+    nk_buffer_init_fixed(&c->buffer, cv, capacity * sizeof(struct nk_name_color));
+    c->buffer.allocated = count * sizeof(struct nk_name_color);
+    c->count = count;
+}
+
+NK_API void nk_map_name_color_free(struct nk_map_name_color *c)
+{
+    NK_ASSERT(c);
+
+    if (!c)
+        return;
+
+    nk_buffer_free(&c->buffer);
+    c->count = 0;
+}
+
+NK_API void nk_map_name_color_push(struct nk_map_name_color *c, const struct nk_name_color *cv, int cc)
+{
+    nk_size size;
+    void *mem;
+
+    NK_ASSERT(c);
+
+    if (!c)
+        return;
+
+    if (cc == 0)
+        return;
+    NK_ASSERT(cv);
+    if (!cv)
+        return;
+
+    size = cc * sizeof(struct nk_name_color);
+    mem = nk_buffer_alloc(&c->buffer, NK_BUFFER_FRONT, size, sizeof(nk_hash));
+    if (!mem)
+        return;
+    NK_MEMCPY(mem, cv, size);
+    c->count += cc;
+}
+
+NK_API void nk_map_name_color_push_colors(struct nk_map_name_color *c, const char **nv, struct nk_color *cv, int cc)
+{
+    nk_size size;
+    void *mem;
+    struct nk_name_color ct;
+    struct nk_name_color *m;
+    int i;
+
+    NK_ASSERT(c);
+
+    if (!c)
+        return;
+
+    if (cc == 0)
+        return;
+    NK_ASSERT(nv);
+    NK_ASSERT(cv);
+    if (!nv || !cv)
+        return;
+
+    size = sizeof(struct nk_name_color) * cc;
+    mem = nk_buffer_alloc(&c->buffer, NK_BUFFER_FRONT, size, sizeof(nk_hash));
+    if (!mem)
+        return;
+    m = mem;
+    for (i = 0; i < cc; ++i) {
+        nk_name_color_init(&ct, nv[i], cv[i]);
+        NK_MEMCPY(&m[i], &ct, sizeof(struct nk_name_color));
+    }
+    c->count += cc;
+}
+
+NK_API void nk_map_name_color_push_map_name_color(struct nk_map_name_color *c0, const struct nk_map_name_color *c1)
+{
+    nk_size size;
+    void *mem;
+
+    NK_ASSERT(c0);
+    NK_ASSERT(c1);
+
+    if (!c0 || !c1)
+        return;
+
+    size = c1->count * sizeof(struct nk_name_color);
+    mem = nk_buffer_alloc(&c0->buffer, NK_BUFFER_FRONT, size, sizeof(nk_hash));
+    if (!mem)
+        return;
+    NK_MEMCPY(mem, c1->buffer.memory.ptr, size);
+    c0->count += c1->count;
+}
+
+NK_API void nk_map_name_color_delete(struct nk_map_name_color *c, const char **filter_out, int count)
+{
+    nk_size size;
+    int hashes_count, out_count = 0;
+    nk_bool filtered;
+    int out_begin, out_end, i, j, len, out_state;
+    struct nk_name_color *cv;
+    nk_hash hashes[32];
+
+    NK_ASSERT(c);
+
+    if (!c || c->count == 0)
+        return;
+
+    if (count == 0)
+        return;
+    NK_ASSERT(filter_out);
+    if (!filter_out)
+        return;
+
+    cv = c->buffer.memory.ptr;
+    while (count > 0) {
+        hashes_count = NK_MIN((int)NK_LEN(hashes), count);
+
+        for (j = 0; j < hashes_count; ++j) {
+            len = NK_MIN(nk_strlen(filter_out[j]), NK_NAME_COLOR_MAX_NAME - 1);
+            hashes[j] = nk_murmur_hash(filter_out[j], len, NK_COLOR_INLINE_TAG);
+        }
+
+        out_state = -1;
+        for (i = 0; i < c->count; ++i) {
+            filtered = 0;
+            for (j = 0; j < hashes_count; ++j) {
+                if (hashes[j] == cv[i].name) {
+                    if (nk_stricmpn(cv[i].name_string, filter_out[j], NK_NAME_COLOR_MAX_NAME - 1) == 0) {
+                        filtered = 1;
+                        break;
+                    }
+                }
+            }
+            if (filtered) {
+                if (out_state == 1) {
+                    /* memmove */
+                    size = (i - out_end) * sizeof(struct nk_name_color);
+                    NK_MEMCPY(&cv[out_begin], &cv[out_end], size);
+                    out_count += out_end - out_begin;
+                }
+                if (out_state != 0) {
+                    out_state = 0;
+                    out_begin = i;
+                }
+            } else {
+                if (out_state == 0) {
+                    out_state = 1;
+                    out_end = i;
+                }
+            }
+        }
+        /* copy final stretch if needed */
+        if (out_state == 1) {
+            size = (i - out_end) * sizeof(struct nk_name_color);
+            NK_MEMCPY(&cv[out_begin], &cv[out_end], size);
+            out_count += out_end - out_begin;
+        } else if (out_state == 0) {
+            out_count += i - out_begin;
+        }
+
+        c->buffer.allocated -= out_count * sizeof(struct nk_name_color);
+        c->count -= out_count;
+
+        filter_out += hashes_count;
+        count -= hashes_count;
+    }
+}
+
+NK_API void nk_map_name_color_clear(struct nk_map_name_color *c)
+{
+    NK_ASSERT(c);
+
+    if (!c)
+        return;
+
+    nk_buffer_clear(&c->buffer);
+    c->count = 0;
+}
 
 
 
@@ -8843,6 +9271,10 @@ nk_command_buffer_init(struct nk_command_buffer *cb,
     cb->begin = b->allocated;
     cb->end = b->allocated;
     cb->last = b->allocated;
+#ifdef NK_INCLUDE_COMMAND_USERDATA
+    cb->userdata.ptr = 0;
+#endif
+    cb->draw_config = 0;
 }
 NK_LIB void
 nk_command_buffer_reset(struct nk_command_buffer *b)
@@ -8856,6 +9288,7 @@ nk_command_buffer_reset(struct nk_command_buffer *b)
 #ifdef NK_INCLUDE_COMMAND_USERDATA
     b->userdata.ptr = 0;
 #endif
+    b->draw_config = 0;
 }
 NK_LIB void*
 nk_command_buffer_push(struct nk_command_buffer* b,
@@ -9340,34 +9773,186 @@ nk_push_custom(struct nk_command_buffer *b, struct nk_rect r,
     cmd->callback = cb;
 }
 NK_API void
-nk_draw_text(struct nk_command_buffer *b, struct nk_rect r,
-    const char *string, int length, const struct nk_user_font *font,
-    struct nk_color bg, struct nk_color fg)
+nk_draw_set_color_inline(struct nk_context *ctx, enum nk_color_inline_type color_inline)
 {
-    float text_width = 0;
-    struct nk_command_text *cmd;
+    NK_ASSERT(ctx);
+    if (!ctx) return;
+    ctx->draw_config.color_inline = color_inline;
+}
+NK_API nk_bool
+nk_draw_push_color_inline(struct nk_context *ctx, enum nk_color_inline_type color_inline)
+{
+    struct nk_config_stack_color_inline *color_inline_stack;
+    struct nk_config_stack_color_inline_element *element;
+
+    NK_ASSERT(ctx);
+    if (!ctx) return 0;
+
+    color_inline_stack = &ctx->stacks.color_inline;
+    NK_ASSERT(color_inline_stack->head < (int)NK_LEN(color_inline_stack->elements));
+    if (color_inline_stack->head >= (int)NK_LEN(color_inline_stack->elements))
+        return 0;
+
+    element = &color_inline_stack->elements[color_inline_stack->head++];
+    element->old_value = ctx->draw_config.color_inline;
+    ctx->draw_config.color_inline = color_inline;
+    return 1;
+}
+NK_API nk_bool
+nk_draw_pop_color_inline(struct nk_context *ctx)
+{
+    struct nk_config_stack_color_inline *color_inline_stack;
+    struct nk_config_stack_color_inline_element *element;
+
+    NK_ASSERT(ctx);
+    if (!ctx) return 0;
+
+    color_inline_stack = &ctx->stacks.color_inline;
+    NK_ASSERT(color_inline_stack->head > 0);
+    if (color_inline_stack->head < 1)
+        return 0;
+
+    element = &color_inline_stack->elements[--color_inline_stack->head];
+    ctx->draw_config.color_inline = element->old_value;
+    return 1;
+}
+NK_API nk_bool nk_draw_push_map_name_color(struct nk_context *ctx, struct nk_map_name_color *c)
+{
+    NK_ASSERT(ctx);
+    NK_ASSERT(c);
+
+    if (!ctx || !c)
+        return 0;
+
+    struct nk_map_name_color_stack *stack = &ctx->draw_config.map_name_color;
+    NK_ASSERT(stack->head < (int)NK_LEN(stack->elements));
+    if (stack->head >= (int)NK_LEN(stack->elements))
+        return 0;
+
+    stack->elements[stack->head++] = c;
+
+    return 1;
+}
+NK_API struct nk_map_name_color *nk_draw_get_map_name_color(struct nk_context* ctx, int index)
+{
+    NK_ASSERT(ctx);
+    if (!ctx) return 0;
+
+    struct nk_map_name_color_stack *stack = &ctx->draw_config.map_name_color;
+    NK_ASSERT(stack->head > index);
+    if (stack->head <= index)
+        return 0;
+
+    return stack->elements[stack->head - 1 - index];
+}
+NK_API int nk_draw_get_map_name_color_index_range(struct nk_context *ctx)
+{
+    NK_ASSERT(ctx);
+    if (!ctx) return 0;
+
+    struct nk_map_name_color_stack *stack = &ctx->draw_config.map_name_color;
+    return stack->head;
+}
+NK_API struct nk_map_name_color *nk_draw_pop_map_name_color(struct nk_context *ctx)
+{
+    NK_ASSERT(ctx);
+
+    if (!ctx)
+        return 0;
+
+    struct nk_map_name_color_stack *stack = &ctx->draw_config.map_name_color;
+    NK_ASSERT(stack->head > 0);
+    if (stack->head < 1)
+        return 0;
+
+    return stack->elements[--stack->head];
+}
+NK_API struct nk_name_color *nk_draw_get_name_color(struct nk_map_name_color_stack *stack, const char *name, int len)
+{
+    int i, j;
+    struct nk_map_name_color *c;
+    struct nk_name_color *cv;
+    nk_hash hash;
+
+    NK_ASSERT(stack);
+
+    if (!stack || !name)
+        return 0;
+
+    NK_ASSERT(stack->head > 0);
+    if (stack->head < 1)
+        return 0;
+
+    i = stack->head;
+    len = NK_MIN(len, NK_NAME_COLOR_MAX_NAME - 1);
+    hash = nk_murmur_hash(name, len, NK_COLOR_INLINE_TAG);
+    do {
+        c = stack->elements[--i];
+        cv = c->buffer.memory.ptr;
+        /* more recently pushed are on the back, so we start from the back */
+        for (j = c->count; j > 0;) {
+            --j;
+            if (cv[j].name == hash) {
+                if (nk_stricmpn(cv[j].name_string, name, len) == 0) {
+                    return &cv[j];
+                }
+            }
+        }
+    } while (i > 0);
+    return 0;
+}
+NK_API int
+nk_draw_raw_text(struct nk_command_buffer *b, struct nk_rect r,
+    const char *text, int len, const struct nk_user_font *font,
+    struct nk_color bg, struct nk_color fg, float *w)
+{
+    struct nk_command_text *cmd = 0;
+    enum nk_color_inline_type color_inline;
+    int i, j;
+    float font_width;
 
     NK_ASSERT(b);
     NK_ASSERT(font);
-    if (!b || !string || !length || (bg.a == 0 && fg.a == 0)) return;
-    if (b->use_clipping) {
-        const struct nk_rect *c = &b->clip;
-        if (c->w == 0 || c->h == 0 || !NK_INTERSECT(r.x, r.y, r.w, r.h, c->x, c->y, c->w, c->h))
-            return;
+
+    if (!b || !font || !text || !len || (bg.a == 0 && fg.a == 0)) return 0;
+
+    if (b->draw_config) {
+        color_inline = b->draw_config->color_inline;
+    } else {
+        color_inline = NK_COLOR_INLINE_NONE;
+    }
+
+    if (color_inline != NK_COLOR_INLINE_NONE) {
+        cmd = (struct nk_command_text*)
+            nk_command_buffer_push(b, NK_COMMAND_TEXT, sizeof(*cmd) + (nk_size)(len + 1));
+        if (!cmd) return 0;
+
+        for (i = 0, j = 0; j < len; ++i)
+            if (text[i] != '\e')
+                cmd->string[j++] = text[i];
+        text = cmd->string;
     }
 
     /* make sure text fits inside bounds */
-    text_width = font->width(font->userdata, font->height, string, length);
-    if (text_width > r.w){
+    font_width = font->width(font->userdata, font->height, text, len);
+    if (font_width > r.w){
         int glyphs = 0;
-        float txt_width = (float)text_width;
-        length = nk_text_clamp(font, string, length, r.w, &glyphs, &txt_width, 0,0);
+        len = nk_text_clamp(font, text, len, r.w, &glyphs, &font_width, 0,0);
+    }
+    if (w)
+        *w = font_width;
+
+    if (color_inline == NK_COLOR_INLINE_NONE) {
+        if (!len)
+            return 0;
+
+        cmd = (struct nk_command_text*)
+            nk_command_buffer_push(b, NK_COMMAND_TEXT, sizeof(*cmd) + (nk_size)(len + 1));
+        if (!cmd) return 0;
+
+        NK_MEMCPY(cmd->string, text, (nk_size)len);
     }
 
-    if (!length) return;
-    cmd = (struct nk_command_text*)
-        nk_command_buffer_push(b, NK_COMMAND_TEXT, sizeof(*cmd) + (nk_size)(length + 1));
-    if (!cmd) return;
     cmd->x = (short)r.x;
     cmd->y = (short)r.y;
     cmd->w = (unsigned short)r.w;
@@ -9375,12 +9960,191 @@ nk_draw_text(struct nk_command_buffer *b, struct nk_rect r,
     cmd->background = bg;
     cmd->foreground = fg;
     cmd->font = font;
-    cmd->length = length;
+    cmd->length = len;
+    cmd->string[len] = '\0';
     cmd->height = font->height;
-    NK_MEMCPY(cmd->string, string, (nk_size)length);
-    cmd->string[length] = '\0';
-}
 
+    return len;
+}
+#define NK_COLOR_INLINE_HEX_CODE_READ_LOOP(N) do { \
+    if ((color_name_end = k++) >= length) \
+        goto end_branch; \
+} while ( \
+    NK_CHAR_IS_HEX_DIGIT(c = string[color_name_end]) && ++found < N \
+)
+#define NK_COLOR_INLINE_GET_COLOR_FROM_STACK(DST, TAG_INDEX, DEF) do { \
+    DST = stack_index[TAG_INDEX] > 0 && \
+        stack_index[TAG_INDEX] <= NK_LEN(stack[TAG_INDEX]) ? \
+        stack[TAG_INDEX][stack_index[TAG_INDEX] - 1] : DEF; \
+} while (0)
+#define NK_COLOR_INLINE_DRAW_TEXT() do { if (j + esc_count < i) { \
+    NK_COLOR_INLINE_GET_COLOR_FROM_STACK(current_bg, NK_INLINE_TAG_BGCOLOR, bg); \
+    NK_COLOR_INLINE_GET_COLOR_FROM_STACK(current_fg, NK_INLINE_TAG_COLOR, fg); \
+    len = i - j - esc_count; \
+    draw_len = nk_draw_raw_text(b, r, string + j, len, font, current_bg, current_fg, &w); \
+    if (draw_len < len) \
+        return; \
+    r.x += w; \
+    r.w -= w; \
+} esc_count = 0; } while (0)
+enum {
+    NK_INLINE_TAG_COLOR,
+    NK_INLINE_TAG_BGCOLOR,
+    NK_INLINE_TAG_MAX,
+};
+NK_API void
+nk_draw_text(struct nk_command_buffer *b, struct nk_rect r,
+    const char *string, int length, const struct nk_user_font *font,
+    struct nk_color bg, struct nk_color fg)
+{
+    struct nk_color stack[NK_INLINE_TAG_MAX][16];
+    nk_size stack_index[NK_INLINE_TAG_MAX] = {0};
+    struct nk_name_color *name_color;
+    struct nk_color color, current_fg, current_bg;
+    enum nk_color_inline_type color_inline;
+    struct nk_map_name_color_stack *name_color_stack;
+    const char *tag_begin[NK_INLINE_TAG_MAX] = {"[color=", "[bgcolor="};
+    const char *tag_end[NK_INLINE_TAG_MAX] = {"[/color]", "[/bgcolor]"};
+
+    int i, j = 0, k, l, esc_count = 0, len, draw_len, found, color_name_begin, color_name_end;
+    char c;
+    float w;
+
+    NK_ASSERT(b);
+    NK_ASSERT(font);
+    if (!b || !font || !string || !length || (bg.a == 0 && fg.a == 0)) return;
+    if (b->use_clipping) {
+        const struct nk_rect *c = &b->clip;
+        if (c->w == 0 || c->h == 0 || !NK_INTERSECT(r.x, r.y, r.w, r.h, c->x, c->y, c->w, c->h))
+            return;
+    }
+
+    if (b->draw_config) {
+        color_inline = b->draw_config->color_inline;
+        name_color_stack = &b->draw_config->map_name_color;
+    } else {
+        color_inline = NK_COLOR_INLINE_NONE;
+        name_color_stack = 0;
+    }
+
+    if (color_inline == NK_COLOR_INLINE_NONE || color_inline >= NK_COLOR_INLINE_MAX) {
+        i = length;
+        goto end;
+    }
+    if (color_inline == NK_COLOR_INLINE_ESCAPE_TAG)
+        found = 0;
+    for (i = 0; i < length; ++i) {
+begin:
+        if (string[i] == '\e') {
+            ++esc_count;
+            if (color_inline == NK_COLOR_INLINE_TAG) {
+                if (++i < length) {
+                    if (string[i] == '[')
+                        continue;
+                    goto begin;
+                }
+                break;
+            } else if (color_inline == NK_COLOR_INLINE_ESCAPE_TAG) {
+                found = 1;
+                continue;
+            }
+        }
+        if (color_inline == NK_COLOR_INLINE_ESCAPE_TAG && found == 0)
+            continue;
+        for (l = 0; l < NK_INLINE_TAG_MAX; ++l) {
+            if (length - i > nk_strlen(tag_begin[l]) &&
+                nk_stricmpn(&string[i], tag_begin[l], nk_strlen(tag_begin[l])) == 0
+            ) {
+                k = i + nk_strlen(tag_begin[l]);
+                if (string[k] == '"') {
+                    color_name_begin = ++k;
+                    /* found = (NK_NAME_COLOR_MAX_NAME - 1) + 1 + 1 */
+                    /* first (+ 1) is to read one past end for '"' */
+                    /* second (+ 1) is to terminate loop immediately after one past end */
+                    found = NK_NAME_COLOR_MAX_NAME + 1;
+                    while (--found) {
+                        if ((color_name_end = k++) >= length)
+                            goto end_branch;
+                        if (string[color_name_end] == '"') {
+                            if (k >= length)
+                                goto end_branch;
+                            if (string[k] == ']') {
+                                found = 1;
+                                break;
+                            }
+                        }
+                    }
+                    if (found) {
+                        name_color = nk_draw_get_name_color(name_color_stack,
+                            string + color_name_begin,
+                            color_name_end - color_name_begin);
+                        if (name_color) {
+                            color = name_color->color;
+                        } else {
+                            found = 0;
+                        }
+                    }
+                } else if (string[k] == '#') {
+                    found = 0;
+                    color_name_begin = ++k;
+                    NK_COLOR_INLINE_HEX_CODE_READ_LOOP(6);
+                    if (k >= length)
+                        goto end_branch;
+                    found = 0;
+                    if (NK_CHAR_IS_HEX_DIGIT(c)) {
+                        if (string[k] == ']') {
+                            color = nk_rgb_hex(string + color_name_begin);
+                            found = 1;
+                        } else {
+                            NK_COLOR_INLINE_HEX_CODE_READ_LOOP(2);
+                            if (k >= length)
+                                goto end_branch;
+                            found = 0;
+                            if (NK_CHAR_IS_HEX_DIGIT(c)) {
+                                if (string[k] == ']') {
+                                    color = nk_rgba_hex(string + color_name_begin);
+                                    found = 1;
+                                }
+                            }
+                        }
+                    }
+                }
+                if (found) {
+                    NK_COLOR_INLINE_DRAW_TEXT();
+                    i = j = k + 1;
+                    if (i >= length)
+                        goto end;
+                    if (stack_index[l] < NK_LEN(stack[l])) {
+                        stack[l][stack_index[l]] = color;
+                    }
+                    ++stack_index[l];
+                    found = 0;
+                    goto begin;
+                }
+            }
+end_branch:
+            found = 0;
+            if (length - i >= nk_strlen(tag_end[l]) &&
+                nk_stricmpn(&string[i], tag_end[l], nk_strlen(tag_end[l])) == 0
+            ) {
+                if (stack_index[l] > 0) {
+                    NK_COLOR_INLINE_DRAW_TEXT();
+                    --stack_index[l];
+                    j = i += nk_strlen(tag_end[l]);
+                    if (i < length)
+                        goto begin;
+                    else
+                        goto end;
+                }
+            }
+        } /* for l */
+    } /* for i */
+end:
+    NK_COLOR_INLINE_DRAW_TEXT();
+}
+#undef NK_COLOR_INLINE_DRAW_TEXT
+#undef NK_COLOR_INLINE_GET_COLOR_FROM_STACK
+#undef NK_COLOR_INLINE_HEX_CODE_READ_LOOP
 
 
 
@@ -18957,7 +19721,10 @@ nk_free(struct nk_context *ctx)
     ctx->begin = 0;
     ctx->end = 0;
     ctx->active = 0;
-    ctx->current = 0;
+    if (ctx->current) {
+        ctx->current->buffer.draw_config = 0;
+        ctx->current = 0;
+    }
     ctx->freelist = 0;
     ctx->count = 0;
 }
@@ -19537,6 +20304,7 @@ nk_panel_begin(struct nk_context *ctx, const char *title, enum nk_panel_type pan
 #ifdef NK_INCLUDE_COMMAND_USERDATA
     win->buffer.userdata = ctx->userdata;
 #endif
+    win->buffer.draw_config = &ctx->draw_config;
     /* pull style configuration into local stack */
     scrollbar_size = style->window.scrollbar_size;
     panel_padding = nk_panel_get_padding(style, panel_type);

--- a/src/nuklear_color.c
+++ b/src/nuklear_color.c
@@ -412,3 +412,350 @@ nk_color_hsv_bv(nk_byte *out, struct nk_color in)
     out[2] = (nk_byte)tmp[2];
 }
 
+NK_API void nk_name_color_init(struct nk_name_color *cn, const char *n, struct nk_color c)
+{
+    int len;
+
+    NK_ASSERT(cn);
+    NK_ASSERT(n);
+
+    if (!cn || !n)
+        return;
+
+    len = NK_MIN(nk_strlen(n), NK_NAME_COLOR_MAX_NAME - 1);
+    cn->name = nk_murmur_hash(n, len, NK_COLOR_INLINE_TAG);
+    NK_MEMCPY(cn->name_string, n, len);
+    cn->name_string[len] = '\0';
+    cn->color = c;
+}
+
+#ifdef NK_INCLUDE_DEFAULT_ALLOCATOR
+NK_API void nk_map_name_color_init_default(struct nk_map_name_color *c)
+{
+    struct nk_allocator alloc;
+
+    NK_ASSERT(c);
+
+    if (!c)
+        return;
+
+    alloc.userdata.ptr = 0;
+    alloc.alloc = nk_malloc;
+    alloc.free = nk_mfree;
+    nk_buffer_init(&c->buffer, &alloc, NK_DEFAULT_MAP_NAME_COLOR_BUFFER_SIZE);
+    c->count = 0;
+}
+
+#endif
+
+NK_API void nk_map_name_color_init(struct nk_map_name_color *c, const struct nk_allocator *a, const struct nk_name_color *cv, int cc)
+{
+    nk_size size;
+
+    NK_ASSERT(c);
+    NK_ASSERT(a);
+
+    if (!c || !a)
+        return;
+
+    if (cc == 0) {
+        nk_buffer_init(&c->buffer, a, NK_DEFAULT_MAP_NAME_COLOR_BUFFER_SIZE);
+        c->count = 0;
+        return;
+    }
+
+    NK_ASSERT(cv);
+    if (!cv)
+        return;
+
+    size = sizeof(struct nk_name_color) * cc;
+    nk_buffer_init(&c->buffer, a, size);
+    nk_buffer_push(&c->buffer, NK_BUFFER_FRONT, cv, size, sizeof(nk_hash));
+    c->count = cc;
+}
+
+NK_API void nk_map_name_color_init_colors(struct nk_map_name_color *c, const struct nk_allocator *a, const char **nv, struct nk_color *cv, int cc)
+{
+    nk_size size;
+    struct nk_name_color ct;
+    struct nk_name_color *m;
+    int i;
+
+    NK_ASSERT(c);
+    NK_ASSERT(a);
+
+    if (!c || !a)
+        return;
+
+    if (cc == 0) {
+        nk_buffer_init(&c->buffer, a, NK_DEFAULT_MAP_NAME_COLOR_BUFFER_SIZE);
+        c->count = 0;
+        return;
+    }
+
+    NK_ASSERT(nv);
+    NK_ASSERT(cv);
+    if (!nv || !cv)
+        return;
+
+    size = sizeof(struct nk_name_color) * cc;
+    nk_buffer_init(&c->buffer, a, size);
+    nk_buffer_alloc(&c->buffer, NK_BUFFER_FRONT, size, sizeof(nk_hash));
+    m = c->buffer.memory.ptr;
+    for (i = 0; i < cc; ++i) {
+        nk_name_color_init(&ct, nv[i], cv[i]);
+        NK_MEMCPY(&m[i], &ct, sizeof(struct nk_name_color));
+    }
+    c->count = cc;
+}
+
+NK_API void nk_map_name_color_init_map_name_color(struct nk_map_name_color *c0, const struct nk_allocator *a, const struct nk_map_name_color *c1, const char **filter_out, int count)
+{
+    nk_size size;
+    struct nk_name_color *cv1;
+    int i, j, len, hashes_count;
+    nk_bool filtered;
+    nk_hash hashes[32];
+
+    NK_ASSERT(c0);
+    NK_ASSERT(a);
+    NK_ASSERT(c1);
+
+    if (!c0 || !a || !c1)
+        return;
+
+    if (c1->count == 0) {
+        nk_buffer_init(&c0->buffer, a, NK_DEFAULT_MAP_NAME_COLOR_BUFFER_SIZE);
+        c0->count = 0;
+        return;
+    }
+
+    size = sizeof(struct nk_name_color) * c1->count;
+    cv1 = c1->buffer.memory.ptr;
+
+    if (count == 0) {
+        nk_buffer_init(&c0->buffer, a, size);
+        nk_buffer_push(&c0->buffer, NK_BUFFER_FRONT, cv1, size, sizeof(nk_hash));
+        c0->count = c1->count;
+        return;
+    }
+
+    NK_ASSERT(filter_out);
+    if (!filter_out)
+        return;
+
+    nk_buffer_init(&c0->buffer, a, size);
+
+    c0->count = 0;
+    hashes_count = NK_MIN((int)NK_LEN(hashes), count);
+    for (j = 0; j < hashes_count; ++j) {
+        len = NK_MIN(nk_strlen(filter_out[j]), NK_NAME_COLOR_MAX_NAME - 1);
+        hashes[j] = nk_murmur_hash(filter_out[j], len, NK_COLOR_INLINE_TAG);
+    }
+
+    for (i = 0; i < c1->count; ++i) {
+        filtered = 0;
+        for (j = 0; j < hashes_count; ++j) {
+            if (hashes[j] == cv1[i].name) {
+                if (nk_stricmpn(cv1[i].name_string, filter_out[j], NK_NAME_COLOR_MAX_NAME - 1) == 0) {
+                    filtered = 1;
+                    break;
+                }
+            }
+        }
+        if (!filtered) {
+            nk_buffer_push(&c0->buffer, NK_BUFFER_FRONT, &cv1[i], sizeof(struct nk_name_color), sizeof(nk_hash));
+            ++c0->count;
+        }
+    }
+
+    if (count > hashes_count)
+        nk_map_name_color_delete(c0, filter_out + hashes_count, count - hashes_count);
+}
+
+NK_API void nk_map_name_color_init_fixed(struct nk_map_name_color *c, struct nk_name_color *cv, int count, int capacity)
+{
+    NK_ASSERT(c);
+    NK_ASSERT(cv);
+    NK_ASSERT(count <= capacity);
+    NK_ASSERT(capacity != 0);
+
+    if (!c || !cv || count > capacity || capacity == 0)
+        return;
+
+    nk_buffer_init_fixed(&c->buffer, cv, capacity * sizeof(struct nk_name_color));
+    c->buffer.allocated = count * sizeof(struct nk_name_color);
+    c->count = count;
+}
+
+NK_API void nk_map_name_color_free(struct nk_map_name_color *c)
+{
+    NK_ASSERT(c);
+
+    if (!c)
+        return;
+
+    nk_buffer_free(&c->buffer);
+    c->count = 0;
+}
+
+NK_API void nk_map_name_color_push(struct nk_map_name_color *c, const struct nk_name_color *cv, int cc)
+{
+    nk_size size;
+    void *mem;
+
+    NK_ASSERT(c);
+
+    if (!c)
+        return;
+
+    if (cc == 0)
+        return;
+    NK_ASSERT(cv);
+    if (!cv)
+        return;
+
+    size = cc * sizeof(struct nk_name_color);
+    mem = nk_buffer_alloc(&c->buffer, NK_BUFFER_FRONT, size, sizeof(nk_hash));
+    if (!mem)
+        return;
+    NK_MEMCPY(mem, cv, size);
+    c->count += cc;
+}
+
+NK_API void nk_map_name_color_push_colors(struct nk_map_name_color *c, const char **nv, struct nk_color *cv, int cc)
+{
+    nk_size size;
+    void *mem;
+    struct nk_name_color ct;
+    struct nk_name_color *m;
+    int i;
+
+    NK_ASSERT(c);
+
+    if (!c)
+        return;
+
+    if (cc == 0)
+        return;
+    NK_ASSERT(nv);
+    NK_ASSERT(cv);
+    if (!nv || !cv)
+        return;
+
+    size = sizeof(struct nk_name_color) * cc;
+    mem = nk_buffer_alloc(&c->buffer, NK_BUFFER_FRONT, size, sizeof(nk_hash));
+    if (!mem)
+        return;
+    m = mem;
+    for (i = 0; i < cc; ++i) {
+        nk_name_color_init(&ct, nv[i], cv[i]);
+        NK_MEMCPY(&m[i], &ct, sizeof(struct nk_name_color));
+    }
+    c->count += cc;
+}
+
+NK_API void nk_map_name_color_push_map_name_color(struct nk_map_name_color *c0, const struct nk_map_name_color *c1)
+{
+    nk_size size;
+    void *mem;
+
+    NK_ASSERT(c0);
+    NK_ASSERT(c1);
+
+    if (!c0 || !c1)
+        return;
+
+    size = c1->count * sizeof(struct nk_name_color);
+    mem = nk_buffer_alloc(&c0->buffer, NK_BUFFER_FRONT, size, sizeof(nk_hash));
+    if (!mem)
+        return;
+    NK_MEMCPY(mem, c1->buffer.memory.ptr, size);
+    c0->count += c1->count;
+}
+
+NK_API void nk_map_name_color_delete(struct nk_map_name_color *c, const char **filter_out, int count)
+{
+    nk_size size;
+    int hashes_count, out_count = 0;
+    nk_bool filtered;
+    int out_begin, out_end, i, j, len, out_state;
+    struct nk_name_color *cv;
+    nk_hash hashes[32];
+
+    NK_ASSERT(c);
+
+    if (!c || c->count == 0)
+        return;
+
+    if (count == 0)
+        return;
+    NK_ASSERT(filter_out);
+    if (!filter_out)
+        return;
+
+    cv = c->buffer.memory.ptr;
+    while (count > 0) {
+        hashes_count = NK_MIN((int)NK_LEN(hashes), count);
+
+        for (j = 0; j < hashes_count; ++j) {
+            len = NK_MIN(nk_strlen(filter_out[j]), NK_NAME_COLOR_MAX_NAME - 1);
+            hashes[j] = nk_murmur_hash(filter_out[j], len, NK_COLOR_INLINE_TAG);
+        }
+
+        out_state = -1;
+        for (i = 0; i < c->count; ++i) {
+            filtered = 0;
+            for (j = 0; j < hashes_count; ++j) {
+                if (hashes[j] == cv[i].name) {
+                    if (nk_stricmpn(cv[i].name_string, filter_out[j], NK_NAME_COLOR_MAX_NAME - 1) == 0) {
+                        filtered = 1;
+                        break;
+                    }
+                }
+            }
+            if (filtered) {
+                if (out_state == 1) {
+                    /* memmove */
+                    size = (i - out_end) * sizeof(struct nk_name_color);
+                    NK_MEMCPY(&cv[out_begin], &cv[out_end], size);
+                    out_count += out_end - out_begin;
+                }
+                if (out_state != 0) {
+                    out_state = 0;
+                    out_begin = i;
+                }
+            } else {
+                if (out_state == 0) {
+                    out_state = 1;
+                    out_end = i;
+                }
+            }
+        }
+        /* copy final stretch if needed */
+        if (out_state == 1) {
+            size = (i - out_end) * sizeof(struct nk_name_color);
+            NK_MEMCPY(&cv[out_begin], &cv[out_end], size);
+            out_count += out_end - out_begin;
+        } else if (out_state == 0) {
+            out_count += i - out_begin;
+        }
+
+        c->buffer.allocated -= out_count * sizeof(struct nk_name_color);
+        c->count -= out_count;
+
+        filter_out += hashes_count;
+        count -= hashes_count;
+    }
+}
+
+NK_API void nk_map_name_color_clear(struct nk_map_name_color *c)
+{
+    NK_ASSERT(c);
+
+    if (!c)
+        return;
+
+    nk_buffer_clear(&c->buffer);
+    c->count = 0;
+}

--- a/src/nuklear_context.c
+++ b/src/nuklear_context.c
@@ -102,7 +102,10 @@ nk_free(struct nk_context *ctx)
     ctx->begin = 0;
     ctx->end = 0;
     ctx->active = 0;
-    ctx->current = 0;
+    if (ctx->current) {
+        ctx->current->buffer.draw_config = 0;
+        ctx->current = 0;
+    }
     ctx->freelist = 0;
     ctx->count = 0;
 }

--- a/src/nuklear_draw.c
+++ b/src/nuklear_draw.c
@@ -18,6 +18,10 @@ nk_command_buffer_init(struct nk_command_buffer *cb,
     cb->begin = b->allocated;
     cb->end = b->allocated;
     cb->last = b->allocated;
+#ifdef NK_INCLUDE_COMMAND_USERDATA
+    cb->userdata.ptr = 0;
+#endif
+    cb->draw_config = 0;
 }
 NK_LIB void
 nk_command_buffer_reset(struct nk_command_buffer *b)
@@ -31,6 +35,7 @@ nk_command_buffer_reset(struct nk_command_buffer *b)
 #ifdef NK_INCLUDE_COMMAND_USERDATA
     b->userdata.ptr = 0;
 #endif
+    b->draw_config = 0;
 }
 NK_LIB void*
 nk_command_buffer_push(struct nk_command_buffer* b,
@@ -515,34 +520,186 @@ nk_push_custom(struct nk_command_buffer *b, struct nk_rect r,
     cmd->callback = cb;
 }
 NK_API void
-nk_draw_text(struct nk_command_buffer *b, struct nk_rect r,
-    const char *string, int length, const struct nk_user_font *font,
-    struct nk_color bg, struct nk_color fg)
+nk_draw_set_color_inline(struct nk_context *ctx, enum nk_color_inline_type color_inline)
 {
-    float text_width = 0;
-    struct nk_command_text *cmd;
+    NK_ASSERT(ctx);
+    if (!ctx) return;
+    ctx->draw_config.color_inline = color_inline;
+}
+NK_API nk_bool
+nk_draw_push_color_inline(struct nk_context *ctx, enum nk_color_inline_type color_inline)
+{
+    struct nk_config_stack_color_inline *color_inline_stack;
+    struct nk_config_stack_color_inline_element *element;
+
+    NK_ASSERT(ctx);
+    if (!ctx) return 0;
+
+    color_inline_stack = &ctx->stacks.color_inline;
+    NK_ASSERT(color_inline_stack->head < (int)NK_LEN(color_inline_stack->elements));
+    if (color_inline_stack->head >= (int)NK_LEN(color_inline_stack->elements))
+        return 0;
+
+    element = &color_inline_stack->elements[color_inline_stack->head++];
+    element->old_value = ctx->draw_config.color_inline;
+    ctx->draw_config.color_inline = color_inline;
+    return 1;
+}
+NK_API nk_bool
+nk_draw_pop_color_inline(struct nk_context *ctx)
+{
+    struct nk_config_stack_color_inline *color_inline_stack;
+    struct nk_config_stack_color_inline_element *element;
+
+    NK_ASSERT(ctx);
+    if (!ctx) return 0;
+
+    color_inline_stack = &ctx->stacks.color_inline;
+    NK_ASSERT(color_inline_stack->head > 0);
+    if (color_inline_stack->head < 1)
+        return 0;
+
+    element = &color_inline_stack->elements[--color_inline_stack->head];
+    ctx->draw_config.color_inline = element->old_value;
+    return 1;
+}
+NK_API nk_bool nk_draw_push_map_name_color(struct nk_context *ctx, struct nk_map_name_color *c)
+{
+    NK_ASSERT(ctx);
+    NK_ASSERT(c);
+
+    if (!ctx || !c)
+        return 0;
+
+    struct nk_map_name_color_stack *stack = &ctx->draw_config.map_name_color;
+    NK_ASSERT(stack->head < (int)NK_LEN(stack->elements));
+    if (stack->head >= (int)NK_LEN(stack->elements))
+        return 0;
+
+    stack->elements[stack->head++] = c;
+
+    return 1;
+}
+NK_API struct nk_map_name_color *nk_draw_get_map_name_color(struct nk_context* ctx, int index)
+{
+    NK_ASSERT(ctx);
+    if (!ctx) return 0;
+
+    struct nk_map_name_color_stack *stack = &ctx->draw_config.map_name_color;
+    NK_ASSERT(stack->head > index);
+    if (stack->head <= index)
+        return 0;
+
+    return stack->elements[stack->head - 1 - index];
+}
+NK_API int nk_draw_get_map_name_color_index_range(struct nk_context *ctx)
+{
+    NK_ASSERT(ctx);
+    if (!ctx) return 0;
+
+    struct nk_map_name_color_stack *stack = &ctx->draw_config.map_name_color;
+    return stack->head;
+}
+NK_API struct nk_map_name_color *nk_draw_pop_map_name_color(struct nk_context *ctx)
+{
+    NK_ASSERT(ctx);
+
+    if (!ctx)
+        return 0;
+
+    struct nk_map_name_color_stack *stack = &ctx->draw_config.map_name_color;
+    NK_ASSERT(stack->head > 0);
+    if (stack->head < 1)
+        return 0;
+
+    return stack->elements[--stack->head];
+}
+NK_API struct nk_name_color *nk_draw_get_name_color(struct nk_map_name_color_stack *stack, const char *name, int len)
+{
+    int i, j;
+    struct nk_map_name_color *c;
+    struct nk_name_color *cv;
+    nk_hash hash;
+
+    NK_ASSERT(stack);
+
+    if (!stack || !name)
+        return 0;
+
+    NK_ASSERT(stack->head > 0);
+    if (stack->head < 1)
+        return 0;
+
+    i = stack->head;
+    len = NK_MIN(len, NK_NAME_COLOR_MAX_NAME - 1);
+    hash = nk_murmur_hash(name, len, NK_COLOR_INLINE_TAG);
+    do {
+        c = stack->elements[--i];
+        cv = c->buffer.memory.ptr;
+        /* more recently pushed are on the back, so we start from the back */
+        for (j = c->count; j > 0;) {
+            --j;
+            if (cv[j].name == hash) {
+                if (nk_stricmpn(cv[j].name_string, name, len) == 0) {
+                    return &cv[j];
+                }
+            }
+        }
+    } while (i > 0);
+    return 0;
+}
+NK_API int
+nk_draw_raw_text(struct nk_command_buffer *b, struct nk_rect r,
+    const char *text, int len, const struct nk_user_font *font,
+    struct nk_color bg, struct nk_color fg, float *w)
+{
+    struct nk_command_text *cmd = 0;
+    enum nk_color_inline_type color_inline;
+    int i, j;
+    float font_width;
 
     NK_ASSERT(b);
     NK_ASSERT(font);
-    if (!b || !string || !length || (bg.a == 0 && fg.a == 0)) return;
-    if (b->use_clipping) {
-        const struct nk_rect *c = &b->clip;
-        if (c->w == 0 || c->h == 0 || !NK_INTERSECT(r.x, r.y, r.w, r.h, c->x, c->y, c->w, c->h))
-            return;
+
+    if (!b || !font || !text || !len || (bg.a == 0 && fg.a == 0)) return 0;
+
+    if (b->draw_config) {
+        color_inline = b->draw_config->color_inline;
+    } else {
+        color_inline = NK_COLOR_INLINE_NONE;
+    }
+
+    if (color_inline != NK_COLOR_INLINE_NONE) {
+        cmd = (struct nk_command_text*)
+            nk_command_buffer_push(b, NK_COMMAND_TEXT, sizeof(*cmd) + (nk_size)(len + 1));
+        if (!cmd) return 0;
+
+        for (i = 0, j = 0; j < len; ++i)
+            if (text[i] != '\e')
+                cmd->string[j++] = text[i];
+        text = cmd->string;
     }
 
     /* make sure text fits inside bounds */
-    text_width = font->width(font->userdata, font->height, string, length);
-    if (text_width > r.w){
+    font_width = font->width(font->userdata, font->height, text, len);
+    if (font_width > r.w){
         int glyphs = 0;
-        float txt_width = (float)text_width;
-        length = nk_text_clamp(font, string, length, r.w, &glyphs, &txt_width, 0,0);
+        len = nk_text_clamp(font, text, len, r.w, &glyphs, &font_width, 0,0);
+    }
+    if (w)
+        *w = font_width;
+
+    if (color_inline == NK_COLOR_INLINE_NONE) {
+        if (!len)
+            return 0;
+
+        cmd = (struct nk_command_text*)
+            nk_command_buffer_push(b, NK_COMMAND_TEXT, sizeof(*cmd) + (nk_size)(len + 1));
+        if (!cmd) return 0;
+
+        NK_MEMCPY(cmd->string, text, (nk_size)len);
     }
 
-    if (!length) return;
-    cmd = (struct nk_command_text*)
-        nk_command_buffer_push(b, NK_COMMAND_TEXT, sizeof(*cmd) + (nk_size)(length + 1));
-    if (!cmd) return;
     cmd->x = (short)r.x;
     cmd->y = (short)r.y;
     cmd->w = (unsigned short)r.w;
@@ -550,9 +707,188 @@ nk_draw_text(struct nk_command_buffer *b, struct nk_rect r,
     cmd->background = bg;
     cmd->foreground = fg;
     cmd->font = font;
-    cmd->length = length;
+    cmd->length = len;
+    cmd->string[len] = '\0';
     cmd->height = font->height;
-    NK_MEMCPY(cmd->string, string, (nk_size)length);
-    cmd->string[length] = '\0';
-}
 
+    return len;
+}
+#define NK_COLOR_INLINE_HEX_CODE_READ_LOOP(N) do { \
+    if ((color_name_end = k++) >= length) \
+        goto end_branch; \
+} while ( \
+    NK_CHAR_IS_HEX_DIGIT(c = string[color_name_end]) && ++found < N \
+)
+#define NK_COLOR_INLINE_GET_COLOR_FROM_STACK(DST, TAG_INDEX, DEF) do { \
+    DST = stack_index[TAG_INDEX] > 0 && \
+        stack_index[TAG_INDEX] <= NK_LEN(stack[TAG_INDEX]) ? \
+        stack[TAG_INDEX][stack_index[TAG_INDEX] - 1] : DEF; \
+} while (0)
+#define NK_COLOR_INLINE_DRAW_TEXT() do { if (j + esc_count < i) { \
+    NK_COLOR_INLINE_GET_COLOR_FROM_STACK(current_bg, NK_INLINE_TAG_BGCOLOR, bg); \
+    NK_COLOR_INLINE_GET_COLOR_FROM_STACK(current_fg, NK_INLINE_TAG_COLOR, fg); \
+    len = i - j - esc_count; \
+    draw_len = nk_draw_raw_text(b, r, string + j, len, font, current_bg, current_fg, &w); \
+    if (draw_len < len) \
+        return; \
+    r.x += w; \
+    r.w -= w; \
+} esc_count = 0; } while (0)
+enum {
+    NK_INLINE_TAG_COLOR,
+    NK_INLINE_TAG_BGCOLOR,
+    NK_INLINE_TAG_MAX,
+};
+NK_API void
+nk_draw_text(struct nk_command_buffer *b, struct nk_rect r,
+    const char *string, int length, const struct nk_user_font *font,
+    struct nk_color bg, struct nk_color fg)
+{
+    struct nk_color stack[NK_INLINE_TAG_MAX][16];
+    nk_size stack_index[NK_INLINE_TAG_MAX] = {0};
+    struct nk_name_color *name_color;
+    struct nk_color color, current_fg, current_bg;
+    enum nk_color_inline_type color_inline;
+    struct nk_map_name_color_stack *name_color_stack;
+    const char *tag_begin[NK_INLINE_TAG_MAX] = {"[color=", "[bgcolor="};
+    const char *tag_end[NK_INLINE_TAG_MAX] = {"[/color]", "[/bgcolor]"};
+
+    int i, j = 0, k, l, esc_count = 0, len, draw_len, found, color_name_begin, color_name_end;
+    char c;
+    float w;
+
+    NK_ASSERT(b);
+    NK_ASSERT(font);
+    if (!b || !font || !string || !length || (bg.a == 0 && fg.a == 0)) return;
+    if (b->use_clipping) {
+        const struct nk_rect *c = &b->clip;
+        if (c->w == 0 || c->h == 0 || !NK_INTERSECT(r.x, r.y, r.w, r.h, c->x, c->y, c->w, c->h))
+            return;
+    }
+
+    if (b->draw_config) {
+        color_inline = b->draw_config->color_inline;
+        name_color_stack = &b->draw_config->map_name_color;
+    } else {
+        color_inline = NK_COLOR_INLINE_NONE;
+        name_color_stack = 0;
+    }
+
+    if (color_inline == NK_COLOR_INLINE_NONE || color_inline >= NK_COLOR_INLINE_MAX) {
+        i = length;
+        goto end;
+    }
+    if (color_inline == NK_COLOR_INLINE_ESCAPE_TAG)
+        found = 0;
+    for (i = 0; i < length; ++i) {
+begin:
+        if (string[i] == '\e') {
+            ++esc_count;
+            if (color_inline == NK_COLOR_INLINE_TAG) {
+                if (++i < length) {
+                    if (string[i] == '[')
+                        continue;
+                    goto begin;
+                }
+                break;
+            } else if (color_inline == NK_COLOR_INLINE_ESCAPE_TAG) {
+                found = 1;
+                continue;
+            }
+        }
+        if (color_inline == NK_COLOR_INLINE_ESCAPE_TAG && found == 0)
+            continue;
+        for (l = 0; l < NK_INLINE_TAG_MAX; ++l) {
+            if (length - i > nk_strlen(tag_begin[l]) &&
+                nk_stricmpn(&string[i], tag_begin[l], nk_strlen(tag_begin[l])) == 0
+            ) {
+                k = i + nk_strlen(tag_begin[l]);
+                if (string[k] == '"') {
+                    color_name_begin = ++k;
+                    /* found = (NK_NAME_COLOR_MAX_NAME - 1) + 1 + 1 */
+                    /* first (+ 1) is to read one past end for '"' */
+                    /* second (+ 1) is to terminate loop immediately after one past end */
+                    found = NK_NAME_COLOR_MAX_NAME + 1;
+                    while (--found) {
+                        if ((color_name_end = k++) >= length)
+                            goto end_branch;
+                        if (string[color_name_end] == '"') {
+                            if (k >= length)
+                                goto end_branch;
+                            if (string[k] == ']') {
+                                found = 1;
+                                break;
+                            }
+                        }
+                    }
+                    if (found) {
+                        name_color = nk_draw_get_name_color(name_color_stack,
+                            string + color_name_begin,
+                            color_name_end - color_name_begin);
+                        if (name_color) {
+                            color = name_color->color;
+                        } else {
+                            found = 0;
+                        }
+                    }
+                } else if (string[k] == '#') {
+                    found = 0;
+                    color_name_begin = ++k;
+                    NK_COLOR_INLINE_HEX_CODE_READ_LOOP(6);
+                    if (k >= length)
+                        goto end_branch;
+                    found = 0;
+                    if (NK_CHAR_IS_HEX_DIGIT(c)) {
+                        if (string[k] == ']') {
+                            color = nk_rgb_hex(string + color_name_begin);
+                            found = 1;
+                        } else {
+                            NK_COLOR_INLINE_HEX_CODE_READ_LOOP(2);
+                            if (k >= length)
+                                goto end_branch;
+                            found = 0;
+                            if (NK_CHAR_IS_HEX_DIGIT(c)) {
+                                if (string[k] == ']') {
+                                    color = nk_rgba_hex(string + color_name_begin);
+                                    found = 1;
+                                }
+                            }
+                        }
+                    }
+                }
+                if (found) {
+                    NK_COLOR_INLINE_DRAW_TEXT();
+                    i = j = k + 1;
+                    if (i >= length)
+                        goto end;
+                    if (stack_index[l] < NK_LEN(stack[l])) {
+                        stack[l][stack_index[l]] = color;
+                    }
+                    ++stack_index[l];
+                    found = 0;
+                    goto begin;
+                }
+            }
+end_branch:
+            found = 0;
+            if (length - i >= nk_strlen(tag_end[l]) &&
+                nk_stricmpn(&string[i], tag_end[l], nk_strlen(tag_end[l])) == 0
+            ) {
+                if (stack_index[l] > 0) {
+                    NK_COLOR_INLINE_DRAW_TEXT();
+                    --stack_index[l];
+                    j = i += nk_strlen(tag_end[l]);
+                    if (i < length)
+                        goto begin;
+                    else
+                        goto end;
+                }
+            }
+        } /* for l */
+    } /* for i */
+end:
+    NK_COLOR_INLINE_DRAW_TEXT();
+}
+#undef NK_COLOR_INLINE_DRAW_TEXT
+#undef NK_COLOR_INLINE_GET_COLOR_FROM_STACK
+#undef NK_COLOR_INLINE_HEX_CODE_READ_LOOP

--- a/src/nuklear_internal.h
+++ b/src/nuklear_internal.h
@@ -13,6 +13,10 @@
 #define NK_BUFFER_DEFAULT_INITIAL_SIZE (4*1024)
 #endif
 
+#ifndef NK_DEFAULT_MAP_NAME_COLOR_BUFFER_SIZE
+#define NK_DEFAULT_MAP_NAME_COLOR_BUFFER_SIZE (4*sizeof(struct nk_name_color))
+#endif
+
 /* standard library headers */
 #ifdef NK_INCLUDE_DEFAULT_ALLOCATOR
 #include <stdlib.h> /* malloc, free */

--- a/src/nuklear_panel.c
+++ b/src/nuklear_panel.c
@@ -116,6 +116,7 @@ nk_panel_begin(struct nk_context *ctx, const char *title, enum nk_panel_type pan
 #ifdef NK_INCLUDE_COMMAND_USERDATA
     win->buffer.userdata = ctx->userdata;
 #endif
+    win->buffer.draw_config = &ctx->draw_config;
     /* pull style configuration into local stack */
     scrollbar_size = style->window.scrollbar_size;
     panel_padding = nk_panel_get_padding(style, panel_type);


### PR DESCRIPTION
Originally requested here: https://github.com/vurtun/nuklear/issues/575

I happen to need this feature in my app so this is an implementation of it.

### How it works
A new property `draw_config` is stored in `nk_context` and passed to `nk_command_buffer` when windows are drawn.
`nk_draw_text` then use the settings in the command buffer to draw text as required.

There are two ways to encode inline color information:

1.
```c
nk_draw_set_color_inline(ctx, NK_COLOR_INLINE_TAG);
/* then pass text to widget like follows: */
nk_label(ctx, "default [color=#ff0000]red[/color] color", NK_TEXT_LEFT)
```

2.
```c
nk_draw_set_color_inline(ctx, NK_COLOR_INLINE_ESCAPE_TAG);
/* then pass text to widget like follows: */
nk_label(ctx, "default \e[color=#ff0000]red\e[/color] color", NK_TEXT_LEFT)
```

The difference is that in the first option, `'\e'` can be used to escape and display the opening tag without changing the color of subsequent text, e.g:
```c
"displaying color tag \e[color=#ff00ff]code"
```
In the second option `'\e'` must be used before each opening and closing tag for them to take effect.

You can also give _names_ to colors like so:

```c
const char *color_name = "my_color";
struct nk_color color= nk_rgb_hex("bb00bb");
struct nk_map_name_color color_name_map;
nk_map_name_color_init_colors(&color_name_map, &ctx->memory.pool, &color_name, &color, 1);

nk_draw_push_map_name_color(ctx, &color_name_map);

nk_draw_set_color_inline(ctx, NK_COLOR_INLINE_TAG);
nk_label(ctx, "default [color=\"my_color\"]some[/color] color", NK_TEXT_LEFT)
```

### Notes on possible improvement in code

Most of the changes in this [file](https://github.com/xzn/Nuklear/commit/527c85a40df981c51920bb103749959dd1b6f9eb#diff-18bc2a7408fe6d3751f4078220d46c8ff243928c6ca61c17f652f9b9bb637743) should not be needed, most of it can be cut down if we say, include [`stb_ds.h`](https://github.com/nothings/stb/blob/master/stb_ds.h) and use the hash map implementation for user-defined color name to color map.
Alternatively we can choose to not support user-define color names (although it's already implemented in this PR).

### Testing done so far

This PR has only been moderately tested. There should not be any buffer overrun or off by one error. If you've found any bugs please let me know so I can fix them.

Only the built-in `stb_truetype` font renderer has been tested. No idea right now how this feature will fare against different font rendering backend.

## Example usages:

Will be added later

## Screenshots

Will be added later.
