### PR TITLE
Node editor demo expanded

### DIFF
--- a/demo/common/node_editor.c
+++ b/demo/common/node_editor.c
@@ -66,6 +66,7 @@ struct node_editor {
     int initialized;
     struct node *node_buf[32];
     struct node_link links[64];
+    struct node *outputNode;
     struct node *begin;
     struct node *end;
     int node_count;
@@ -196,6 +197,9 @@ node_editor_link(struct node_editor *editor, struct node *in_node, int in_slot,
     link = &editor->links[editor->link_count++];
     out_node->inputs[out_slot].isConnected = nk_true;
     in_node->outputs[in_slot].isConnected = nk_true;
+    out_node->inputs[out_slot].connectedNode = in_node;
+    out_node->inputs[out_slot].connectedSlot = in_slot;
+    
     link->input_node = in_node;
     link->input_slot = in_slot;
     link->output_node = out_node;
@@ -209,8 +213,10 @@ node_editor_init(struct node_editor *editor)
     memset(editor, 0, sizeof(*editor));
     editor->begin = NULL;
     editor->end = NULL;
+
+    editor->outputNode = node_output_create(editor, (struct nk_vec2){600, 400});
+
     node_color_create(editor, (struct nk_vec2){40, 10});
-    node_output_create(editor, (struct nk_vec2){200, 200});
     editor->show_grid = nk_true;
 }
 

--- a/demo/common/node_editor.c
+++ b/demo/common/node_editor.c
@@ -183,6 +183,7 @@ node_editor_add(struct node_editor *editor, const char *name, struct nk_rect bou
     for (int i = 0; i < node->input_count; i++) {
         node->inputs[i].isConnected = nk_false;
         node->inputs[i].type = fValue; 
+        if (i == 0) node->inputs[i].type = fColor; /* for testing */ 
     }
     for (i = 0; i < node->output_count; i++) {
         node->outputs[i].isConnected = nk_false;
@@ -312,10 +313,14 @@ node_editor_main(struct nk_context *ctx)
                     /* (loop through outputs) */
                     for (n = 0; n < it->output_count; ++n) {
                         struct nk_rect circle;
+                        struct nk_color color;
                         circle.x = nodePanel->bounds.x + nodePanel->bounds.w-4;
                         circle.y = nodePanel->bounds.y + it->slot_spacing.out_top + it->slot_spacing.out_space * (float)n;
                         circle.w = 8; circle.h = 8;
-                        nk_fill_circle(canvas, circle, nk_rgb(100, 100, 100));
+                        if (it->outputs[n].type == fColor)
+                            color = nk_rgb(200, 200, 0);
+                        else color = nk_rgb(100, 100, 100);
+                        nk_fill_circle(canvas, circle, color);
 
                         /* start linking process */
                         /* (set linking active) */
@@ -340,10 +345,14 @@ node_editor_main(struct nk_context *ctx)
                     /* input connector */
                     for (n = 0; n < it->input_count; ++n) {
                         struct nk_rect circle;
+                        struct nk_color color;
                         circle.x = nodePanel->bounds.x-4;
                         circle.y = nodePanel->bounds.y + it->slot_spacing.in_top + it->slot_spacing.in_space * (float)n;
                         circle.w = 8; circle.h = 8;
-                        nk_fill_circle(canvas, circle, nk_rgb(100, 100, 100));
+                        if (it->inputs[n].type == fColor)
+                            color = nk_rgb(200, 200, 0);
+                        else color = nk_rgb(100, 100, 100);
+                        nk_fill_circle(canvas, circle, color);
 
                         /* Detach link */
                         if (nk_input_has_mouse_click_down_in_rect(in, NK_BUTTON_LEFT, circle, nk_true) &&
@@ -364,6 +373,7 @@ node_editor_main(struct nk_context *ctx)
                             nk_input_is_mouse_hovering_rect(in, circle) &&
                             nodedit->linking.active && 
                             nodedit->linking.node != it &&
+                            it->inputs[n].type == nodedit->linking.node->outputs[nodedit->linking.input_slot].type &&
                             it->inputs[n].isConnected != nk_true) {
                             nodedit->linking.active = nk_false;
                             

--- a/demo/common/node_editor.c
+++ b/demo/common/node_editor.c
@@ -178,7 +178,7 @@ int in_count, int out_count)
     int i;
     static int IDs = 0;
     struct node *node = NULL;
-    /* NK_ASSERT((nk_size)editor->node_count < NK_LEN(editor->node_buf)); */
+
     if ((nk_size)editor->node_count < NK_LEN(editor->node_buf))
     {  
         node = malloc(nodeSize);
@@ -197,7 +197,7 @@ int in_count, int out_count)
         }
     }
     if (node == NULL) {
-        printf("Node creation failed\n");
+        fprintf(stdout, "Node creation failed\n");
         return NULL;
     }
 
@@ -239,19 +239,34 @@ node_editor_link(struct node_editor *editor, struct node *in_node, int in_slot,
     struct node *out_node, int out_slot)
 {
     /* Confusingly, in and out nodes/slots here refer to the inputs and outputs OF THE LINK ITSELF, not the nodes */
-    struct node_link *link;
-    NK_ASSERT((nk_size)editor->link_count < NK_LEN(editor->links));
-    link = &editor->links[editor->link_count++];
-    out_node->inputs[out_slot].isConnected = nk_true;
-    in_node->outputs[in_slot].isConnected = nk_true;
-    out_node->inputs[out_slot].connectedNode = in_node;
-    out_node->inputs[out_slot].connectedSlot = in_slot;
+    struct node_link *link = NULL;
     
-    link->input_node = in_node;
-    link->input_slot = in_slot;
-    link->output_node = out_node;
-    link->output_slot = out_slot;
-    link->isActive = nk_true;
+    if ((nk_size)editor->link_count < NK_LEN(editor->links))
+        link = &editor->links[editor->link_count++];
+    else {
+        int i;
+        for (i = 0; i < (int)NK_LEN(editor->links); i++)
+        {
+            if (editor->links[i].isActive == nk_false) {
+                link = &editor->links[i];
+                break;
+            }
+        }
+    }
+    if (link) {
+        out_node->inputs[out_slot].isConnected = nk_true;
+        in_node->outputs[in_slot].isConnected = nk_true;
+        out_node->inputs[out_slot].connectedNode = in_node;
+        out_node->inputs[out_slot].connectedSlot = in_slot;
+        
+        link->input_node = in_node;
+        link->input_slot = in_slot;
+        link->output_node = out_node;
+        link->output_slot = out_slot;
+        link->isActive = nk_true;
+    }
+    else
+        fprintf(stdout, "Too many links\n");
 }
 
 static void

--- a/demo/common/node_editor.c
+++ b/demo/common/node_editor.c
@@ -72,7 +72,7 @@ struct node_editor {
     struct nk_vec2 scrolling;
     struct node_linking linking;
 };
-static struct node_editor node_editor;
+static struct node_editor nodeEditor;
 
 /* === PROTOTYPES === */
 /* Each type of node needs these two functions. */
@@ -287,18 +287,18 @@ node_editor_init(struct node_editor *editor)
 }
 
 static int
-node_editor_main(struct nk_context *ctx)
+node_editor(struct nk_context *ctx)
 {
     int n = 0;
     struct nk_rect total_space;
     const struct nk_input *in = &ctx->input;
     struct nk_command_buffer *canvas;
     struct node *updated = 0;
-    struct node_editor *editor = &node_editor;
+    struct node_editor *editor = &nodeEditor;
 
-    if (!node_editor.initialized) {
-        node_editor_init(&node_editor);
-        node_editor.initialized = 1;
+    if (!nodeEditor.initialized) {
+        node_editor_init(&nodeEditor);
+        nodeEditor.initialized = 1;
     }
 
     if (nk_begin(ctx, "NodeEdit", nk_rect(0, 0, 800, 600),

--- a/demo/common/node_editor.c
+++ b/demo/common/node_editor.c
@@ -86,6 +86,7 @@ void* node_editor_eval_connected(struct node *node, int inputSlot);
 #include "nodeeditor/node_type_color.c"
 #include "nodeeditor/node_type_float.c"
 #include "nodeeditor/node_type_output.c"
+#include "nodeeditor/node_type_blend.c"
 
 static void
 node_editor_push(struct node_editor *editor, struct node *node)
@@ -180,12 +181,14 @@ int in_count, int out_count)
     struct node *node = NULL;
 
     if ((nk_size)editor->node_count < NK_LEN(editor->node_buf))
-    {  
+    {
+        /* node_buf has unused slots */
         node = malloc(nodeSize);
         editor->node_buf[editor->node_count++] = node;
         node->ID = IDs++;
     }
     else {
+        /* check for freed up slots in node_buf */
         for (i = 0; i < editor->node_count; i++)
         {
             if (editor->node_buf[i] == NULL) {
@@ -229,7 +232,8 @@ int in_count, int out_count)
 }
 
 void *
-node_editor_eval_connected(struct node* node, int inputSlot) {
+node_editor_eval_connected(struct node* node, int inputSlot) 
+{
     NK_ASSERT(node->inputs[inputSlot].isConnected);
     return node->inputs[inputSlot].connectedNode->evalFunc(node->inputs[inputSlot].connectedNode, node->inputs[inputSlot].connectedSlot);
 }
@@ -240,7 +244,7 @@ node_editor_link(struct node_editor *editor, struct node *in_node, int in_slot,
 {
     /* Confusingly, in and out nodes/slots here refer to the inputs and outputs OF THE LINK ITSELF, not the nodes */
     struct node_link *link = NULL;
-    
+
     if ((nk_size)editor->link_count < NK_LEN(editor->links))
         link = &editor->links[editor->link_count++];
     else {
@@ -517,6 +521,8 @@ node_editor_main(struct nk_context *ctx)
                     node_color_create(nodedit, in->mouse.pos);
                 if (nk_contextual_item_label(ctx, "Add Float node", NK_TEXT_CENTERED))
                     node_float_create(nodedit, in->mouse.pos);
+                if (nk_contextual_item_label(ctx, "Add Blend Node", NK_TEXT_CENTERED))
+                    node_blend_create(nodedit, in->mouse.pos);
                 if (nk_contextual_item_label(ctx, grid_option[nodedit->show_grid],NK_TEXT_CENTERED))
                     nodedit->show_grid = !nodedit->show_grid;
                 nk_contextual_end(ctx);

--- a/demo/common/node_editor.c
+++ b/demo/common/node_editor.c
@@ -75,17 +75,21 @@ struct node_editor {
 static struct node_editor nodeEditor;
 
 /* === PROTOTYPES === */
-/* Each type of node needs these two functions. */
+/* The node implementations need these two functions. */
 /* These could/should go in a header file along with the node and node_connector structs and be #included in the node implementations */
+
 struct node* node_editor_add(struct node_editor *editor, size_t nodeSize, const char *name, struct nk_rect bounds,
     int in_count, int out_count);
 void* node_editor_eval_connected(struct node *node, int inputSlot);
 /* ================== */
 
+/* === NODE TYPE IMPLEMENTATIONS === */
+
 #include "nodeeditor/node_type_float.c"
 #include "nodeeditor/node_type_color.c"
 #include "nodeeditor/node_type_blend.c"
 #include "nodeeditor/node_type_output.c"
+/* ================================= */
 
 static void
 node_editor_push(struct node_editor *editor, struct node *node)
@@ -350,12 +354,8 @@ node_editor(struct nk_context *ctx)
                         updated = it;
                     }
 
-                    if (!(nodePanel->flags & NK_WINDOW_HIDDEN)) { /* Node close button has not been clicked */
-                        /* ================= NODE CONTENT ===================== */
-                        it->display_func(ctx, it);
-                        /* ==================================================== */
-                    }
-                    else {
+                    if ((nodePanel->flags & NK_WINDOW_HIDDEN)) /* Node close button has been clicked */
+                    { 
                         /* Delete node */
                         struct node_link *link_remove;
                         node_editor_pop(editor, it);
@@ -373,14 +373,23 @@ node_editor(struct nk_context *ctx)
                                 node_editor_delete_link(link_remove);
                             }
                         }
-                    NK_ASSERT(editor->node_buf[it->ID] == it);
-                    editor->node_buf[it->ID] = NULL;
-                    free(it->inputs);
-                    free(it->outputs);
-                    free(it);
+                        NK_ASSERT(editor->node_buf[it->ID] == it);
+                        editor->node_buf[it->ID] = NULL;
+                        free(it->inputs);
+                        free(it->outputs);
+                        free(it);
                     }
+                    else {
 
+                        /* ================= NODE CONTENT ===================== */
+                        
+                        it->display_func(ctx, it);
+                        
+                        /* ==================================================== */
+                        
+                    }
                     nk_group_end(ctx);
+
                 }
                 if (!(nodePanel->flags & NK_WINDOW_HIDDEN)) 
                 {

--- a/demo/common/node_editor.c
+++ b/demo/common/node_editor.c
@@ -72,6 +72,14 @@ struct node_editor {
 };
 static struct node_editor nodeEditor;
 
+/* === PROTOTYPES === */
+
+static struct node* node_editor_add(struct node_editor *editor, const char *name, struct nk_rect bounds,
+    struct nk_color col, int in_count, int out_count);
+
+/* ================== */
+
+
 #include "nodeeditor/node_type_color.c"
 
 static void
@@ -133,7 +141,7 @@ node_editor_find_link_by_output(struct node_editor *editor, struct node *output_
     return NULL;
 }
 
-static void
+static struct node*
 node_editor_add(struct node_editor *editor, const char *name, struct nk_rect bounds,
     struct nk_color col, int in_count, int out_count)
 {
@@ -179,6 +187,7 @@ node_editor_add(struct node_editor *editor, const char *name, struct nk_rect bou
     node->bounds = bounds;
     strcpy(node->name, name);
     node_editor_push(editor, node);
+    return node;
 }
 
 static void
@@ -204,9 +213,9 @@ node_editor_init(struct node_editor *editor)
     memset(editor, 0, sizeof(*editor));
     editor->begin = NULL;
     editor->end = NULL;
-    node_editor_add(editor, "Source", nk_rect(40, 10, 180, 220), nk_rgb(255, 0, 0), 0, 1);
-    node_editor_add(editor, "Source", nk_rect(40, 260, 180, 220), nk_rgb(0, 255, 0), 0, 1);
-    node_editor_add(editor, "Combine", nk_rect(400, 100, 180, 220), nk_rgb(0,0,255), 2, 2);
+    node_editor_add(editor, "Dummy1", nk_rect(40, 10, 180, 220), nk_rgb(255, 0, 0), 0, 1);
+    node_editor_add(editor, "Dummy2", nk_rect(40, 260, 180, 220), nk_rgb(0, 255, 0), 0, 1);
+    node_editor_add(editor, "Dummy3", nk_rect(400, 100, 180, 220), nk_rgb(0,0,255), 2, 2);
     //node_editor_link(editor, node_editor_find(&nodeEditor, 0), 0, node_editor_find(&nodeEditor, 2), 0);
     //node_editor_link(editor, node_editor_find(&nodeEditor, 1), 0, node_editor_find(&nodeEditor, 2), 1);
     editor->show_grid = nk_true;
@@ -407,12 +416,14 @@ node_editor_main(struct nk_context *ctx)
             }
 
             /* contextual menu */
-            if (nk_contextual_begin(ctx, 0, nk_vec2(100, 220), nk_window_get_bounds(ctx))) {
+            if (nk_contextual_begin(ctx, 0, nk_vec2(150, 220), nk_window_get_bounds(ctx))) {
                 const char *grid_option[] = {"Show Grid", "Hide Grid"};
                 nk_layout_row_dynamic(ctx, 25, 1);
                 if (nk_contextual_item_label(ctx, "New", NK_TEXT_CENTERED))
-                    node_editor_add(nodedit, "New", nk_rect(400, 260, 180, 220),
+                    node_editor_add(nodedit, "New", nk_rect(in->mouse.pos.x, in->mouse.pos.y, 180, 220),
                             nk_rgb(255, 255, 255), 1, 2);
+                if (nk_contextual_item_label(ctx, "Add Color node", NK_TEXT_CENTERED))
+                    node_color_create(nodedit, in->mouse.pos);
                 if (nk_contextual_item_label(ctx, grid_option[nodedit->show_grid],NK_TEXT_CENTERED))
                     nodedit->show_grid = !nodedit->show_grid;
                 nk_contextual_end(ctx);

--- a/demo/common/nodeeditor/node_type_blend.c
+++ b/demo/common/nodeeditor/node_type_blend.c
@@ -1,0 +1,73 @@
+struct node_type_blend {
+    struct node node;
+    struct nk_colorf inputVal[2];
+    struct nk_colorf outputVal;
+    float blendVal;
+};
+
+static struct nk_colorf *node_blend_eval(struct node *node, int oIndex) {
+    struct node_type_blend* blendNode = (struct node_type_blend*)node;
+    return &blendNode->outputVal;
+}
+
+static void node_blend_display(struct nk_context *ctx, struct node *node) {
+    struct node_type_blend *blendNode = (struct node_type_blend*)node;
+    const struct nk_colorf blank = {0.0f, 0.0f, 0.0f, 0.0f};
+    float blendAmnt;
+    int i;
+
+    nk_layout_row_dynamic(ctx, 25, 1);
+    for (i = 0; i < (int)NK_LEN(blendNode->inputVal); i++){
+        if(node->inputs[i].isConnected) {
+            blendNode->inputVal[i] = *(struct nk_colorf*)node_editor_eval_connected(node, i);
+        }
+        else {
+            blendNode->inputVal[i] = blank;
+        }
+        nk_button_color(ctx, nk_rgba_cf(blendNode->inputVal[i]));
+    }
+
+        if (node->inputs[2].isConnected) {
+            blendAmnt = *(float*)node_editor_eval_connected(node, 2);
+            blendAmnt = nk_propertyf(ctx, "#Blend", blendAmnt, blendAmnt, blendAmnt, 0.01f, 0.01f);
+        }
+        else {
+            blendNode->blendVal = nk_propertyf(ctx, "#Blend", 0.0f, blendNode->blendVal, 1.0f, 0.01f, 0.01f);
+            blendAmnt = blendNode->blendVal;
+        }
+    
+    
+    if(node->inputs[0].isConnected && node->inputs[1].isConnected) {
+        blendNode->outputVal.r = blendNode->inputVal[0].r * blendAmnt + blendNode->inputVal[1].r * (1.0f-blendAmnt);
+        blendNode->outputVal.g = blendNode->inputVal[0].g * blendAmnt + blendNode->inputVal[1].g * (1.0f-blendAmnt);
+        blendNode->outputVal.b = blendNode->inputVal[0].b * blendAmnt + blendNode->inputVal[1].b * (1.0f-blendAmnt);
+        blendNode->outputVal.a = blendNode->inputVal[0].a * blendAmnt + blendNode->inputVal[1].a * (1.0f-blendAmnt);
+    }
+    else {
+        blendNode->outputVal = blank;
+    }
+}
+
+void node_blend_create(struct node_editor *editor, struct nk_vec2 position) {
+    struct node_type_blend* blendNode = (struct node_type_blend*)node_editor_add(editor, sizeof(struct node_type_blend), "Blend", nk_rect(position.x, position.y, 180, 130), 3, 1);
+    if (blendNode) {
+        const struct nk_colorf blank = {0.0f, 0.0f, 0.0f, 0.0f};
+        int i;
+        for (i = 0; i < (int)NK_LEN(blendNode->inputVal); i++)
+            blendNode->node.inputs[i].type = fColor;
+        blendNode->node.outputs[0].type = fColor;
+
+        blendNode->node.slot_spacing.in_top = 42.0f;
+        blendNode->node.slot_spacing.in_space = 29.0f;
+
+        for (i = 0; i < (int)NK_LEN(blendNode->inputVal); i++)
+            blendNode->inputVal[i] = blank;
+        blendNode->outputVal = blank;
+
+        blendNode->blendVal = 0.5f;
+
+        blendNode->node.displayFunc = node_blend_display;
+        blendNode->node.evalFunc = (void*(*)(struct node*, int)) node_blend_eval;
+
+    }
+}

--- a/demo/common/nodeeditor/node_type_blend.c
+++ b/demo/common/nodeeditor/node_type_blend.c
@@ -17,7 +17,7 @@ static void node_blend_display(struct nk_context *ctx, struct node *node) {
     int i;
 
     nk_layout_row_dynamic(ctx, 25, 1);
-    for (i = 0; i < (int)NK_LEN(blend_node->input_val); i++){
+    for (i = 0; i < 2; i++){
         if(node->inputs[i].is_connected) {
             blend_node->input_val[i] = *(struct nk_colorf*)node_editor_eval_connected(node, i);
         }
@@ -38,10 +38,10 @@ static void node_blend_display(struct nk_context *ctx, struct node *node) {
     
     
     if(node->inputs[0].is_connected && node->inputs[1].is_connected) {
-        blend_node->output_val.r = blend_node->input_val[0].r * blend_amnt + blend_node->input_val[1].r * (1.0f-blend_amnt);
-        blend_node->output_val.g = blend_node->input_val[0].g * blend_amnt + blend_node->input_val[1].g * (1.0f-blend_amnt);
-        blend_node->output_val.b = blend_node->input_val[0].b * blend_amnt + blend_node->input_val[1].b * (1.0f-blend_amnt);
-        blend_node->output_val.a = blend_node->input_val[0].a * blend_amnt + blend_node->input_val[1].a * (1.0f-blend_amnt);
+        blend_node->output_val.r = blend_node->input_val[0].r * (1.0f-blend_amnt) + blend_node->input_val[1].r * blend_amnt;
+        blend_node->output_val.g = blend_node->input_val[0].g * (1.0f-blend_amnt) + blend_node->input_val[1].g * blend_amnt;
+        blend_node->output_val.b = blend_node->input_val[0].b * (1.0f-blend_amnt) + blend_node->input_val[1].b * blend_amnt;
+        blend_node->output_val.a = blend_node->input_val[0].a * (1.0f-blend_amnt) + blend_node->input_val[1].a * blend_amnt;
     }
     else {
         blend_node->output_val = blank;

--- a/demo/common/nodeeditor/node_type_blend.c
+++ b/demo/common/nodeeditor/node_type_blend.c
@@ -1,73 +1,73 @@
 struct node_type_blend {
     struct node node;
-    struct nk_colorf inputVal[2];
-    struct nk_colorf outputVal;
-    float blendVal;
+    struct nk_colorf input_val[2];
+    struct nk_colorf output_val;
+    float blend_val;
 };
 
 static struct nk_colorf *node_blend_eval(struct node *node, int oIndex) {
-    struct node_type_blend* blendNode = (struct node_type_blend*)node;
-    return &blendNode->outputVal;
+    struct node_type_blend* blend_node = (struct node_type_blend*)node;
+    return &blend_node->output_val;
 }
 
 static void node_blend_display(struct nk_context *ctx, struct node *node) {
-    struct node_type_blend *blendNode = (struct node_type_blend*)node;
+    struct node_type_blend *blend_node = (struct node_type_blend*)node;
     const struct nk_colorf blank = {0.0f, 0.0f, 0.0f, 0.0f};
-    float blendAmnt;
+    float blend_amnt;
     int i;
 
     nk_layout_row_dynamic(ctx, 25, 1);
-    for (i = 0; i < (int)NK_LEN(blendNode->inputVal); i++){
-        if(node->inputs[i].isConnected) {
-            blendNode->inputVal[i] = *(struct nk_colorf*)node_editor_eval_connected(node, i);
+    for (i = 0; i < (int)NK_LEN(blend_node->input_val); i++){
+        if(node->inputs[i].is_connected) {
+            blend_node->input_val[i] = *(struct nk_colorf*)node_editor_eval_connected(node, i);
         }
         else {
-            blendNode->inputVal[i] = blank;
+            blend_node->input_val[i] = blank;
         }
-        nk_button_color(ctx, nk_rgba_cf(blendNode->inputVal[i]));
+        nk_button_color(ctx, nk_rgba_cf(blend_node->input_val[i]));
     }
 
-        if (node->inputs[2].isConnected) {
-            blendAmnt = *(float*)node_editor_eval_connected(node, 2);
-            blendAmnt = nk_propertyf(ctx, "#Blend", blendAmnt, blendAmnt, blendAmnt, 0.01f, 0.01f);
+        if (node->inputs[2].is_connected) {
+            blend_amnt = *(float*)node_editor_eval_connected(node, 2);
+            blend_amnt = nk_propertyf(ctx, "#Blend", blend_amnt, blend_amnt, blend_amnt, 0.01f, 0.01f);
         }
         else {
-            blendNode->blendVal = nk_propertyf(ctx, "#Blend", 0.0f, blendNode->blendVal, 1.0f, 0.01f, 0.01f);
-            blendAmnt = blendNode->blendVal;
+            blend_node->blend_val = nk_propertyf(ctx, "#Blend", 0.0f, blend_node->blend_val, 1.0f, 0.01f, 0.01f);
+            blend_amnt = blend_node->blend_val;
         }
     
     
-    if(node->inputs[0].isConnected && node->inputs[1].isConnected) {
-        blendNode->outputVal.r = blendNode->inputVal[0].r * blendAmnt + blendNode->inputVal[1].r * (1.0f-blendAmnt);
-        blendNode->outputVal.g = blendNode->inputVal[0].g * blendAmnt + blendNode->inputVal[1].g * (1.0f-blendAmnt);
-        blendNode->outputVal.b = blendNode->inputVal[0].b * blendAmnt + blendNode->inputVal[1].b * (1.0f-blendAmnt);
-        blendNode->outputVal.a = blendNode->inputVal[0].a * blendAmnt + blendNode->inputVal[1].a * (1.0f-blendAmnt);
+    if(node->inputs[0].is_connected && node->inputs[1].is_connected) {
+        blend_node->output_val.r = blend_node->input_val[0].r * blend_amnt + blend_node->input_val[1].r * (1.0f-blend_amnt);
+        blend_node->output_val.g = blend_node->input_val[0].g * blend_amnt + blend_node->input_val[1].g * (1.0f-blend_amnt);
+        blend_node->output_val.b = blend_node->input_val[0].b * blend_amnt + blend_node->input_val[1].b * (1.0f-blend_amnt);
+        blend_node->output_val.a = blend_node->input_val[0].a * blend_amnt + blend_node->input_val[1].a * (1.0f-blend_amnt);
     }
     else {
-        blendNode->outputVal = blank;
+        blend_node->output_val = blank;
     }
 }
 
 void node_blend_create(struct node_editor *editor, struct nk_vec2 position) {
-    struct node_type_blend* blendNode = (struct node_type_blend*)node_editor_add(editor, sizeof(struct node_type_blend), "Blend", nk_rect(position.x, position.y, 180, 130), 3, 1);
-    if (blendNode) {
+    struct node_type_blend* blend_node = (struct node_type_blend*)node_editor_add(editor, sizeof(struct node_type_blend), "Blend", nk_rect(position.x, position.y, 180, 130), 3, 1);
+    if (blend_node) {
         const struct nk_colorf blank = {0.0f, 0.0f, 0.0f, 0.0f};
         int i;
-        for (i = 0; i < (int)NK_LEN(blendNode->inputVal); i++)
-            blendNode->node.inputs[i].type = fColor;
-        blendNode->node.outputs[0].type = fColor;
+        for (i = 0; i < (int)NK_LEN(blend_node->input_val); i++)
+            blend_node->node.inputs[i].type = fColor;
+        blend_node->node.outputs[0].type = fColor;
 
-        blendNode->node.slot_spacing.in_top = 42.0f;
-        blendNode->node.slot_spacing.in_space = 29.0f;
+        blend_node->node.slot_spacing.in_top = 42.0f;
+        blend_node->node.slot_spacing.in_space = 29.0f;
 
-        for (i = 0; i < (int)NK_LEN(blendNode->inputVal); i++)
-            blendNode->inputVal[i] = blank;
-        blendNode->outputVal = blank;
+        for (i = 0; i < (int)NK_LEN(blend_node->input_val); i++)
+            blend_node->input_val[i] = blank;
+        blend_node->output_val = blank;
 
-        blendNode->blendVal = 0.5f;
+        blend_node->blend_val = 0.5f;
 
-        blendNode->node.displayFunc = node_blend_display;
-        blendNode->node.evalFunc = (void*(*)(struct node*, int)) node_blend_eval;
+        blend_node->node.display_func = node_blend_display;
+        blend_node->node.eval_func = (void*(*)(struct node*, int)) node_blend_eval;
 
     }
 }

--- a/demo/common/nodeeditor/node_type_color.c
+++ b/demo/common/nodeeditor/node_type_color.c
@@ -17,7 +17,7 @@ static void node_color_draw(struct nk_context *ctx, struct node *node)
 {
     struct node_type_color *colornode = (struct node_type_color*)node;
     float evalResult; /* Get the values from connected nodes into this so the inputs revert on disconnect */
-    char* labels[4] = {"#R:","#G:","B:","A:"};
+    const char* labels[4] = {"#R:","#G:","#B:","#A:"};
     float colorVals[4]; /* Because we can't just loop through the struct... */
     int i;
     nk_layout_row_dynamic(ctx, 25, 1);
@@ -47,7 +47,8 @@ void node_color_create(struct node_editor *editor, struct nk_vec2 position)
     if (colornode)
     {
         int i;
-        struct nk_colorf white = {1.0f, 1.0f, 1.0f, 1.0f};
+        const struct nk_colorf white = {1.0f, 1.0f, 1.0f, 1.0f};
+        
         colornode->node.slot_spacing.in_top = 72.0f;
         colornode->node.slot_spacing.in_space = 29.0f;
         colornode->node.slot_spacing.out_top = 42.0f;

--- a/demo/common/nodeeditor/node_type_color.c
+++ b/demo/common/nodeeditor/node_type_color.c
@@ -1,0 +1,66 @@
+struct node_type_color {
+    struct node node;
+    float *inputVal;
+    struct nk_colorf *outputVal;
+
+};
+
+/*
+static void* node_color_get(struct node* self, int oIndex)
+{
+    struct node_type_color *node = ((struct node_type_color*)self);
+    for (int i = 0; i < self->input_count; i++)
+    {
+        if (self->inputs[i].isConnected)
+        {
+            /*
+            call getter func of connected node and assign to ((node_type_color*)self)->inputVal[i]
+            *//*
+        }
+    }
+    node->outputVal->r = node->inputVal[0];
+    node->outputVal->g = node->inputVal[1];
+    node->outputVal->b = node->inputVal[2];
+    node->outputVal->a = node->inputVal[3];
+
+    struct nk_colorf *returnpointer = ((struct node_type_color*)self)->outputVal;
+    return (void*) returnpointer;
+}*/
+
+
+static void node_color_draw(struct nk_context *ctx, struct node* node)
+{
+    /* ================= NODE CONTENT =====================*/
+    nk_layout_row_dynamic(ctx, 25, 1);
+    nk_button_color(ctx, node->color);
+    node->color.r = (nk_byte)nk_propertyi(ctx, "#R:", 0, node->color.r, 255, 1,1);
+    node->color.g = (nk_byte)nk_propertyi(ctx, "#G:", 0, node->color.g, 255, 1,1);
+    node->color.b = (nk_byte)nk_propertyi(ctx, "#B:", 0, node->color.b, 255, 1,1);
+    node->color.a = (nk_byte)nk_propertyi(ctx, "#A:", 0, node->color.a, 255, 1,1);
+    /* ====================================================*/
+}
+
+/*
+struct node* node_color_init()
+{
+    struct node_type_color *colornode = (struct node_type_color*)malloc(sizeof(struct node_type_color));
+    colornode->node.input_count = 4;
+    colornode->node.output_count = 1;
+
+    colornode->node.inputs = (struct node_connector*)malloc(colornode->node.input_count * sizeof(struct node_connector));
+    for (int i = 0; i < colornode->node.input_count; i++) {
+        colornode->node.inputs[i].type = fValue;
+    }
+    colornode->inputVal = (float*)malloc(colornode->node.input_count * sizeof(float));
+
+
+    colornode->node.outputs = (struct node_connector*)malloc(colornode->node.output_count * sizeof(struct node_connector));
+    colornode->node.outputs->type = fColor;
+    colornode->outputVal = (struct nk_colorf*)malloc(colornode->node.input_count * sizeof(struct nk_colorf));
+
+    colornode->node.displayFunc = node_color_draw;
+    //colornode->node.evalFunc = get_nodetypes_color;
+
+    return (struct node*)colornode; // does this need to return (node*)(&colornode->node) ??
+}
+*/

--- a/demo/common/nodeeditor/node_type_color.c
+++ b/demo/common/nodeeditor/node_type_color.c
@@ -43,4 +43,8 @@ static void node_color_draw(struct nk_context *ctx, struct node* node)
 void node_color_create(struct node_editor* editor, struct nk_vec2 position)
 {
     struct node *node = node_editor_add(editor, "Color", nk_rect(position.x, position.y, 180, 220), nk_rgb(255, 255, 255), 4, 1);
+    node->slot_spacing.in_top = 72.0f;
+    node->slot_spacing.in_space = 29.0f;
+    node->slot_spacing.out_top = 42.0f;
+    node->slot_spacing.out_space = 0.0f;
 }

--- a/demo/common/nodeeditor/node_type_color.c
+++ b/demo/common/nodeeditor/node_type_color.c
@@ -6,7 +6,7 @@ struct node_type_color {
 
 static struct nk_colorf *node_color_eval(struct node* node, int oIndex)
 {
-    NK_ASSERT(oIndex == 0); /* only one output node */
+    NK_ASSERT(oIndex == 0); /* only one output connector */
     struct node_type_color *colornode = (struct node_type_color*)node;
 
     return &colornode->outputVal;
@@ -24,12 +24,12 @@ static void node_color_draw(struct nk_context *ctx, struct node *node)
     
     for (int i = 0; i < 4; i++) {
         if (colornode->node.inputs[i].isConnected) {
-            evalResult = *(float*)node->inputs[i].connectedNode->evalFunc(node->inputs[i].connectedNode, node->inputs[i].connectedSlot);
-            evalResult = nk_propertyf(ctx, labels[i], evalResult, evalResult, evalResult, 0.05f, 0.05f);
+            evalResult = *(float*)node_editor_eval_connected(node, i);
+            evalResult = nk_propertyf(ctx, labels[i], evalResult, evalResult, evalResult, 0.01f, 0.01f);
             colorVals[i] = evalResult;
         }
         else {
-            colornode->inputVal[i] = nk_propertyf(ctx, labels[i], 0.0f, colornode->inputVal[i], 1.0f, 0.05f, 0.05f);
+            colornode->inputVal[i] = nk_propertyf(ctx, labels[i], 0.0f, colornode->inputVal[i], 1.0f, 0.01f, 0.01f);
             colorVals[i] = colornode->inputVal[i];
         }
     }
@@ -39,7 +39,7 @@ static void node_color_draw(struct nk_context *ctx, struct node *node)
 
 void node_color_create(struct node_editor *editor, struct nk_vec2 position)
 {
-    struct node_type_color *colornode = (struct node_type_color*)node_editor_add(editor, sizeof(struct node_type_color), "Color", nk_rect(position.x, position.y, 180, 220), 4, 1);
+    struct node_type_color *colornode = (struct node_type_color*)node_editor_add(editor, sizeof(struct node_type_color), "Color", nk_rect(position.x, position.y, 180, 190), 4, 1);
     colornode->node.slot_spacing.in_top = 72.0f;
     colornode->node.slot_spacing.in_space = 29.0f;
     colornode->node.slot_spacing.out_top = 42.0f;

--- a/demo/common/nodeeditor/node_type_color.c
+++ b/demo/common/nodeeditor/node_type_color.c
@@ -47,4 +47,8 @@ void node_color_create(struct node_editor* editor, struct nk_vec2 position)
     node->slot_spacing.in_space = 29.0f;
     node->slot_spacing.out_top = 42.0f;
     node->slot_spacing.out_space = 0.0f;
+    
+    for (int i = 0; i < node->input_count; i++)
+        node->inputs[i].type = fValue;
+    node->outputs[0].type = fColor;
 }

--- a/demo/common/nodeeditor/node_type_color.c
+++ b/demo/common/nodeeditor/node_type_color.c
@@ -4,46 +4,37 @@ struct node_type_color {
     struct nk_colorf outputVal;
 };
 
-/*
-static void* node_color_get(struct node* self, int oIndex)
+static struct nk_colorf *node_color_eval(struct node* node, int oIndex)
 {
-    struct node_type_color *node = ((struct node_type_color*)self);
-    for (int i = 0; i < self->input_count; i++)
-    {
-        if (self->inputs[i].isConnected)
-        {
-            /*
-            call getter func of connected node and assign to ((node_type_color*)self)->inputVal[i]
-            *//*
-        }
-    }
-    node->outputVal->r = node->inputVal[0];
-    node->outputVal->g = node->inputVal[1];
-    node->outputVal->b = node->inputVal[2];
-    node->outputVal->a = node->inputVal[3];
+    NK_ASSERT(oIndex == 0); /* only one output node */
+    struct node_type_color *colornode = (struct node_type_color*)node;
 
-    struct nk_colorf *returnpointer = ((struct node_type_color*)self)->outputVal;
-    return (void*) returnpointer;
-}*/
+    return &colornode->outputVal;
+}
 
 
 static void node_color_draw(struct nk_context *ctx, struct node *node)
 {
     struct node_type_color *colornode = (struct node_type_color*)node;
+    float evalResult; /* Get the values from connected nodes into this so the inputs revert on disconnect */
+    char* labels[4] = {"#R:","#G:","B:","A:"};
+    float colorVals[4]; /* Because we can't just loop through the struct... */
     nk_layout_row_dynamic(ctx, 25, 1);
-    nk_button_color(ctx, nk_rgba_f(colornode->inputVal[0],colornode->inputVal[1],colornode->inputVal[2],colornode->inputVal[3]));
-    colornode->inputVal[0] = colornode->node.inputs[0].isConnected ?
-        nk_propertyf(ctx, "#R:", colornode->inputVal[0], colornode->inputVal[0], colornode->inputVal[0], 0.05f, 0.05f) :
-        nk_propertyf(ctx, "#R:", 0.0f, colornode->inputVal[0], 1.0f, 0.01f, 0.01f);
-    colornode->inputVal[1] = colornode->node.inputs[1].isConnected ?
-        nk_propertyf(ctx, "#G:", colornode->inputVal[1], colornode->inputVal[1], colornode->inputVal[1], 0.05f, 0.05f) :
-        nk_propertyf(ctx, "#G:", 0.0f, colornode->inputVal[1], 1.0f, 0.01f, 0.01f);
-    colornode->inputVal[2] = colornode->node.inputs[2].isConnected ?
-        nk_propertyf(ctx, "#B:", colornode->inputVal[2], colornode->inputVal[2], colornode->inputVal[2], 0.05f, 0.05f) :
-        nk_propertyf(ctx, "#B:", 0.0f, colornode->inputVal[2], 1.0f, 0.01f, 0.01f);
-    colornode->inputVal[3] = colornode->node.inputs[3].isConnected ?
-        nk_propertyf(ctx, "#A:", colornode->inputVal[3], colornode->inputVal[3], colornode->inputVal[3], 0.05f, 0.05f) :
-        nk_propertyf(ctx, "#A:", 0.0f, colornode->inputVal[3], 1.0f, 0.01f, 0.01f);
+    nk_button_color(ctx, nk_rgba_cf(colornode->outputVal));
+    
+    for (int i = 0; i < 4; i++) {
+        if (colornode->node.inputs[i].isConnected) {
+            evalResult = *(float*)node->inputs[i].connectedNode->evalFunc(node->inputs[i].connectedNode, node->inputs[i].connectedSlot);
+            evalResult = nk_propertyf(ctx, labels[i], evalResult, evalResult, evalResult, 0.05f, 0.05f);
+            colorVals[i] = evalResult;
+        }
+        else {
+            colornode->inputVal[i] = nk_propertyf(ctx, labels[i], 0.0f, colornode->inputVal[i], 1.0f, 0.05f, 0.05f);
+            colorVals[i] = colornode->inputVal[i];
+        }
+    }
+
+    colornode->outputVal = (struct nk_colorf){colorVals[0],colorVals[1],colorVals[2],colorVals[3]};
 }
 
 void node_color_create(struct node_editor *editor, struct nk_vec2 position)
@@ -66,4 +57,5 @@ void node_color_create(struct node_editor *editor, struct nk_vec2 position)
     colornode->outputVal = (struct nk_colorf){1.0f, 1.0f, 1.0f, 1.0f};
 
     colornode->node.displayFunc = node_color_draw;
+    colornode->node.evalFunc = node_color_eval;
 }

--- a/demo/common/nodeeditor/node_type_color.c
+++ b/demo/common/nodeeditor/node_type_color.c
@@ -6,8 +6,8 @@ struct node_type_color {
 
 static struct nk_colorf *node_color_eval(struct node* node, int oIndex)
 {
-    NK_ASSERT(oIndex == 0); /* only one output connector */
     struct node_type_color *colornode = (struct node_type_color*)node;
+    NK_ASSERT(oIndex == 0); /* only one output connector */
 
     return &colornode->outputVal;
 }
@@ -19,10 +19,11 @@ static void node_color_draw(struct nk_context *ctx, struct node *node)
     float evalResult; /* Get the values from connected nodes into this so the inputs revert on disconnect */
     char* labels[4] = {"#R:","#G:","B:","A:"};
     float colorVals[4]; /* Because we can't just loop through the struct... */
+    int i;
     nk_layout_row_dynamic(ctx, 25, 1);
     nk_button_color(ctx, nk_rgba_cf(colornode->outputVal));
     
-    for (int i = 0; i < 4; i++) {
+    for (i = 0; i < 4; i++) {
         if (colornode->node.inputs[i].isConnected) {
             evalResult = *(float*)node_editor_eval_connected(node, i);
             evalResult = nk_propertyf(ctx, labels[i], evalResult, evalResult, evalResult, 0.01f, 0.01f);
@@ -34,28 +35,36 @@ static void node_color_draw(struct nk_context *ctx, struct node *node)
         }
     }
 
-    colornode->outputVal = (struct nk_colorf){colorVals[0],colorVals[1],colorVals[2],colorVals[3]};
+    colornode->outputVal.r = colorVals[0];
+    colornode->outputVal.g = colorVals[1];
+    colornode->outputVal.b = colorVals[2];
+    colornode->outputVal.a = colorVals[3];
 }
 
 void node_color_create(struct node_editor *editor, struct nk_vec2 position)
 {
     struct node_type_color *colornode = (struct node_type_color*)node_editor_add(editor, sizeof(struct node_type_color), "Color", nk_rect(position.x, position.y, 180, 190), 4, 1);
-    colornode->node.slot_spacing.in_top = 72.0f;
-    colornode->node.slot_spacing.in_space = 29.0f;
-    colornode->node.slot_spacing.out_top = 42.0f;
-    colornode->node.slot_spacing.out_space = 0.0f;
+    if (colornode)
+    {
+        int i;
+        struct nk_colorf white = {1.0f, 1.0f, 1.0f, 1.0f};
+        colornode->node.slot_spacing.in_top = 72.0f;
+        colornode->node.slot_spacing.in_space = 29.0f;
+        colornode->node.slot_spacing.out_top = 42.0f;
+        colornode->node.slot_spacing.out_space = 0.0f;
 
-    for (int i = 0; i < colornode->node.input_count; i++)
-        colornode->node.inputs[i].type = fValue;
-    colornode->node.outputs[0].type = fColor;
-    
-    colornode->inputVal[0] = 
-    colornode->inputVal[1] = 
-    colornode->inputVal[2] = 
-    colornode->inputVal[3] = 1.0f;
+        for (i = 0; i < colornode->node.input_count; i++)
+            colornode->node.inputs[i].type = fValue;
+        colornode->node.outputs[0].type = fColor;
+        
+        colornode->inputVal[0] = 
+        colornode->inputVal[1] = 
+        colornode->inputVal[2] = 
+        colornode->inputVal[3] = 1.0f;
 
-    colornode->outputVal = (struct nk_colorf){1.0f, 1.0f, 1.0f, 1.0f};
+        colornode->outputVal = white;
 
-    colornode->node.displayFunc = node_color_draw;
-    colornode->node.evalFunc = node_color_eval;
+        colornode->node.displayFunc = node_color_draw;
+        colornode->node.evalFunc = (void*(*)(struct node*, int)) node_color_eval;
+    }
 }

--- a/demo/common/nodeeditor/node_type_color.c
+++ b/demo/common/nodeeditor/node_type_color.c
@@ -40,27 +40,7 @@ static void node_color_draw(struct nk_context *ctx, struct node* node)
     /* ====================================================*/
 }
 
-/*
-struct node* node_color_init()
+void node_color_create(struct node_editor* editor, struct nk_vec2 position)
 {
-    struct node_type_color *colornode = (struct node_type_color*)malloc(sizeof(struct node_type_color));
-    colornode->node.input_count = 4;
-    colornode->node.output_count = 1;
-
-    colornode->node.inputs = (struct node_connector*)malloc(colornode->node.input_count * sizeof(struct node_connector));
-    for (int i = 0; i < colornode->node.input_count; i++) {
-        colornode->node.inputs[i].type = fValue;
-    }
-    colornode->inputVal = (float*)malloc(colornode->node.input_count * sizeof(float));
-
-
-    colornode->node.outputs = (struct node_connector*)malloc(colornode->node.output_count * sizeof(struct node_connector));
-    colornode->node.outputs->type = fColor;
-    colornode->outputVal = (struct nk_colorf*)malloc(colornode->node.input_count * sizeof(struct nk_colorf));
-
-    colornode->node.displayFunc = node_color_draw;
-    //colornode->node.evalFunc = get_nodetypes_color;
-
-    return (struct node*)colornode; // does this need to return (node*)(&colornode->node) ??
+    struct node *node = node_editor_add(editor, "Color", nk_rect(position.x, position.y, 180, 220), nk_rgb(255, 255, 255), 4, 1);
 }
-*/

--- a/demo/common/nodeeditor/node_type_color.c
+++ b/demo/common/nodeeditor/node_type_color.c
@@ -1,71 +1,72 @@
 struct node_type_color {
     struct node node;
-    float inputVal[4];
-    struct nk_colorf outputVal;
+    float input_val[4];
+    struct nk_colorf output_val;
 };
 
 static struct nk_colorf *node_color_eval(struct node* node, int oIndex)
 {
-    struct node_type_color *colornode = (struct node_type_color*)node;
+    struct node_type_color *color_node = (struct node_type_color*)node;
     NK_ASSERT(oIndex == 0); /* only one output connector */
 
-    return &colornode->outputVal;
+    return &color_node->output_val;
 }
 
 
 static void node_color_draw(struct nk_context *ctx, struct node *node)
 {
-    struct node_type_color *colornode = (struct node_type_color*)node;
-    float evalResult; /* Get the values from connected nodes into this so the inputs revert on disconnect */
+    struct node_type_color *color_node = (struct node_type_color*)node;
+    float eval_result; /* Get the values from connected nodes into this so the inputs revert on disconnect */
     const char* labels[4] = {"#R:","#G:","#B:","#A:"};
-    float colorVals[4]; /* Because we can't just loop through the struct... */
+    float color_val[4]; /* Because we can't just loop through the struct... */
     int i;
     nk_layout_row_dynamic(ctx, 25, 1);
-    nk_button_color(ctx, nk_rgba_cf(colornode->outputVal));
+    nk_button_color(ctx, nk_rgba_cf(color_node->output_val));
     
-    for (i = 0; i < 4; i++) {
-        if (colornode->node.inputs[i].isConnected) {
-            evalResult = *(float*)node_editor_eval_connected(node, i);
-            evalResult = nk_propertyf(ctx, labels[i], evalResult, evalResult, evalResult, 0.01f, 0.01f);
-            colorVals[i] = evalResult;
+    for (i = 0; i < 4; i++) 
+    {
+        if (color_node->node.inputs[i].is_connected) {
+            eval_result = *(float*)node_editor_eval_connected(node, i);
+            eval_result = nk_propertyf(ctx, labels[i], eval_result, eval_result, eval_result, 0.01f, 0.01f);
+            color_val[i] = eval_result;
         }
         else {
-            colornode->inputVal[i] = nk_propertyf(ctx, labels[i], 0.0f, colornode->inputVal[i], 1.0f, 0.01f, 0.01f);
-            colorVals[i] = colornode->inputVal[i];
+            color_node->input_val[i] = nk_propertyf(ctx, labels[i], 0.0f, color_node->input_val[i], 1.0f, 0.01f, 0.01f);
+            color_val[i] = color_node->input_val[i];
         }
     }
 
-    colornode->outputVal.r = colorVals[0];
-    colornode->outputVal.g = colorVals[1];
-    colornode->outputVal.b = colorVals[2];
-    colornode->outputVal.a = colorVals[3];
+    color_node->output_val.r = color_val[0];
+    color_node->output_val.g = color_val[1];
+    color_node->output_val.b = color_val[2];
+    color_node->output_val.a = color_val[3];
 }
 
 void node_color_create(struct node_editor *editor, struct nk_vec2 position)
 {
-    struct node_type_color *colornode = (struct node_type_color*)node_editor_add(editor, sizeof(struct node_type_color), "Color", nk_rect(position.x, position.y, 180, 190), 4, 1);
-    if (colornode)
+    struct node_type_color *color_node = (struct node_type_color*)node_editor_add(editor, sizeof(struct node_type_color), "Color", nk_rect(position.x, position.y, 180, 190), 4, 1);
+    if (color_node)
     {
         int i;
         const struct nk_colorf white = {1.0f, 1.0f, 1.0f, 1.0f};
         
-        colornode->node.slot_spacing.in_top = 72.0f;
-        colornode->node.slot_spacing.in_space = 29.0f;
-        colornode->node.slot_spacing.out_top = 42.0f;
-        colornode->node.slot_spacing.out_space = 0.0f;
+        color_node->node.slot_spacing.in_top = 72.0f;
+        color_node->node.slot_spacing.in_space = 29.0f;
+        color_node->node.slot_spacing.out_top = 42.0f;
+        color_node->node.slot_spacing.out_space = 0.0f;
 
-        for (i = 0; i < colornode->node.input_count; i++)
-            colornode->node.inputs[i].type = fValue;
-        colornode->node.outputs[0].type = fColor;
+        for (i = 0; i < color_node->node.input_count; i++)
+            color_node->node.inputs[i].type = fValue;
+        color_node->node.outputs[0].type = fColor;
         
-        colornode->inputVal[0] = 
-        colornode->inputVal[1] = 
-        colornode->inputVal[2] = 
-        colornode->inputVal[3] = 1.0f;
+        color_node->input_val[0] = 
+        color_node->input_val[1] = 
+        color_node->input_val[2] = 
+        color_node->input_val[3] = 1.0f;
 
-        colornode->outputVal = white;
+        color_node->output_val = white;
 
-        colornode->node.displayFunc = node_color_draw;
-        colornode->node.evalFunc = (void*(*)(struct node*, int)) node_color_eval;
+        color_node->node.display_func = node_color_draw;
+        color_node->node.eval_func = (void*(*)(struct node*, int)) node_color_eval;
     }
 }

--- a/demo/common/nodeeditor/node_type_color.c
+++ b/demo/common/nodeeditor/node_type_color.c
@@ -2,7 +2,6 @@ struct node_type_color {
     struct node node;
     float inputVal[4];
     struct nk_colorf outputVal;
-
 };
 
 /*
@@ -28,7 +27,7 @@ static void* node_color_get(struct node* self, int oIndex)
 }*/
 
 
-static void node_color_draw(struct nk_context *ctx, struct node* node)
+static void node_color_draw(struct nk_context *ctx, struct node *node)
 {
     struct node_type_color *colornode = (struct node_type_color*)node;
     nk_layout_row_dynamic(ctx, 25, 1);
@@ -39,7 +38,7 @@ static void node_color_draw(struct nk_context *ctx, struct node* node)
     colornode->inputVal[1] = colornode->node.inputs[1].isConnected ?
         nk_propertyf(ctx, "#G:", colornode->inputVal[1], colornode->inputVal[1], colornode->inputVal[1], 0.05f, 0.05f) :
         nk_propertyf(ctx, "#G:", 0.0f, colornode->inputVal[1], 1.0f, 0.01f, 0.01f);
-    colornode->inputVal[2] = colornode->node.inputs[0].isConnected ?
+    colornode->inputVal[2] = colornode->node.inputs[2].isConnected ?
         nk_propertyf(ctx, "#B:", colornode->inputVal[2], colornode->inputVal[2], colornode->inputVal[2], 0.05f, 0.05f) :
         nk_propertyf(ctx, "#B:", 0.0f, colornode->inputVal[2], 1.0f, 0.01f, 0.01f);
     colornode->inputVal[3] = colornode->node.inputs[3].isConnected ?
@@ -47,12 +46,9 @@ static void node_color_draw(struct nk_context *ctx, struct node* node)
         nk_propertyf(ctx, "#A:", 0.0f, colornode->inputVal[3], 1.0f, 0.01f, 0.01f);
 }
 
-void node_color_create(struct node_editor* editor, struct nk_vec2 position)
+void node_color_create(struct node_editor *editor, struct nk_vec2 position)
 {
-    /* Not sure if this allocation should be in node_editor_add. Maybe just pass the size, and get the pointer back? */
-    struct node_type_color *colornode = (struct node_type_color*)malloc(sizeof(struct node_type_color));
-
-    node_editor_add(editor, (struct node*)colornode, "Color", nk_rect(position.x, position.y, 180, 220), 4, 1);
+    struct node_type_color *colornode = (struct node_type_color*)node_editor_add(editor, sizeof(struct node_type_color), "Color", nk_rect(position.x, position.y, 180, 220), 4, 1);
     colornode->node.slot_spacing.in_top = 72.0f;
     colornode->node.slot_spacing.in_space = 29.0f;
     colornode->node.slot_spacing.out_top = 42.0f;

--- a/demo/common/nodeeditor/node_type_color.c
+++ b/demo/common/nodeeditor/node_type_color.c
@@ -1,7 +1,7 @@
 struct node_type_color {
     struct node node;
-    float *inputVal;
-    struct nk_colorf *outputVal;
+    float inputVal[4];
+    struct nk_colorf outputVal;
 
 };
 
@@ -30,25 +30,44 @@ static void* node_color_get(struct node* self, int oIndex)
 
 static void node_color_draw(struct nk_context *ctx, struct node* node)
 {
-    /* ================= NODE CONTENT =====================*/
+    struct node_type_color *colornode = (struct node_type_color*)node;
     nk_layout_row_dynamic(ctx, 25, 1);
-    nk_button_color(ctx, node->color);
-    node->color.r = (nk_byte)nk_propertyi(ctx, "#R:", 0, node->color.r, 255, 1,1);
-    node->color.g = (nk_byte)nk_propertyi(ctx, "#G:", 0, node->color.g, 255, 1,1);
-    node->color.b = (nk_byte)nk_propertyi(ctx, "#B:", 0, node->color.b, 255, 1,1);
-    node->color.a = (nk_byte)nk_propertyi(ctx, "#A:", 0, node->color.a, 255, 1,1);
-    /* ====================================================*/
+    nk_button_color(ctx, nk_rgba_f(colornode->inputVal[0],colornode->inputVal[1],colornode->inputVal[2],colornode->inputVal[3]));
+    colornode->inputVal[0] = colornode->node.inputs[0].isConnected ?
+        nk_propertyf(ctx, "#R:", colornode->inputVal[0], colornode->inputVal[0], colornode->inputVal[0], 0.05f, 0.05f) :
+        nk_propertyf(ctx, "#R:", 0.0f, colornode->inputVal[0], 1.0f, 0.01f, 0.01f);
+    colornode->inputVal[1] = colornode->node.inputs[1].isConnected ?
+        nk_propertyf(ctx, "#G:", colornode->inputVal[1], colornode->inputVal[1], colornode->inputVal[1], 0.05f, 0.05f) :
+        nk_propertyf(ctx, "#G:", 0.0f, colornode->inputVal[1], 1.0f, 0.01f, 0.01f);
+    colornode->inputVal[2] = colornode->node.inputs[0].isConnected ?
+        nk_propertyf(ctx, "#B:", colornode->inputVal[2], colornode->inputVal[2], colornode->inputVal[2], 0.05f, 0.05f) :
+        nk_propertyf(ctx, "#B:", 0.0f, colornode->inputVal[2], 1.0f, 0.01f, 0.01f);
+    colornode->inputVal[3] = colornode->node.inputs[3].isConnected ?
+        nk_propertyf(ctx, "#A:", colornode->inputVal[3], colornode->inputVal[3], colornode->inputVal[3], 0.05f, 0.05f) :
+        nk_propertyf(ctx, "#A:", 0.0f, colornode->inputVal[3], 1.0f, 0.01f, 0.01f);
 }
 
 void node_color_create(struct node_editor* editor, struct nk_vec2 position)
 {
-    struct node *node = node_editor_add(editor, "Color", nk_rect(position.x, position.y, 180, 220), nk_rgb(255, 255, 255), 4, 1);
-    node->slot_spacing.in_top = 72.0f;
-    node->slot_spacing.in_space = 29.0f;
-    node->slot_spacing.out_top = 42.0f;
-    node->slot_spacing.out_space = 0.0f;
+    /* Not sure if this allocation should be in node_editor_add. Maybe just pass the size, and get the pointer back? */
+    struct node_type_color *colornode = (struct node_type_color*)malloc(sizeof(struct node_type_color));
+
+    node_editor_add(editor, (struct node*)colornode, "Color", nk_rect(position.x, position.y, 180, 220), 4, 1);
+    colornode->node.slot_spacing.in_top = 72.0f;
+    colornode->node.slot_spacing.in_space = 29.0f;
+    colornode->node.slot_spacing.out_top = 42.0f;
+    colornode->node.slot_spacing.out_space = 0.0f;
+
+    for (int i = 0; i < colornode->node.input_count; i++)
+        colornode->node.inputs[i].type = fValue;
+    colornode->node.outputs[0].type = fColor;
     
-    for (int i = 0; i < node->input_count; i++)
-        node->inputs[i].type = fValue;
-    node->outputs[0].type = fColor;
+    colornode->inputVal[0] = 
+    colornode->inputVal[1] = 
+    colornode->inputVal[2] = 
+    colornode->inputVal[3] = 1.0f;
+
+    colornode->outputVal = (struct nk_colorf){1.0f, 1.0f, 1.0f, 1.0f};
+
+    colornode->node.displayFunc = node_color_draw;
 }

--- a/demo/common/nodeeditor/node_type_float.c
+++ b/demo/common/nodeeditor/node_type_float.c
@@ -1,26 +1,26 @@
 struct node_type_float {
     struct node node;
-    float outputVal;
+    float output_val;
 };
 
 static float *node_float_eval(struct node* node, int oIndex) {
-    struct node_type_float *floatnode = (struct node_type_float*)node;
+    struct node_type_float *float_node = (struct node_type_float*)node;
     NK_ASSERT(oIndex == 0);
-    return &floatnode->outputVal;
+    return &float_node->output_val;
 }
 
 static void node_float_draw(struct nk_context *ctx, struct node *node) {
-    struct node_type_float *floatnode = (struct node_type_float*)node;
+    struct node_type_float *float_node = (struct node_type_float*)node;
     nk_layout_row_dynamic(ctx, 25, 1);
-    floatnode->outputVal = nk_propertyf(ctx, "#Value:", 0.0f, floatnode->outputVal, 1.0f, 0.01f, 0.01f);
+    float_node->output_val = nk_propertyf(ctx, "#Value:", 0.0f, float_node->output_val, 1.0f, 0.01f, 0.01f);
 }
 
 void node_float_create(struct node_editor *editor, struct nk_vec2 position) {
-    struct node_type_float *floatnode = (struct node_type_float*)node_editor_add(editor, sizeof(struct node_type_float), "Float", nk_rect(position.x, position.y, 180, 75), 0, 1);
-    if (floatnode)
+    struct node_type_float *float_node = (struct node_type_float*)node_editor_add(editor, sizeof(struct node_type_float), "Float", nk_rect(position.x, position.y, 180, 75), 0, 1);
+    if (float_node)
     {
-        floatnode->outputVal = 1.0f;
-        floatnode->node.displayFunc = node_float_draw;
-        floatnode->node.evalFunc = (void*(*)(struct node*, int)) node_float_eval;
+        float_node->output_val = 1.0f;
+        float_node->node.display_func = node_float_draw;
+        float_node->node.eval_func = (void*(*)(struct node*, int)) node_float_eval;
     }
 }

--- a/demo/common/nodeeditor/node_type_float.c
+++ b/demo/common/nodeeditor/node_type_float.c
@@ -6,8 +6,8 @@ struct node_type_float {
 };
 
 static float *node_float_eval(struct node* node, int oIndex) {
-    NK_ASSERT(oIndex == 0);
     struct node_type_float *floatnode = (struct node_type_float*)node;
+    NK_ASSERT(oIndex == 0);
     return &floatnode->outputVal;
 }
 
@@ -19,8 +19,10 @@ static void node_float_draw(struct nk_context *ctx, struct node *node) {
 
 void node_float_create(struct node_editor *editor, struct nk_vec2 position) {
     struct node_type_float *floatnode = (struct node_type_float*)node_editor_add(editor, sizeof(struct node_type_float), "Float", nk_rect(position.x, position.y, 180, 75), 0, 1);
-
-    floatnode->outputVal = 1.0f;
-    floatnode->node.displayFunc = node_float_draw;
-    floatnode->node.evalFunc = node_float_eval;
+    if (floatnode)
+    {
+        floatnode->outputVal = 1.0f;
+        floatnode->node.displayFunc = node_float_draw;
+        floatnode->node.evalFunc = (void*(*)(struct node*, int)) node_float_eval;
+    }
 }

--- a/demo/common/nodeeditor/node_type_float.c
+++ b/demo/common/nodeeditor/node_type_float.c
@@ -1,3 +1,5 @@
+#include <float.h>
+
 struct node_type_float {
     struct node node;
     float outputVal;
@@ -12,11 +14,11 @@ static float *node_float_eval(struct node* node, int oIndex) {
 static void node_float_draw(struct nk_context *ctx, struct node *node) {
     struct node_type_float *floatnode = (struct node_type_float*)node;
     nk_layout_row_dynamic(ctx, 25, 1);
-    floatnode->outputVal = nk_propertyf(ctx, "#Value:", 0.0f, floatnode->outputVal, 1.0f, 0.01f, 0.01f);
+    floatnode->outputVal = nk_propertyf(ctx, "#Value:", -FLT_MAX, floatnode->outputVal, FLT_MAX, 0.01f, 0.01f);
 }
 
 void node_float_create(struct node_editor *editor, struct nk_vec2 position) {
-    struct node_type_float *floatnode = (struct node_type_float*)node_editor_add(editor, sizeof(struct node_type_float), "Float", nk_rect(position.x, position.y, 180, 100), 0, 1);
+    struct node_type_float *floatnode = (struct node_type_float*)node_editor_add(editor, sizeof(struct node_type_float), "Float", nk_rect(position.x, position.y, 180, 75), 0, 1);
 
     floatnode->outputVal = 1.0f;
     floatnode->node.displayFunc = node_float_draw;

--- a/demo/common/nodeeditor/node_type_float.c
+++ b/demo/common/nodeeditor/node_type_float.c
@@ -3,6 +3,12 @@ struct node_type_float {
     float outputVal;
 };
 
+static float *node_float_eval(struct node* node, int oIndex) {
+    NK_ASSERT(oIndex == 0);
+    struct node_type_float *floatnode = (struct node_type_float*)node;
+    return &floatnode->outputVal;
+}
+
 static void node_float_draw(struct nk_context *ctx, struct node *node) {
     struct node_type_float *floatnode = (struct node_type_float*)node;
     nk_layout_row_dynamic(ctx, 25, 1);
@@ -14,4 +20,5 @@ void node_float_create(struct node_editor *editor, struct nk_vec2 position) {
 
     floatnode->outputVal = 1.0f;
     floatnode->node.displayFunc = node_float_draw;
+    floatnode->node.evalFunc = node_float_eval;
 }

--- a/demo/common/nodeeditor/node_type_float.c
+++ b/demo/common/nodeeditor/node_type_float.c
@@ -1,5 +1,3 @@
-#include <float.h>
-
 struct node_type_float {
     struct node node;
     float outputVal;
@@ -14,7 +12,7 @@ static float *node_float_eval(struct node* node, int oIndex) {
 static void node_float_draw(struct nk_context *ctx, struct node *node) {
     struct node_type_float *floatnode = (struct node_type_float*)node;
     nk_layout_row_dynamic(ctx, 25, 1);
-    floatnode->outputVal = nk_propertyf(ctx, "#Value:", -FLT_MAX, floatnode->outputVal, FLT_MAX, 0.01f, 0.01f);
+    floatnode->outputVal = nk_propertyf(ctx, "#Value:", 0.0f, floatnode->outputVal, 1.0f, 0.01f, 0.01f);
 }
 
 void node_float_create(struct node_editor *editor, struct nk_vec2 position) {

--- a/demo/common/nodeeditor/node_type_float.c
+++ b/demo/common/nodeeditor/node_type_float.c
@@ -1,0 +1,17 @@
+struct node_type_float {
+    struct node node;
+    float outputVal;
+};
+
+static void node_float_draw(struct nk_context *ctx, struct node *node) {
+    struct node_type_float *floatnode = (struct node_type_float*)node;
+    nk_layout_row_dynamic(ctx, 25, 1);
+    floatnode->outputVal = nk_propertyf(ctx, "#Value:", 0.0f, floatnode->outputVal, 1.0f, 0.01f, 0.01f);
+}
+
+void node_float_create(struct node_editor *editor, struct nk_vec2 position) {
+    struct node_type_float *floatnode = (struct node_type_float*)node_editor_add(editor, sizeof(struct node_type_float), "Float", nk_rect(position.x, position.y, 180, 100), 0, 1);
+
+    floatnode->outputVal = 1.0f;
+    floatnode->node.displayFunc = node_float_draw;
+}

--- a/demo/common/nodeeditor/node_type_output.c
+++ b/demo/common/nodeeditor/node_type_output.c
@@ -5,8 +5,10 @@ struct node_type_output {
 
 struct nk_colorf *node_output_get(struct node* node) {
     struct node_type_output *outputnode = (struct node_type_output*)node;
-    if (!node->inputs[0].isConnected)
-        outputnode->inputVal = (struct nk_colorf){0.0f, 0.0f, 0.0f, 0.0f};
+    if (!node->inputs[0].isConnected) {
+        struct nk_colorf black = {0.0f, 0.0f, 0.0f, 0.0f};
+        outputnode->inputVal = black;
+    }
     return &outputnode->inputVal;
 }
 
@@ -21,8 +23,9 @@ static void node_output_display(struct nk_context *ctx, struct node *node) {
 
 struct node* node_output_create(struct node_editor *editor, struct nk_vec2 position) {
     struct node_type_output *outputNode = (struct node_type_output*)node_editor_add(editor, sizeof(struct node_type_output), "Output", nk_rect(position.x, position.y, 100, 100), 1, 0);
-    
-    outputNode->node.inputs[0].type = fColor;
-    outputNode->node.displayFunc = node_output_display;
-    return outputNode;
+    if (outputNode){
+        outputNode->node.inputs[0].type = fColor;
+        outputNode->node.displayFunc = node_output_display;
+    }
+    return (struct node*)outputNode;
 }

--- a/demo/common/nodeeditor/node_type_output.c
+++ b/demo/common/nodeeditor/node_type_output.c
@@ -1,15 +1,20 @@
 struct node_type_output {
     struct node node;
-    struct nk_color inputVal;
+    struct nk_colorf inputVal;
 };
 
 static void node_output_display(struct nk_context *ctx, struct node *node) {
-
+    if (node->inputs[0].isConnected) {
+        struct nk_colorf inputVal = *(struct nk_colorf*)(node->inputs[0].connectedNode->evalFunc(node->inputs[0].connectedNode, node->inputs[0].connectedSlot));
+        nk_layout_row_dynamic(ctx, 25, 1);
+        nk_button_color(ctx, nk_rgba_cf(inputVal));
+    }
 }
 
-void node_output_create(struct node_editor *editor, struct nk_vec2 position) {
+struct node* node_output_create(struct node_editor *editor, struct nk_vec2 position) {
     struct node_type_output *outputNode = (struct node_type_output*)node_editor_add(editor, sizeof(struct node_type_output), "Output", nk_rect(position.x, position.y, 100, 100), 1, 0);
     
     outputNode->node.inputs[0].type = fColor;
     outputNode->node.displayFunc = node_output_display;
+    return outputNode;
 }

--- a/demo/common/nodeeditor/node_type_output.c
+++ b/demo/common/nodeeditor/node_type_output.c
@@ -1,31 +1,31 @@
 struct node_type_output {
     struct node node;
-    struct nk_colorf inputVal;
+    struct nk_colorf input_val;
 };
 
 struct nk_colorf *node_output_get(struct node* node) {
-    struct node_type_output *outputnode = (struct node_type_output*)node;
-    if (!node->inputs[0].isConnected) {
+    struct node_type_output *output_node = (struct node_type_output*)node;
+    if (!node->inputs[0].is_connected) {
         struct nk_colorf black = {0.0f, 0.0f, 0.0f, 0.0f};
-        outputnode->inputVal = black;
+        output_node->input_val = black;
     }
-    return &outputnode->inputVal;
+    return &output_node->input_val;
 }
 
 static void node_output_display(struct nk_context *ctx, struct node *node) {
-    if (node->inputs[0].isConnected) {
-        struct node_type_output *outputnode = (struct node_type_output*)node;
-        outputnode->inputVal = *(struct nk_colorf*)node_editor_eval_connected(node, 0);
+    if (node->inputs[0].is_connected) {
+        struct node_type_output *output_node = (struct node_type_output*)node;
+        output_node->input_val = *(struct nk_colorf*)node_editor_eval_connected(node, 0);
         nk_layout_row_dynamic(ctx, 60, 1);
-        nk_button_color(ctx, nk_rgba_cf(outputnode->inputVal)); 
+        nk_button_color(ctx, nk_rgba_cf(output_node->input_val)); 
     }
 }
 
 struct node* node_output_create(struct node_editor *editor, struct nk_vec2 position) {
-    struct node_type_output *outputNode = (struct node_type_output*)node_editor_add(editor, sizeof(struct node_type_output), "Output", nk_rect(position.x, position.y, 100, 100), 1, 0);
-    if (outputNode){
-        outputNode->node.inputs[0].type = fColor;
-        outputNode->node.displayFunc = node_output_display;
+    struct node_type_output *output_node = (struct node_type_output*)node_editor_add(editor, sizeof(struct node_type_output), "Output", nk_rect(position.x, position.y, 100, 100), 1, 0);
+    if (output_node){
+        output_node->node.inputs[0].type = fColor;
+        output_node->node.display_func = node_output_display;
     }
-    return (struct node*)outputNode;
+    return (struct node*)output_node;
 }

--- a/demo/common/nodeeditor/node_type_output.c
+++ b/demo/common/nodeeditor/node_type_output.c
@@ -1,0 +1,15 @@
+struct node_type_output {
+    struct node node;
+    struct nk_color inputVal;
+};
+
+static void node_output_display(struct nk_context *ctx, struct node *node) {
+
+}
+
+void node_output_create(struct node_editor *editor, struct nk_vec2 position) {
+    struct node_type_output *outputNode = (struct node_type_output*)node_editor_add(editor, sizeof(struct node_type_output), "Output", nk_rect(position.x, position.y, 100, 100), 1, 0);
+    
+    outputNode->node.inputs[0].type = fColor;
+    outputNode->node.displayFunc = node_output_display;
+}

--- a/demo/common/nodeeditor/node_type_output.c
+++ b/demo/common/nodeeditor/node_type_output.c
@@ -3,11 +3,19 @@ struct node_type_output {
     struct nk_colorf inputVal;
 };
 
+struct nk_colorf *node_output_get(struct node* node) {
+    struct node_type_output *outputnode = (struct node_type_output*)node;
+    if (!node->inputs[0].isConnected)
+        outputnode->inputVal = (struct nk_colorf){0.0f, 0.0f, 0.0f, 0.0f};
+    return &outputnode->inputVal;
+}
+
 static void node_output_display(struct nk_context *ctx, struct node *node) {
     if (node->inputs[0].isConnected) {
-        struct nk_colorf inputVal = *(struct nk_colorf*)(node->inputs[0].connectedNode->evalFunc(node->inputs[0].connectedNode, node->inputs[0].connectedSlot));
-        nk_layout_row_dynamic(ctx, 25, 1);
-        nk_button_color(ctx, nk_rgba_cf(inputVal));
+        struct node_type_output *outputnode = (struct node_type_output*)node;
+        outputnode->inputVal = *(struct nk_colorf*)node_editor_eval_connected(node, 0);
+        nk_layout_row_dynamic(ctx, 60, 1);
+        nk_button_color(ctx, nk_rgba_cf(outputnode->inputVal)); 
     }
 }
 

--- a/demo/glfw_opengl3/main.c
+++ b/demo/glfw_opengl3/main.c
@@ -9,7 +9,8 @@
 #include <limits.h>
 #include <time.h>
 
-#include <GL/glew.h>
+#define GL_SILENCE_DEPRECATION
+/* #include <GL/glew.h> */
 #include <GLFW/glfw3.h>
 
 #define NK_INCLUDE_FIXED_TYPES
@@ -42,8 +43,8 @@
 /*#define INCLUDE_STYLE */
 /*#define INCLUDE_CALCULATOR */
 /*#define INCLUDE_CANVAS */
-#define INCLUDE_OVERVIEW
-/*#define INCLUDE_NODE_EDITOR */
+/*#define INCLUDE_OVERVIEW */
+#define INCLUDE_NODE_EDITOR */
 
 #ifdef INCLUDE_ALL
   #define INCLUDE_STYLE
@@ -104,11 +105,11 @@ int main(void)
 
     /* OpenGL */
     glViewport(0, 0, WINDOW_WIDTH, WINDOW_HEIGHT);
-    glewExperimental = 1;
+    /*glewExperimental = 1;
     if (glewInit() != GLEW_OK) {
         fprintf(stderr, "Failed to setup GLEW\n");
         exit(1);
-    }
+    }*/
 
     ctx = nk_glfw3_init(&glfw, win, NK_GLFW3_INSTALL_CALLBACKS);
     /* Load Fonts: if none of these are loaded a default font will be used  */
@@ -191,7 +192,7 @@ int main(void)
           overview(ctx);
         #endif
         #ifdef INCLUDE_NODE_EDITOR
-          node_editor(ctx);
+          node_editor_main(ctx);
         #endif
         /* ----------------------------------------- */
 

--- a/demo/glfw_opengl3/main.c
+++ b/demo/glfw_opengl3/main.c
@@ -9,8 +9,7 @@
 #include <limits.h>
 #include <time.h>
 
-#define GL_SILENCE_DEPRECATION
-/* #include <GL/glew.h> */
+#include <GL/glew.h>
 #include <GLFW/glfw3.h>
 
 #define NK_INCLUDE_FIXED_TYPES
@@ -43,8 +42,8 @@
 /*#define INCLUDE_STYLE */
 /*#define INCLUDE_CALCULATOR */
 /*#define INCLUDE_CANVAS */
-/*#define INCLUDE_OVERVIEW */
-#define INCLUDE_NODE_EDITOR */
+#define INCLUDE_OVERVIEW
+/*#define INCLUDE_NODE_EDITOR */
 
 #ifdef INCLUDE_ALL
   #define INCLUDE_STYLE
@@ -105,11 +104,11 @@ int main(void)
 
     /* OpenGL */
     glViewport(0, 0, WINDOW_WIDTH, WINDOW_HEIGHT);
-    /*glewExperimental = 1;
+    glewExperimental = 1;
     if (glewInit() != GLEW_OK) {
         fprintf(stderr, "Failed to setup GLEW\n");
         exit(1);
-    }*/
+    }
 
     ctx = nk_glfw3_init(&glfw, win, NK_GLFW3_INSTALL_CALLBACKS);
     /* Load Fonts: if none of these are loaded a default font will be used  */
@@ -192,7 +191,7 @@ int main(void)
           overview(ctx);
         #endif
         #ifdef INCLUDE_NODE_EDITOR
-          node_editor_main(ctx);
+          node_editor(ctx);
         #endif
         /* ----------------------------------------- */
 


### PR DESCRIPTION
This PR expands on the node editor demo to make it a functional example of a node-based UI.

Features: 
- multiple node types
- multiple connector types
- linking between connectors of the same type
- detaching and reattaching links
- getting value from linked node if slot is connected

![node_editor](https://github.com/Immediate-Mode-UI/Nuklear/assets/614951/a4d66b14-93e2-471c-9f4d-2397449d61d3)

Some notes:
- only tested with the glfw_opengl3 backend
- uses system malloc, not sure if nk_malloc should be preferred.
- uses the standard panel close button , then checks for NK_WINDOW_HIDDEN whether to delete a node or display it. Not sure if there's some pitfall here.