### PR TITLE
Suppress compiler `possible loss of data` warning with explicit cast

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -7662,9 +7662,9 @@ nk_rgb_factor(struct nk_color col, const float factor)
 {
     if (factor == 1.0f)
         return col;
-    col.r *= factor;
-    col.g *= factor;
-    col.b *= factor;
+    col.r = (nk_byte)(col.r * factor);
+    col.g = (nk_byte)(col.g * factor);
+    col.b = (nk_byte)(col.b * factor);
     return col;
 }
 NK_API struct nk_color

--- a/src/nuklear_color.c
+++ b/src/nuklear_color.c
@@ -27,9 +27,9 @@ nk_rgb_factor(struct nk_color col, const float factor)
 {
     if (factor == 1.0f)
         return col;
-    col.r *= factor;
-    col.g *= factor;
-    col.b *= factor;
+    col.r = (nk_byte)(col.r * factor);
+    col.g = (nk_byte)(col.g * factor);
+    col.b = (nk_byte)(col.b * factor);
     return col;
 }
 NK_API struct nk_color


### PR DESCRIPTION
Hi! Building `Nuklear` with MSVC (`Microsoft (R) C/C++ Optimizing Compiler Version 19.38.33134 for x64`) results in following W3+ level warnings:

```
Nuklear\nuklear.h(7665): error C2220: the following warning is treated as an error
Nuklear\nuklear.h(7665): warning C4244: '=': conversion from 'const float' to 'nk_byte', possible loss of data
Nuklear\nuklear.h(7666): warning C4244: '=': conversion from 'const float' to 'nk_byte', possible loss of data
Nuklear\nuklear.h(7667): warning C4244: '=': conversion from 'const float' to 'nk_byte', possible loss of data
```

This fix resolves the issue by explicit safe cast which assumed to be safe. Thanks!