### PR TITLE
Add a style option to disable point markers on charts

### DIFF
--- a/demo/common/overview.c
+++ b/demo/common/overview.c
@@ -621,6 +621,7 @@ overview(struct nk_context *ctx)
             float id = 0;
             static int col_index = -1;
             static int line_index = -1;
+            static int hide_markers = nk_false;
             float step = (2*3.141592654f) / 32;
 
             int i;
@@ -629,7 +630,10 @@ overview(struct nk_context *ctx)
             /* line chart */
             id = 0;
             index = -1;
+            nk_layout_row_dynamic(ctx, 15, 1);
+            nk_checkbox_label(ctx, "Hide markers", &hide_markers);
             nk_layout_row_dynamic(ctx, 100, 1);
+            ctx->style.chart.hide_markers = hide_markers;
             if (nk_chart_begin(ctx, NK_CHART_LINES, 32, -1.0f, 1.0f)) {
                 for (i = 0; i < 32; ++i) {
                     nk_flags res = nk_chart_push(ctx, (float)cos(id));

--- a/nuklear.h
+++ b/nuklear.h
@@ -5198,6 +5198,7 @@ struct nk_style_chart {
     struct nk_vec2 padding;
     float color_factor;
     float disabled_factor;
+    nk_bool hide_markers;
 };
 
 struct nk_style_combo {
@@ -5388,6 +5389,7 @@ struct nk_chart_slot {
     int count;
     struct nk_vec2 last;
     int index;
+    nk_bool hide_markers;
 };
 
 struct nk_chart {
@@ -18656,6 +18658,7 @@ nk_style_from_table(struct nk_context *ctx, const struct nk_color *table)
     chart->rounding         = 0;
     chart->color_factor     = 1.0f;
     chart->disabled_factor  = NK_WIDGET_DISABLED_FACTOR;
+    chart->hide_markers     = nk_false;
 
     /* combo */
     combo = &style->combo;
@@ -28492,7 +28495,8 @@ nk_chart_begin_colored(struct nk_context *ctx, enum nk_chart_type type,
     slot->highlight = highlight;
     slot->min = NK_MIN(min_value, max_value);
     slot->max = NK_MAX(min_value, max_value);
-    slot->range = slot->max - slot->min;}
+    slot->range = slot->max - slot->min;
+    slot->hide_markers = style->hide_markers;}
 
     /* draw chart background */
     background = &style->background;
@@ -28544,7 +28548,8 @@ nk_chart_add_slot_colored(struct nk_context *ctx, const enum nk_chart_type type,
     slot->highlight = highlight;
     slot->min = NK_MIN(min_value, max_value);
     slot->max = NK_MAX(min_value, max_value);
-    slot->range = slot->max - slot->min;}
+    slot->range = slot->max - slot->min;
+    slot->hide_markers = style->hide_markers;}
 }
 NK_API void
 nk_chart_add_slot(struct nk_context *ctx, const enum nk_chart_type type,
@@ -28591,7 +28596,9 @@ nk_chart_push_line(struct nk_context *ctx, struct nk_window *win,
                 i->mouse.buttons[NK_BUTTON_LEFT].clicked) ? NK_CHART_CLICKED: 0;
             color = g->slots[slot].highlight;
         }
-        nk_fill_rect(out, bounds, 0, color);
+        if (!g->slots[slot].hide_markers) {
+            nk_fill_rect(out, bounds, 0, color);
+        }
         g->slots[slot].index += 1;
         return ret;
     }
@@ -28615,7 +28622,9 @@ nk_chart_push_line(struct nk_context *ctx, struct nk_window *win,
             color = g->slots[slot].highlight;
         }
     }
-    nk_fill_rect(out, nk_rect(cur.x - 2, cur.y - 2, 4, 4), 0, color);
+    if (!g->slots[slot].hide_markers) {
+        nk_fill_rect(out, nk_rect(cur.x - 2, cur.y - 2, 4, 4), 0, color);
+    }
 
     /* save current data point position */
     g->slots[slot].last.x = cur.x;

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -4976,6 +4976,7 @@ struct nk_style_chart {
     struct nk_vec2 padding;
     float color_factor;
     float disabled_factor;
+    nk_bool hide_markers;
 };
 
 struct nk_style_combo {
@@ -5166,6 +5167,7 @@ struct nk_chart_slot {
     int count;
     struct nk_vec2 last;
     int index;
+    nk_bool hide_markers;
 };
 
 struct nk_chart {

--- a/src/nuklear_chart.c
+++ b/src/nuklear_chart.c
@@ -52,7 +52,8 @@ nk_chart_begin_colored(struct nk_context *ctx, enum nk_chart_type type,
     slot->highlight = highlight;
     slot->min = NK_MIN(min_value, max_value);
     slot->max = NK_MAX(min_value, max_value);
-    slot->range = slot->max - slot->min;}
+    slot->range = slot->max - slot->min;
+    slot->hide_markers = style->hide_markers;}
 
     /* draw chart background */
     background = &style->background;
@@ -104,7 +105,8 @@ nk_chart_add_slot_colored(struct nk_context *ctx, const enum nk_chart_type type,
     slot->highlight = highlight;
     slot->min = NK_MIN(min_value, max_value);
     slot->max = NK_MAX(min_value, max_value);
-    slot->range = slot->max - slot->min;}
+    slot->range = slot->max - slot->min;
+    slot->hide_markers = style->hide_markers;}
 }
 NK_API void
 nk_chart_add_slot(struct nk_context *ctx, const enum nk_chart_type type,
@@ -151,7 +153,9 @@ nk_chart_push_line(struct nk_context *ctx, struct nk_window *win,
                 i->mouse.buttons[NK_BUTTON_LEFT].clicked) ? NK_CHART_CLICKED: 0;
             color = g->slots[slot].highlight;
         }
-        nk_fill_rect(out, bounds, 0, color);
+        if (!g->slots[slot].hide_markers) {
+            nk_fill_rect(out, bounds, 0, color);
+        }
         g->slots[slot].index += 1;
         return ret;
     }
@@ -175,7 +179,9 @@ nk_chart_push_line(struct nk_context *ctx, struct nk_window *win,
             color = g->slots[slot].highlight;
         }
     }
-    nk_fill_rect(out, nk_rect(cur.x - 2, cur.y - 2, 4, 4), 0, color);
+    if (!g->slots[slot].hide_markers) {
+        nk_fill_rect(out, nk_rect(cur.x - 2, cur.y - 2, 4, 4), 0, color);
+    }
 
     /* save current data point position */
     g->slots[slot].last.x = cur.x;

--- a/src/nuklear_style.c
+++ b/src/nuklear_style.c
@@ -486,6 +486,7 @@ nk_style_from_table(struct nk_context *ctx, const struct nk_color *table)
     chart->rounding         = 0;
     chart->color_factor     = 1.0f;
     chart->disabled_factor  = NK_WIDGET_DISABLED_FACTOR;
+    chart->hide_markers     = nk_false;
 
     /* combo */
     combo = &style->combo;


### PR DESCRIPTION
With point markers enabled (default):
![with_markers](https://github.com/Immediate-Mode-UI/Nuklear/assets/546293/494e965b-daa4-4a8d-a7d6-b9651ccc5ac2)
With point markers disabled:
![without_markers](https://github.com/Immediate-Mode-UI/Nuklear/assets/546293/a84ebdba-d0b7-4d76-948d-7de9df569fc9)


Fixes #594