### PR TITLE
Fix fragment shader bindless handle assertion in glfw-gl4 backend

### DIFF
--- a/clib.json
+++ b/clib.json
@@ -1,6 +1,6 @@
 {
   "name": "nuklear",
-  "version": "4.10.6",
+  "version": "4.10.7",
   "repo": "Immediate-Mode-UI/Nuklear",
   "description": "A small ANSI C gui toolkit",
   "keywords": ["gl", "ui", "toolkit"],

--- a/demo/glfw_opengl4/nuklear_glfw_gl4.h
+++ b/demo/glfw_opengl4/nuklear_glfw_gl4.h
@@ -137,7 +137,7 @@ nk_glfw3_device_create()
         NK_SHADER_BINDLESS
         NK_SHADER_64BIT
         "precision mediump float;\n"
-        "uniform uint64_t Texture;\n"
+        "uniform uvec2 Texture;\n"
         "in vec2 Frag_UV;\n"
         "in vec4 Frag_Color;\n"
         "out vec4 Out_Color;\n"
@@ -436,7 +436,7 @@ nk_glfw3_render(enum nk_anti_aliasing AA)
             if (!glIsTextureHandleResidentARB(tex_handle))
                 glMakeTextureHandleResidentARB(tex_handle);
 
-            glUniformHandleui64ARB(dev->uniform_tex, tex_handle);
+            glUniform2ui(dev->uniform_tex, tex_handle, tex_handle >> 32);
             glScissor(
                 (GLint)(cmd->clip_rect.x * glfw.fb_scale.x),
                 (GLint)((glfw.height - (GLint)(cmd->clip_rect.y + cmd->clip_rect.h)) * glfw.fb_scale.y),

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -7,6 +7,7 @@
 ///   - [y]: Minor version with non-breaking API and library changes
 ///   - [z]: Patch version with no direct changes to the API
 ///
+/// - 2022/12/23 (4.10.7) - Fix glfw-gl4 assertion faillure
 /// - 2022/12/23 (4.10.6) - Fix incorrect glyph index in nk_font_bake()
 /// - 2022/12/17 (4.10.5) - Fix nk_font_bake_pack() using TTC font offset incorrectly
 /// - 2022/10/24 (4.10.4) - Fix nk_str_{append,insert}_str_utf8 always returning 0

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -7,7 +7,7 @@
 ///   - [y]: Minor version with non-breaking API and library changes
 ///   - [z]: Patch version with no direct changes to the API
 ///
-/// - 2022/12/23 (4.10.7) - Fix glfw-gl4 assertion faillure
+/// - 2023/10/11 (4.10.7) - Fix glfw-gl4 assertion faillure
 /// - 2022/12/23 (4.10.6) - Fix incorrect glyph index in nk_font_bake()
 /// - 2022/12/17 (4.10.5) - Fix nk_font_bake_pack() using TTC font offset incorrectly
 /// - 2022/10/24 (4.10.4) - Fix nk_str_{append,insert}_str_utf8 always returning 0


### PR DESCRIPTION
I came across #190 while trying to play with the glfw-gl4 backend, some research lead me to the issue and I noticed someone had provided a fix.

Before creating the PR, I had a look at both open and closed PRs to make sure this isn't a duplicate (hopefully I haven't missed a PR with tthese changes)

This PR is meant to introduce the fix @KreideGit gracefuly provided in #190 into the repository. 