### PR TITLE
Fix click drag on touch + WebBroswers

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -17898,6 +17898,10 @@ nk_input_button(struct nk_context *ctx, enum nk_buttons id, int x, int y, nk_boo
     btn->clicked_pos.y = (float)y;
     btn->down = down;
     btn->clicked++;
+
+    /* Fix Click-Drag for touch events. */
+    in->mouse.delta.x = 0;
+    in->mouse.delta.y = 0;
 #ifdef NK_BUTTON_TRIGGER_ON_RELEASE
     if (down == 1 && id == NK_BUTTON_LEFT)
     {

--- a/src/nuklear_input.c
+++ b/src/nuklear_input.c
@@ -83,6 +83,10 @@ nk_input_button(struct nk_context *ctx, enum nk_buttons id, int x, int y, nk_boo
     btn->clicked_pos.y = (float)y;
     btn->down = down;
     btn->clicked++;
+
+    /* Fix Click-Drag for touch events. */
+    in->mouse.delta.x = 0;
+    in->mouse.delta.y = 0;
 #ifdef NK_BUTTON_TRIGGER_ON_RELEASE
     if (down == 1 && id == NK_BUTTON_LEFT)
     {


### PR DESCRIPTION
This one has been driving me insane. Each time I tested my WebApp on a touch device, like a Smartphone, tablet, iPad, what have you, Window resizing and the property click-drag behavior was busted. Touch works a bit differently on Webbrosers and doesn't update the mouse position regularly, which leads to huge deltas, as Nuklear just saves the previous frame's mouse position.

This PR fixes this but setting the drag during the click part of the click-drag to zero. This fixes the breaking behaviour in the video below. Why this doesn't occur on Scrollbars and Window dragging, I'm not sure, but this seems to be a fix without having a negative effect on other things.

https://github.com/Immediate-Mode-UI/Nuklear/assets/60887273/f52751e8-b481-4430-97f6-ae884fb5a96d

