### PR TITLE
Fix button text alignment error.

### DIFF
--- a/clib.json
+++ b/clib.json
@@ -1,6 +1,6 @@
 {
   "name": "nuklear",
-  "version": "4.10.6",
+  "version": "4.10.7",
   "repo": "Immediate-Mode-UI/Nuklear",
   "description": "A small ANSI C gui toolkit",
   "keywords": ["gl", "ui", "toolkit"],

--- a/nuklear.h
+++ b/nuklear.h
@@ -23892,8 +23892,8 @@ nk_do_button(nk_flags *state, struct nk_command_buffer *out, struct nk_rect r,
     /* calculate button content space */
     content->x = r.x + style->padding.x + style->border + style->rounding;
     content->y = r.y + style->padding.y + style->border + style->rounding;
-    content->w = r.w - (2 * style->padding.x + style->border + style->rounding*2);
-    content->h = r.h - (2 * style->padding.y + style->border + style->rounding*2);
+    content->w = r.w - (2 * (style->padding.x + style->border + style->rounding));
+    content->h = r.h - (2 * (style->padding.y + style->border + style->rounding));
 
     /* execute button behavior */
     bounds.x = r.x - style->touch_padding.x;

--- a/src/nuklear_button.c
+++ b/src/nuklear_button.c
@@ -127,8 +127,8 @@ nk_do_button(nk_flags *state, struct nk_command_buffer *out, struct nk_rect r,
     /* calculate button content space */
     content->x = r.x + style->padding.x + style->border + style->rounding;
     content->y = r.y + style->padding.y + style->border + style->rounding;
-    content->w = r.w - (2 * style->padding.x + style->border + style->rounding*2);
-    content->h = r.h - (2 * style->padding.y + style->border + style->rounding*2);
+    content->w = r.w - (2 * (style->padding.x + style->border + style->rounding));
+    content->h = r.h - (2 * (style->padding.y + style->border + style->rounding));
 
     /* execute button behavior */
     bounds.x = r.x - style->touch_padding.x;


### PR DESCRIPTION
When calculating the width and height of the content rect of a button, only the border of one side is being taken into account. Instead the border width needs to be multiplied by two before subtracting from the bounds. This is being done for padding and rounding, but not border, which is resulting in text being misaligned. The screenshots below demonstrate the issue (I've exaggerated the borders to make it easier to see the effect).

Before:
![image](https://github.com/Immediate-Mode-UI/Nuklear/assets/1232553/24cad65b-905e-445d-bbac-27df2e75a9fa)

After:
![image](https://github.com/Immediate-Mode-UI/Nuklear/assets/1232553/4079df05-e868-4058-8751-f12c2f4948f2)