### PR TITLE
Don't draw outside the bounds of a button.

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -23856,6 +23856,7 @@ nk_draw_button(struct nk_command_buffer *out,
     const struct nk_rect *bounds, nk_flags state,
     const struct nk_style_button *style)
 {
+    struct nk_rect stroke_rect;
     const struct nk_style_item *background;
     if (state & NK_WIDGET_STATE_HOVER)
         background = &style->hover;
@@ -23872,7 +23873,16 @@ nk_draw_button(struct nk_command_buffer *out,
             break;
         case NK_STYLE_ITEM_COLOR:
             nk_fill_rect(out, *bounds, style->rounding, background->data.color);
-            nk_stroke_rect(out, *bounds, style->rounding, style->border, style->border_color);
+
+            /*
+            To ensure the stroke used for the border does not end up outside the bounds of the button, the rectangle
+            used for the border stroke needs to be pulled in by half the border width.
+            */
+            stroke_rect.x = bounds->x + style->border*0.5f;
+            stroke_rect.y = bounds->y + style->border*0.5f;
+            stroke_rect.w = bounds->w - style->border;
+            stroke_rect.h = bounds->h - style->border;
+            nk_stroke_rect(out, stroke_rect, style->rounding, style->border, style->border_color);
             break;
     }
     return background;

--- a/src/nuklear_button.c
+++ b/src/nuklear_button.c
@@ -91,6 +91,7 @@ nk_draw_button(struct nk_command_buffer *out,
     const struct nk_rect *bounds, nk_flags state,
     const struct nk_style_button *style)
 {
+    struct nk_rect stroke_rect;
     const struct nk_style_item *background;
     if (state & NK_WIDGET_STATE_HOVER)
         background = &style->hover;
@@ -107,7 +108,16 @@ nk_draw_button(struct nk_command_buffer *out,
             break;
         case NK_STYLE_ITEM_COLOR:
             nk_fill_rect(out, *bounds, style->rounding, background->data.color);
-            nk_stroke_rect(out, *bounds, style->rounding, style->border, style->border_color);
+
+            /*
+            To ensure the stroke used for the border does not end up outside the bounds of the button, the rectangle
+            used for the border stroke needs to be pulled in by half the border width.
+            */
+            stroke_rect.x = bounds->x + style->border*0.5f;
+            stroke_rect.y = bounds->y + style->border*0.5f;
+            stroke_rect.w = bounds->w - style->border;
+            stroke_rect.h = bounds->h - style->border;
+            nk_stroke_rect(out, stroke_rect, style->rounding, style->border, style->border_color);
             break;
     }
     return background;


### PR DESCRIPTION
When drawing the border of a button it's done so via `nk_stroke_rect()`. The problem with this is when a line is stroked, half of the width of the line is on one side, and the other half is on the other side. In the case of a button, this results in half of the border being drawn outside the bounds of the button. This commit pulls in the border rectangle by half the border width before performing the stroke so as to avoid any overflow.

The practical issue with this is clipping against the parent. Consider the layout below:
```c
    if (nk_begin(&ctx, "Menu", nk_recti(300, 64, 400, 400), NK_WINDOW_BORDER | NK_WINDOW_TITLE | NK_WINDOW_NO_SCROLLBAR)) {
        nk_layout_row_dynamic(&ctx, 64, 1);
        if (nk_button_label(&ctx, "Single Player")) {
            ...
        }
    }
    nk_end(&ctx);
```
With this code, the left side of the button is clipped against the parent window, but because half of the border is overflowing the button's bounds, it's resulting in one pixel being clipped. I've set the border to 2 pixels to demonstrate:
![image](https://github.com/Immediate-Mode-UI/Nuklear/assets/1232553/b96138a7-9fc9-4931-bed0-662fccaddb59)

You can see that the left border is thinner compared to the others. With the change in this PR it now looks like this which looks a lot cleaner and professional:
![image](https://github.com/Immediate-Mode-UI/Nuklear/assets/1232553/c389f454-1986-4767-a2b2-e4eb1e35db79)

Note that this change will result in slightly different visual output to previous versions. I'd be happy to to add a flag somewhere to explicitly enable this particular change if that's preferable. Either way, in my opinion there needs to be some way to control this behavior, be it by default or via flag, because in my mind drawing outside the bounds of a control should be considered very bad practice.