### PR TITLE
Fix null deref with y_offset in nk_group and nk_listview

### DIFF
--- a/clib.json
+++ b/clib.json
@@ -1,6 +1,6 @@
 {
   "name": "nuklear",
-  "version": "4.10.6",
+  "version": "4.10.7",
   "repo": "Immediate-Mode-UI/Nuklear",
   "description": "A small ANSI C gui toolkit",
   "keywords": ["gl", "ui", "toolkit"],

--- a/nuklear.h
+++ b/nuklear.h
@@ -22877,7 +22877,15 @@ nk_group_get_scroll(struct nk_context *ctx, const char *id, nk_uint *x_offset, n
         NK_ASSERT(y_offset_ptr);
         if (!x_offset_ptr || !y_offset_ptr) return;
         *x_offset_ptr = *y_offset_ptr = 0;
-    } else y_offset_ptr = nk_find_value(win, id_hash+1);
+    } else {
+        y_offset_ptr = nk_find_value(win, id_hash+1);
+        if (!y_offset_ptr) {
+            y_offset_ptr = nk_add_value(ctx, win, id_hash+1, 0);
+            NK_ASSERT(y_offset_ptr);
+            if (!y_offset_ptr) return;
+            *y_offset_ptr = 0;
+        }
+    }
     if (x_offset)
       *x_offset = *x_offset_ptr;
     if (y_offset)
@@ -22912,7 +22920,15 @@ nk_group_set_scroll(struct nk_context *ctx, const char *id, nk_uint x_offset, nk
         NK_ASSERT(y_offset_ptr);
         if (!x_offset_ptr || !y_offset_ptr) return;
         *x_offset_ptr = *y_offset_ptr = 0;
-    } else y_offset_ptr = nk_find_value(win, id_hash+1);
+    } else {
+        y_offset_ptr = nk_find_value(win, id_hash+1);
+        if (!y_offset_ptr) {
+            y_offset_ptr = nk_add_value(ctx, win, id_hash+1, 0);
+            NK_ASSERT(y_offset_ptr);
+            if (!y_offset_ptr) return;
+            *y_offset_ptr = 0;
+        }
+    }
     *x_offset_ptr = x_offset;
     *y_offset_ptr = y_offset;
 }
@@ -22962,7 +22978,15 @@ nk_list_view_begin(struct nk_context *ctx, struct nk_list_view *view,
         NK_ASSERT(y_offset);
         if (!x_offset || !y_offset) return 0;
         *x_offset = *y_offset = 0;
-    } else y_offset = nk_find_value(win, title_hash+1);
+    } else {
+        y_offset = nk_find_value(win, title_hash+1);
+        if (!y_offset) {
+            y_offset = nk_add_value(ctx, win, title_hash+1, 0);
+            NK_ASSERT(y_offset);
+            if (!y_offset) return 0;
+            *y_offset = 0;
+        }
+    }
     view->scroll_value = *y_offset;
     view->scroll_pointer = y_offset;
 

--- a/nuklear.h
+++ b/nuklear.h
@@ -29741,6 +29741,7 @@ nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)
 ///   - [y]: Minor version with non-breaking API and library changes
 ///   - [z]: Patch version with no direct changes to the API
 ///
+/// - 2023/11/03 (4.10.7) - Fix null pointer dereference with nk_group and nk_listview scroll offsets
 /// - 2022/12/23 (4.10.6) - Fix incorrect glyph index in nk_font_bake()
 /// - 2022/12/17 (4.10.5) - Fix nk_font_bake_pack() using TTC font offset incorrectly
 /// - 2022/10/24 (4.10.4) - Fix nk_str_{append,insert}_str_utf8 always returning 0

--- a/nuklear.h
+++ b/nuklear.h
@@ -22827,7 +22827,15 @@ nk_group_begin_titled(struct nk_context *ctx, const char *id,
         NK_ASSERT(y_offset);
         if (!x_offset || !y_offset) return 0;
         *x_offset = *y_offset = 0;
-    } else y_offset = nk_find_value(win, id_hash+1);
+    } else {
+        y_offset = nk_find_value(win, id_hash+1);
+        if (!y_offset) {
+            y_offset = nk_add_value(ctx, win, id_hash+1, 0);
+            NK_ASSERT(y_offset);
+            if (!y_offset) return 0;
+            *y_offset = 0;
+        }
+    }
     return nk_group_scrolled_offset_begin(ctx, x_offset, y_offset, title, flags);
 }
 NK_API nk_bool

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -7,6 +7,7 @@
 ///   - [y]: Minor version with non-breaking API and library changes
 ///   - [z]: Patch version with no direct changes to the API
 ///
+/// - 2023/10/30 (4.10.7) - Fix null pointer dereference in nk_group_scrolled_offset_begin()
 /// - 2022/12/23 (4.10.6) - Fix incorrect glyph index in nk_font_bake()
 /// - 2022/12/17 (4.10.5) - Fix nk_font_bake_pack() using TTC font offset incorrectly
 /// - 2022/10/24 (4.10.4) - Fix nk_str_{append,insert}_str_utf8 always returning 0

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -7,7 +7,7 @@
 ///   - [y]: Minor version with non-breaking API and library changes
 ///   - [z]: Patch version with no direct changes to the API
 ///
