### PR TITLE
ci: Update to `actions/checkout@v4`.

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: apt-update
       run: sudo apt-get update -qq
     - name: apt get glfw

--- a/.github/workflows/create-tag.yml
+++ b/.github/workflows/create-tag.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - uses: butlerlogic/action-autotag@stable
       with:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
This brings changes to keep up with the GitHub Actions internals (among other changes). This will remove some of the deprecation warnings in the GitHub Actions UI.