### PR TITLE
Fix undefined behavior in `strncpy()` call

### DIFF
--- a/example/file_browser.c
+++ b/example/file_browser.c
@@ -346,7 +346,7 @@ static void
 file_browser_reload_directory_content(struct file_browser *browser, const char *path)
 {
     const size_t path_len = strlen(path) + 1;
-    memmove(browser->directory, path, MIN(path_len, MAX_PATH_LEN));
+    NK_MEMCPY(browser->directory, path, MIN(path_len, MAX_PATH_LEN));
     browser->directory[MAX_PATH_LEN - 1] = 0;
     dir_free_list(browser->files, browser->file_count);
     dir_free_list(browser->directories, browser->dir_count);

--- a/example/file_browser.c
+++ b/example/file_browser.c
@@ -345,7 +345,8 @@ media_init(struct media *media)
 static void
 file_browser_reload_directory_content(struct file_browser *browser, const char *path)
 {
-    strncpy(browser->directory, path, MAX_PATH_LEN);
+    const size_t path_len = strlen(path) + 1;
+    memmove(browser->directory, path, MIN(path_len, MAX_PATH_LEN));
     browser->directory[MAX_PATH_LEN - 1] = 0;
     dir_free_list(browser->files, browser->file_count);
     dir_free_list(browser->directories, browser->dir_count);

--- a/example/file_browser.c
+++ b/example/file_browser.c
@@ -345,7 +345,7 @@ media_init(struct media *media)
 static void
 file_browser_reload_directory_content(struct file_browser *browser, const char *path)
 {
-    const size_t path_len = strlen(path) + 1;
+    const size_t path_len = nk_strlen(path) + 1;
     NK_MEMCPY(browser->directory, path, MIN(path_len, MAX_PATH_LEN));
     browser->directory[MAX_PATH_LEN - 1] = 0;
     dir_free_list(browser->files, browser->file_count);


### PR DESCRIPTION
`strncpy()`'s pointer parameters are marked `restrict`, but when `file_browser_reload_directory_content()` was being called to reload the directory that was currently open:
```c
file_browser_reload_directory_content(browser, browser->directory)
```
it would try to copy its path buffer to itself, causing undefined behavior. The solution uses `memmove()`, which can handle overlapping pointers.

Found with Address Sanitizer.