-/// - 2023/10/30 (4.10.7) - Fix null pointer dereference in nk_group_scrolled_offset_begin()
+/// - 2023/11/03 (4.10.7) - Fix null pointer dereference with nk_group and nk_listview scroll offsets
 /// - 2022/12/23 (4.10.6) - Fix incorrect glyph index in nk_font_bake()
 /// - 2022/12/17 (4.10.5) - Fix nk_font_bake_pack() using TTC font offset incorrectly
 /// - 2022/10/24 (4.10.4) - Fix nk_str_{append,insert}_str_utf8 always returning 0

--- a/src/nuklear_group.c
+++ b/src/nuklear_group.c
@@ -153,7 +153,15 @@ nk_group_begin_titled(struct nk_context *ctx, const char *id,
         NK_ASSERT(y_offset);
         if (!x_offset || !y_offset) return 0;
         *x_offset = *y_offset = 0;
-    } else y_offset = nk_find_value(win, id_hash+1);
+    } else {
+        y_offset = nk_find_value(win, id_hash+1);
+        if (!y_offset) {
+            y_offset = nk_add_value(ctx, win, id_hash+1, 0);
+            NK_ASSERT(y_offset);
+            if (!y_offset) return 0;
+            *y_offset = 0;
+        }
+    }
     return nk_group_scrolled_offset_begin(ctx, x_offset, y_offset, title, flags);
 }
 NK_API nk_bool
@@ -195,7 +203,15 @@ nk_group_get_scroll(struct nk_context *ctx, const char *id, nk_uint *x_offset, n
         NK_ASSERT(y_offset_ptr);
         if (!x_offset_ptr || !y_offset_ptr) return;
         *x_offset_ptr = *y_offset_ptr = 0;
-    } else y_offset_ptr = nk_find_value(win, id_hash+1);
+    } else {
+        y_offset_ptr = nk_find_value(win, id_hash+1);
+        if (!y_offset_ptr) {
+            y_offset_ptr = nk_add_value(ctx, win, id_hash+1, 0);
+            NK_ASSERT(y_offset_ptr);
+            if (!y_offset_ptr) return;
+            *y_offset_ptr = 0;
+        }
+    }
     if (x_offset)
       *x_offset = *x_offset_ptr;
     if (y_offset)
@@ -230,7 +246,15 @@ nk_group_set_scroll(struct nk_context *ctx, const char *id, nk_uint x_offset, nk
         NK_ASSERT(y_offset_ptr);
         if (!x_offset_ptr || !y_offset_ptr) return;
         *x_offset_ptr = *y_offset_ptr = 0;
-    } else y_offset_ptr = nk_find_value(win, id_hash+1);
+    } else {
+        y_offset_ptr = nk_find_value(win, id_hash+1);
+        if (!y_offset_ptr) {
+            y_offset_ptr = nk_add_value(ctx, win, id_hash+1, 0);
+            NK_ASSERT(y_offset_ptr);
+            if (!y_offset_ptr) return;
+            *y_offset_ptr = 0;
+        }
+    }
     *x_offset_ptr = x_offset;
     *y_offset_ptr = y_offset;
 }

--- a/src/nuklear_list_view.c
+++ b/src/nuklear_list_view.c
@@ -43,7 +43,15 @@ nk_list_view_begin(struct nk_context *ctx, struct nk_list_view *view,
         NK_ASSERT(y_offset);
         if (!x_offset || !y_offset) return 0;
         *x_offset = *y_offset = 0;
-    } else y_offset = nk_find_value(win, title_hash+1);
+    } else {
+        y_offset = nk_find_value(win, title_hash+1);
+        if (!y_offset) {
+            y_offset = nk_add_value(ctx, win, title_hash+1, 0);
+            NK_ASSERT(y_offset);
+            if (!y_offset) return 0;
+            *y_offset = 0;
+        }
+    }
     view->scroll_value = *y_offset;
     view->scroll_pointer = y_offset;
 


### PR DESCRIPTION
We hit a rare null deref on `y_offset` in `nk_group_scrolled_offset_begin()`, that I think happens like this:
```C
    // snippet from nk_group_begin_titled()

    x_offset = nk_find_value(win, id_hash);
    if (!x_offset) {
        x_offset = nk_add_value(ctx, win, id_hash, 0);
        y_offset = nk_add_value(ctx, win, id_hash+1, 0);
        NK_ASSERT(x_offset);
        NK_ASSERT(y_offset);
        if (!x_offset || !y_offset) return 0;
        *x_offset = *y_offset = 0;
    } else y_offset = nk_find_value(win, id_hash+1);
    return nk_group_scrolled_offset_begin(ctx, x_offset, y_offset, title, flags);
```
First, we don't find the `x_offset`, so we go into the if() branch. There, we manage to add `x_offset` but not `y_offset`. This causes it to bail early. Then, next frame, it will find `x_offset` and go into the else branch. There, it fails to find `y_offset`, and eventually calls into `nk_group_scrolled_offset_begin()` with `y_offset = NULL`.

Never got a local repro so can't say for sure if the existing `NK_ASSERT(y_offset)` was firing, but end user reports that this patch fixes it.

I think this is one of the issues that was reported in #513 