### PR TITLE
Minor fixes for GLFW Vulkan Demo

### DIFF
--- a/demo/glfw_vulkan/main.c
+++ b/demo/glfw_vulkan/main.c
@@ -2219,7 +2219,7 @@ int main(void) {
         if (result == VK_ERROR_OUT_OF_DATE_KHR) {
             continue;
         }
-        if (result != VK_SUCCESS) {
+        if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR) {
             fprintf(stderr, "vkAcquireNextImageKHR failed: %d\n", result);
             return false;
         }

--- a/demo/glfw_vulkan/main.c
+++ b/demo/glfw_vulkan/main.c
@@ -758,7 +758,6 @@ bool create_swap_chain(struct vulkan_demo *demo) {
     VkResult result;
     VkSwapchainCreateInfoKHR create_info;
     uint32_t queue_family_indices[2];
-    uint32_t old_swap_chain_images_len;
     bool ret = false;
 
     queue_family_indices[0] = (uint32_t)demo->indices.graphics;
@@ -815,20 +814,10 @@ bool create_swap_chain(struct vulkan_demo *demo) {
         goto cleanup;
     }
 
-    old_swap_chain_images_len = demo->swap_chain_images_len;
     result = vkGetSwapchainImagesKHR(demo->device, demo->swap_chain,
                                      &demo->swap_chain_images_len, NULL);
     if (result != VK_SUCCESS) {
         fprintf(stderr, "vkGetSwapchainImagesKHR failed: %d\n", result);
-        goto cleanup;
-    }
-    if (old_swap_chain_images_len > 0 &&
-        old_swap_chain_images_len != demo->swap_chain_images_len) {
-        fprintf(stderr,
-                "number of assigned swap chain images changed between "
-                "runs. old: %u, new: %u\n",
-                (unsigned)old_swap_chain_images_len,
-                (unsigned)demo->swap_chain_images_len);
         goto cleanup;
     }
     if (demo->swap_chain_images == NULL) {


### PR DESCRIPTION
This PR contains changes I needed for the glfw_vulkan demo to function in a reasonable manner (launch + window resizing) on my Void Linux machine.

`40a172b` - It is valid to continue a render process in the event that `vkAcquireNextImageKHR` returns `VK_SUBOPTIMAL_KHR`. The implementation already correctly handles recreating the swapchain when necessary so no other changes were needed beyond preventing the error-out.

`03aa308` - Vulkan may create more swapchain images than requested via `minImageCount` to `vkCreateSwapchainKHR`. In my testing on two different machines, `vkGetSwapchainImagesKHR` was returning `minImageCount + 1` when queried, causing me to hit this error-out. The demo works without any other changes beyond preventing the error-out.
https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/vkCreateSwapchainKHR.html
https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkSwapchainCreateInfoKHR.html

@m0ppers Since you added Vulkan, can you double-check me on this?