### PR TITLE
Add delta_time_seconds to a few renderers

### DIFF
--- a/demo/allegro5/nuklear_allegro5.h
+++ b/demo/allegro5/nuklear_allegro5.h
@@ -66,7 +66,7 @@ static struct nk_allegro5 {
     int touch_down_id;
     struct nk_context ctx;
     struct nk_buffer cmds;
-    double delta_time_last;
+    float delta_time_seconds_last;
 } allegro5;
 
 
@@ -179,9 +179,9 @@ nk_allegro5_render()
     const struct nk_command *cmd;
 
     /* Update the timer */
-    double now = al_get_time();
-    allegro5.ctx.delta_time_seconds = now - allegro5.delta_time_last;
-    allegro5.delta_time_last = now;
+    float now = (float)al_get_time();
+    allegro5.ctx.delta_time_seconds = now - allegro5.delta_time_seconds_last;
+    allegro5.delta_time_seconds_last = now;
 
     al_set_target_backbuffer(allegro5.dsp);
 
@@ -504,7 +504,7 @@ nk_allegro5_init(NkAllegro5Font *allegro5font, ALLEGRO_DISPLAY *dsp,
     allegro5.height = height;
     allegro5.is_touch_down = 0;
     allegro5.touch_down_id = -1;
-    allegro5.delta_time_last = al_get_time();
+    allegro5.delta_time_seconds_last = (float)al_get_time();
 
     nk_init_default(&allegro5.ctx, font);
     allegro5.ctx.clip.copy = nk_allegro5_clipboard_copy;

--- a/demo/allegro5/nuklear_allegro5.h
+++ b/demo/allegro5/nuklear_allegro5.h
@@ -66,6 +66,7 @@ static struct nk_allegro5 {
     int touch_down_id;
     struct nk_context ctx;
     struct nk_buffer cmds;
+    double delta_time_last;
 } allegro5;
 
 
@@ -176,6 +177,11 @@ NK_API void
 nk_allegro5_render()
 {
     const struct nk_command *cmd;
+
+    /* Update the timer */
+    double now = al_get_time();
+    allegro5.ctx.delta_time_seconds = now - allegro5.delta_time_last;
+    allegro5.delta_time_last = now;
 
     al_set_target_backbuffer(allegro5.dsp);
 
@@ -498,6 +504,7 @@ nk_allegro5_init(NkAllegro5Font *allegro5font, ALLEGRO_DISPLAY *dsp,
     allegro5.height = height;
     allegro5.is_touch_down = 0;
     allegro5.touch_down_id = -1;
+    allegro5.delta_time_last = al_get_time();
 
     nk_init_default(&allegro5.ctx, font);
     allegro5.ctx.clip.copy = nk_allegro5_clipboard_copy;

--- a/demo/common/overview.c
+++ b/demo/common/overview.c
@@ -3,11 +3,11 @@ overview(struct nk_context *ctx)
 {
     /* window flags */
     static nk_bool show_menu = nk_true;
-    static nk_flags window_flags = NK_WINDOW_TITLE|NK_WINDOW_BORDER|NK_WINDOW_SCALABLE|NK_WINDOW_MOVABLE|NK_WINDOW_MINIMIZABLE;
+    static nk_flags window_flags = NK_WINDOW_TITLE|NK_WINDOW_BORDER|NK_WINDOW_SCALABLE|NK_WINDOW_MOVABLE|NK_WINDOW_MINIMIZABLE|NK_WINDOW_SCROLL_AUTO_HIDE;
     nk_flags actual_window_flags = 0;
 
     /* widget flags */
-	static nk_bool disable_widgets = nk_false;
+    static nk_bool disable_widgets = nk_false;
 
     /* popups */
     static enum nk_style_header_align header_align = NK_HEADER_RIGHT;

--- a/demo/glfw_opengl2/nuklear_glfw_gl2.h
+++ b/demo/glfw_opengl2/nuklear_glfw_gl2.h
@@ -79,7 +79,7 @@ static struct nk_glfw {
     double last_button_click;
     int is_double_click_down;
     struct nk_vec2 double_click_pos;
-    double delta_time_last;
+    float delta_time_seconds_last;
 } glfw;
 
 NK_INTERN void
@@ -274,7 +274,7 @@ nk_glfw3_init(GLFWwindow *win, enum nk_glfw_init_state init_state)
     glfw.is_double_click_down = nk_false;
     glfw.double_click_pos = nk_vec2(0, 0);
 
-    glfw.delta_time_last = glfwGetTime();
+    glfw.delta_time_seconds_last = (float)glfwGetTime();
 
     return &glfw.ctx;
 }
@@ -307,9 +307,9 @@ nk_glfw3_new_frame(void)
     struct GLFWwindow *win = glfw.win;
 
     /* update the timer */
-    double delta_time_now = glfwGetTime();
-    glfw.ctx.delta_time_seconds = delta_time_now - glfw.delta_time_last;
-    glfw.delta_time_last = delta_time_now;
+    float delta_time_now = (float)glfwGetTime();
+    glfw.ctx.delta_time_seconds = delta_time_now - glfw.delta_time_seconds_last;
+    glfw.delta_time_seconds_last = delta_time_now;
 
     glfwGetWindowSize(win, &glfw.width, &glfw.height);
     glfwGetFramebufferSize(win, &glfw.display_width, &glfw.display_height);

--- a/demo/glfw_opengl2/nuklear_glfw_gl2.h
+++ b/demo/glfw_opengl2/nuklear_glfw_gl2.h
@@ -79,6 +79,7 @@ static struct nk_glfw {
     double last_button_click;
     int is_double_click_down;
     struct nk_vec2 double_click_pos;
+    double delta_time_last;
 } glfw;
 
 NK_INTERN void
@@ -273,6 +274,8 @@ nk_glfw3_init(GLFWwindow *win, enum nk_glfw_init_state init_state)
     glfw.is_double_click_down = nk_false;
     glfw.double_click_pos = nk_vec2(0, 0);
 
+    glfw.delta_time_last = glfwGetTime();
+
     return &glfw.ctx;
 }
 
@@ -302,6 +305,11 @@ nk_glfw3_new_frame(void)
     double x, y;
     struct nk_context *ctx = &glfw.ctx;
     struct GLFWwindow *win = glfw.win;
+
+    /* update the timer */
+    double delta_time_now = glfwGetTime();
+    glfw.ctx.delta_time_seconds = delta_time_now - glfw.delta_time_last;
+    glfw.delta_time_last = delta_time_now;
 
     glfwGetWindowSize(win, &glfw.width, &glfw.height);
     glfwGetFramebufferSize(win, &glfw.display_width, &glfw.display_height);

--- a/demo/glfw_opengl3/nuklear_glfw_gl3.h
+++ b/demo/glfw_opengl3/nuklear_glfw_gl3.h
@@ -53,7 +53,7 @@ struct nk_glfw {
     double last_button_click;
     int is_double_click_down;
     struct nk_vec2 double_click_pos;
-    double delta_time_last;
+    float delta_time_seconds_last;
 };
 
 NK_API struct nk_context*   nk_glfw3_init(struct nk_glfw* glfw, GLFWwindow *win, enum nk_glfw_init_state);
@@ -390,7 +390,7 @@ nk_glfw3_init(struct nk_glfw* glfw, GLFWwindow *win, enum nk_glfw_init_state ini
     glfw->is_double_click_down = nk_false;
     glfw->double_click_pos = nk_vec2(0, 0);
 
-    glfw->delta_time_last = glfwGetTime();
+    glfw->delta_time_seconds_last = (float)glfwGetTime();
 
     return &glfw->ctx;
 }
@@ -423,9 +423,9 @@ nk_glfw3_new_frame(struct nk_glfw* glfw)
     struct GLFWwindow *win = glfw->win;
 
     /* update the timer */
-    double delta_time_now = glfwGetTime();
-    glfw->ctx.delta_time_seconds = delta_time_now - glfw->delta_time_last;
-    glfw->delta_time_last = delta_time_now;
+    float delta_time_now = (float)glfwGetTime();
+    glfw->ctx.delta_time_seconds = delta_time_now - glfw->delta_time_seconds_last;
+    glfw->delta_time_seconds_last = delta_time_now;
 
     glfwGetWindowSize(win, &glfw->width, &glfw->height);
     glfwGetFramebufferSize(win, &glfw->display_width, &glfw->display_height);

--- a/demo/glfw_opengl3/nuklear_glfw_gl3.h
+++ b/demo/glfw_opengl3/nuklear_glfw_gl3.h
@@ -53,6 +53,7 @@ struct nk_glfw {
     double last_button_click;
     int is_double_click_down;
     struct nk_vec2 double_click_pos;
+    double delta_time_last;
 };
 
 NK_API struct nk_context*   nk_glfw3_init(struct nk_glfw* glfw, GLFWwindow *win, enum nk_glfw_init_state);
@@ -389,6 +390,8 @@ nk_glfw3_init(struct nk_glfw* glfw, GLFWwindow *win, enum nk_glfw_init_state ini
     glfw->is_double_click_down = nk_false;
     glfw->double_click_pos = nk_vec2(0, 0);
 
+    glfw->delta_time_last = glfwGetTime();
+
     return &glfw->ctx;
 }
 
@@ -418,6 +421,11 @@ nk_glfw3_new_frame(struct nk_glfw* glfw)
     double x, y;
     struct nk_context *ctx = &glfw->ctx;
     struct GLFWwindow *win = glfw->win;
+
+    /* update the timer */
+    double delta_time_now = glfwGetTime();
+    glfw->ctx.delta_time_seconds = delta_time_now - glfw->delta_time_last;
+    glfw->delta_time_last = delta_time_now;
 
     glfwGetWindowSize(win, &glfw->width, &glfw->height);
     glfwGetFramebufferSize(win, &glfw->display_width, &glfw->display_height);

--- a/demo/glfw_vulkan/nuklear_glfw_vulkan.h
+++ b/demo/glfw_vulkan/nuklear_glfw_vulkan.h
@@ -379,6 +379,7 @@ static struct nk_glfw {
     double last_button_click;
     int is_double_click_down;
     struct nk_vec2 double_click_pos;
+    double delta_time_last;
 } glfw;
 
 struct Mat4f {
@@ -1253,6 +1254,11 @@ NK_API void nk_glfw3_new_frame(void) {
     double x, y;
     struct nk_context *ctx = &glfw.ctx;
     struct GLFWwindow *win = glfw.win;
+
+    /* update the timer */
+    double delta_time_now = glfwGetTime();
+    glfw.ctx.delta_time_seconds = delta_time_now - glfw.delta_time_last;
+    glfw.delta_time_last = delta_time_now;
 
     nk_input_begin(ctx);
     for (i = 0; i < glfw.text_len; ++i)

--- a/demo/glfw_vulkan/nuklear_glfw_vulkan.h
+++ b/demo/glfw_vulkan/nuklear_glfw_vulkan.h
@@ -379,7 +379,7 @@ static struct nk_glfw {
     double last_button_click;
     int is_double_click_down;
     struct nk_vec2 double_click_pos;
-    double delta_time_last;
+    float delta_time_seconds_last;
 } glfw;
 
 struct Mat4f {
@@ -1256,9 +1256,9 @@ NK_API void nk_glfw3_new_frame(void) {
     struct GLFWwindow *win = glfw.win;
 
     /* update the timer */
-    double delta_time_now = glfwGetTime();
-    glfw.ctx.delta_time_seconds = delta_time_now - glfw.delta_time_last;
-    glfw.delta_time_last = delta_time_now;
+    float delta_time_now = (float)glfwGetTime();
+    glfw.ctx.delta_time_seconds = delta_time_now - glfw.delta_time_seconds_last;
+    glfw.delta_time_seconds_last = delta_time_now;
 
     nk_input_begin(ctx);
     for (i = 0; i < glfw.text_len; ++i)

--- a/demo/rawfb/nuklear_rawfb.h
+++ b/demo/rawfb/nuklear_rawfb.h
@@ -70,7 +70,6 @@ struct rawfb_context {
     struct rawfb_image fb;
     struct rawfb_image font_tex;
     struct nk_font_atlas atlas;
-    Uint64 delta_time_last;
 };
 
 #ifndef MIN
@@ -1034,11 +1033,6 @@ nk_rawfb_render(const struct rawfb_context *rawfb,
                 const unsigned char enable_clear)
 {
     const struct nk_command *cmd;
-
-    /* update the timer */
-    Uint64 now = SDL_GetTicks64();
-    sdlsurface->ctx.delta_time_seconds = (float)(now - sdlsurface->delta_time_last) / 1000;
-    sdlsurface->delta_time_last = now;
 
     if (enable_clear)
         nk_rawfb_clear(rawfb, clear);

--- a/demo/rawfb/nuklear_rawfb.h
+++ b/demo/rawfb/nuklear_rawfb.h
@@ -70,6 +70,7 @@ struct rawfb_context {
     struct rawfb_image fb;
     struct rawfb_image font_tex;
     struct nk_font_atlas atlas;
+    Uint64 delta_time_last;
 };
 
 #ifndef MIN
@@ -1033,6 +1034,12 @@ nk_rawfb_render(const struct rawfb_context *rawfb,
                 const unsigned char enable_clear)
 {
     const struct nk_command *cmd;
+
+    /* update the timer */
+    Uint64 now = SDL_GetTicks64();
+    sdlsurface->ctx.delta_time_seconds = (float)(now - sdlsurface->delta_time_last) / 1000;
+    sdlsurface->delta_time_last = now;
+
     if (enable_clear)
         nk_rawfb_clear(rawfb, clear);
 

--- a/demo/sdl_opengl2/nuklear_sdl_gl2.h
+++ b/demo/sdl_opengl2/nuklear_sdl_gl2.h
@@ -51,7 +51,7 @@ static struct nk_sdl {
     struct nk_sdl_device ogl;
     struct nk_context ctx;
     struct nk_font_atlas atlas;
-    float time_of_last_frame;
+    float delta_time_seconds_last;
 } sdl;
 
 NK_INTERN void
@@ -76,8 +76,8 @@ nk_sdl_render(enum nk_anti_aliasing AA)
     struct nk_vec2 scale;
 
     float now = ((float)SDL_GetTicks64()) / 1000;
-    sdl.ctx.delta_time_seconds = now - sdl.time_of_last_frame;
-    sdl.time_of_last_frame = now;
+    sdl.ctx.delta_time_seconds = now - sdl.delta_time_seconds_last;
+    sdl.delta_time_seconds_last = now;
 
     SDL_GetWindowSize(sdl.win, &width, &height);
     SDL_GL_GetDrawableSize(sdl.win, &display_width, &display_height);

--- a/demo/sdl_opengl2/nuklear_sdl_gl2.h
+++ b/demo/sdl_opengl2/nuklear_sdl_gl2.h
@@ -51,7 +51,7 @@ static struct nk_sdl {
     struct nk_sdl_device ogl;
     struct nk_context ctx;
     struct nk_font_atlas atlas;
-    float delta_time_seconds_last;
+    Uint64 time_of_last_frame;
 } sdl;
 
 NK_INTERN void
@@ -75,9 +75,9 @@ nk_sdl_render(enum nk_anti_aliasing AA)
     int display_width, display_height;
     struct nk_vec2 scale;
 
-    float now = ((float)SDL_GetTicks64()) / 1000;
-    sdl.ctx.delta_time_seconds = now - sdl.delta_time_seconds_last;
-    sdl.delta_time_seconds_last = now;
+    Uint64 now = SDL_GetTicks64();
+    sdl.ctx.delta_time_seconds = (float)(now - sdl.time_of_last_frame) / 1000;
+    sdl.time_of_last_frame = now;
 
     SDL_GetWindowSize(sdl.win, &width, &height);
     SDL_GL_GetDrawableSize(sdl.win, &display_width, &display_height);
@@ -217,7 +217,7 @@ nk_sdl_init(SDL_Window *win)
     sdl.ctx.clip.paste = nk_sdl_clipboard_paste;
     sdl.ctx.clip.userdata = nk_handle_ptr(0);
     nk_buffer_init_default(&sdl.ogl.cmds);
-    sdl.time_of_last_frame = ((float)SDL_GetTicks64()) / 1000;
+    sdl.time_of_last_frame = SDL_GetTicks64();
     return &sdl.ctx;
 }
 

--- a/demo/sdl_opengl3/nuklear_sdl_gl3.h
+++ b/demo/sdl_opengl3/nuklear_sdl_gl3.h
@@ -67,7 +67,7 @@ static struct nk_sdl {
     struct nk_sdl_device ogl;
     struct nk_context ctx;
     struct nk_font_atlas atlas;
-    float time_of_last_frame;
+    float delta_time_seconds_last;
 } sdl;
 
 #ifdef __APPLE__
@@ -200,8 +200,8 @@ nk_sdl_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_b
     };
 
     float now = ((float)SDL_GetTicks64()) / 1000;
-    sdl.ctx.delta_time_seconds = now - sdl.time_of_last_frame;
-    sdl.time_of_last_frame = now;
+    sdl.ctx.delta_time_seconds = now - sdl.delta_time_seconds_last;
+    sdl.delta_time_seconds_last = now;
 
     SDL_GetWindowSize(sdl.win, &width, &height);
     SDL_GL_GetDrawableSize(sdl.win, &display_width, &display_height);

--- a/demo/sdl_opengl3/nuklear_sdl_gl3.h
+++ b/demo/sdl_opengl3/nuklear_sdl_gl3.h
@@ -67,7 +67,7 @@ static struct nk_sdl {
     struct nk_sdl_device ogl;
     struct nk_context ctx;
     struct nk_font_atlas atlas;
-    float delta_time_seconds_last;
+    Uint64 time_of_last_frame;
 } sdl;
 
 #ifdef __APPLE__
@@ -199,9 +199,9 @@ nk_sdl_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_b
         { -1.0f,  1.0f,  0.0f, 1.0f },
     };
 
-    float now = ((float)SDL_GetTicks64()) / 1000;
-    sdl.ctx.delta_time_seconds = now - sdl.delta_time_seconds_last;
-    sdl.delta_time_seconds_last = now;
+    Uint64 now = SDL_GetTicks64();
+    sdl.ctx.delta_time_seconds = (float)(now - sdl.time_of_last_frame) / 1000;
+    sdl.time_of_last_frame = now;
 
     SDL_GetWindowSize(sdl.win, &width, &height);
     SDL_GL_GetDrawableSize(sdl.win, &display_width, &display_height);
@@ -326,7 +326,7 @@ nk_sdl_init(SDL_Window *win)
     sdl.ctx.clip.paste = nk_sdl_clipboard_paste;
     sdl.ctx.clip.userdata = nk_handle_ptr(0);
     nk_sdl_device_create();
-    sdl.time_of_last_frame = ((float)SDL_GetTicks64()) / 1000;
+    sdl.time_of_last_frame = SDL_GetTicks64();
     return &sdl.ctx;
 }
 

--- a/demo/sdl_opengles2/nuklear_sdl_gles2.h
+++ b/demo/sdl_opengles2/nuklear_sdl_gles2.h
@@ -71,7 +71,7 @@ static struct nk_sdl {
     struct nk_sdl_device ogl;
     struct nk_context ctx;
     struct nk_font_atlas atlas;
-    float delta_time_seconds_last;
+    Uint64 time_of_last_frame;
 } sdl;
 
 
@@ -187,9 +187,9 @@ nk_sdl_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_b
         { -1.0f,  1.0f,  0.0f, 1.0f },
     };
 
-    float now = ((float)SDL_GetTicks64()) / 1000;
-    sdl.ctx.delta_time_seconds = now - sdl.delta_time_seconds_last;
-    sdl.delta_time_seconds_last = now;
+    Uint64 now = SDL_GetTicks64();
+    sdl.ctx.delta_time_seconds = (float)(now - sdl.time_of_last_frame) / 1000;
+    sdl.time_of_last_frame = now;
 
     SDL_GetWindowSize(sdl.win, &width, &height);
     SDL_GL_GetDrawableSize(sdl.win, &display_width, &display_height);
@@ -326,7 +326,7 @@ nk_sdl_init(SDL_Window *win)
     sdl.ctx.clip.paste = nk_sdl_clipboard_paste;
     sdl.ctx.clip.userdata = nk_handle_ptr(0);
     nk_sdl_device_create();
-    sdl.time_of_last_frame = ((float)SDL_GetTicks64()) / 1000;
+    sdl.time_of_last_frame = SDL_GetTicks64();
     return &sdl.ctx;
 }
 

--- a/demo/sdl_opengles2/nuklear_sdl_gles2.h
+++ b/demo/sdl_opengles2/nuklear_sdl_gles2.h
@@ -71,7 +71,7 @@ static struct nk_sdl {
     struct nk_sdl_device ogl;
     struct nk_context ctx;
     struct nk_font_atlas atlas;
-    float time_of_last_frame;
+    float delta_time_seconds_last;
 } sdl;
 
 
@@ -188,8 +188,8 @@ nk_sdl_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_b
     };
 
     float now = ((float)SDL_GetTicks64()) / 1000;
-    sdl.ctx.delta_time_seconds = now - sdl.time_of_last_frame;
-    sdl.time_of_last_frame = now;
+    sdl.ctx.delta_time_seconds = now - sdl.delta_time_seconds_last;
+    sdl.delta_time_seconds_last = now;
 
     SDL_GetWindowSize(sdl.win, &width, &height);
     SDL_GL_GetDrawableSize(sdl.win, &display_width, &display_height);

--- a/demo/sdl_renderer/main.c
+++ b/demo/sdl_renderer/main.c
@@ -39,7 +39,7 @@
 /*#define INCLUDE_CANVAS */
 /*#define INCLUDE_OVERVIEW */
 /*#define INCLUDE_NODE_EDITOR */
-
+#define INCLUDE_ALL
 #ifdef INCLUDE_ALL
   #define INCLUDE_STYLE
   #define INCLUDE_CALCULATOR

--- a/demo/sdl_renderer/main.c
+++ b/demo/sdl_renderer/main.c
@@ -39,6 +39,7 @@
 /*#define INCLUDE_CANVAS */
 /*#define INCLUDE_OVERVIEW */
 /*#define INCLUDE_NODE_EDITOR */
+
 #ifdef INCLUDE_ALL
   #define INCLUDE_STYLE
   #define INCLUDE_CALCULATOR

--- a/demo/sdl_renderer/main.c
+++ b/demo/sdl_renderer/main.c
@@ -39,7 +39,6 @@
 /*#define INCLUDE_CANVAS */
 /*#define INCLUDE_OVERVIEW */
 /*#define INCLUDE_NODE_EDITOR */
-#define INCLUDE_ALL
 #ifdef INCLUDE_ALL
   #define INCLUDE_STYLE
   #define INCLUDE_CALCULATOR

--- a/demo/sdl_renderer/nuklear_sdl_renderer.h
+++ b/demo/sdl_renderer/nuklear_sdl_renderer.h
@@ -64,7 +64,7 @@ static struct nk_sdl {
     struct nk_sdl_device ogl;
     struct nk_context ctx;
     struct nk_font_atlas atlas;
-    float delta_time_seconds_last;
+    Uint64 time_of_last_frame;
 } sdl;
 
 NK_INTERN void
@@ -113,9 +113,9 @@ nk_sdl_render(enum nk_anti_aliasing AA)
             {NK_VERTEX_LAYOUT_END}
         };
 
-        float now = ((float)SDL_GetTicks64()) / 1000;
-        sdl.ctx.delta_time_seconds = now - sdl.delta_time_seconds_last;
-        sdl.delta_time_seconds_last = now;
+        Uint64 now = SDL_GetTicks64();
+        sdl.ctx.delta_time_seconds = (float)(now - sdl.time_of_last_frame) / 1000;
+        sdl.time_of_last_frame = now;
 
         NK_MEMSET(&config, 0, sizeof(config));
         config.vertex_layout = vertex_layout;
@@ -245,7 +245,7 @@ nk_sdl_init(SDL_Window *win, SDL_Renderer *renderer)
 #endif
     sdl.win = win;
     sdl.renderer = renderer;
-    sdl.delta_time_seconds_last = ((float)SDL_GetTicks64()) / 1000;
+    sdl.time_of_last_frame = SDL_GetTicks64();
     nk_init_default(&sdl.ctx, 0);
     sdl.ctx.clip.copy = nk_sdl_clipboard_copy;
     sdl.ctx.clip.paste = nk_sdl_clipboard_paste;

--- a/demo/sdl_renderer/nuklear_sdl_renderer.h
+++ b/demo/sdl_renderer/nuklear_sdl_renderer.h
@@ -88,11 +88,6 @@ nk_sdl_render(enum nk_anti_aliasing AA)
     /* setup global state */
     struct nk_sdl_device *dev = &sdl.ogl;
 
-    /* update the timer */
-    Uint64 now = SDL_GetTicks64();
-    sdl.ctx.delta_time_seconds = (float)(now - sdl.delta_time_last) / 1000;
-    sdl.delta_time_last = now;
-
     {
         SDL_Rect saved_clip;
 #ifdef NK_SDL_CLAMP_CLIP_RECT
@@ -250,7 +245,7 @@ nk_sdl_init(SDL_Window *win, SDL_Renderer *renderer)
 #endif
     sdl.win = win;
     sdl.renderer = renderer;
-    sdl.delta_time_last = SDL_GetTicks64();
+    sdl.delta_time_seconds_last = ((float)SDL_GetTicks64()) / 1000;
     nk_init_default(&sdl.ctx, 0);
     sdl.ctx.clip.copy = nk_sdl_clipboard_copy;
     sdl.ctx.clip.paste = nk_sdl_clipboard_paste;

--- a/demo/sdl_renderer/nuklear_sdl_renderer.h
+++ b/demo/sdl_renderer/nuklear_sdl_renderer.h
@@ -67,8 +67,6 @@ static struct nk_sdl {
     float delta_time_seconds_last;
 } sdl;
 
-
-
 NK_INTERN void
 nk_sdl_device_upload_atlas(const void *image, int width, int height)
 {
@@ -89,6 +87,11 @@ nk_sdl_render(enum nk_anti_aliasing AA)
 {
     /* setup global state */
     struct nk_sdl_device *dev = &sdl.ogl;
+
+    /* update the timer */
+    Uint64 now = SDL_GetTicks64();
+    sdl.ctx.delta_time_seconds = (float)(now - sdl.delta_time_last) / 1000;
+    sdl.delta_time_last = now;
 
     {
         SDL_Rect saved_clip;
@@ -247,6 +250,7 @@ nk_sdl_init(SDL_Window *win, SDL_Renderer *renderer)
 #endif
     sdl.win = win;
     sdl.renderer = renderer;
+    sdl.delta_time_last = SDL_GetTicks64();
     nk_init_default(&sdl.ctx, 0);
     sdl.ctx.clip.copy = nk_sdl_clipboard_copy;
     sdl.ctx.clip.paste = nk_sdl_clipboard_paste;

--- a/demo/sdl_renderer/nuklear_sdl_renderer.h
+++ b/demo/sdl_renderer/nuklear_sdl_renderer.h
@@ -64,6 +64,7 @@ static struct nk_sdl {
     struct nk_sdl_device ogl;
     struct nk_context ctx;
     struct nk_font_atlas atlas;
+    float delta_time_seconds_last;
 } sdl;
 
 
@@ -113,6 +114,11 @@ nk_sdl_render(enum nk_anti_aliasing AA)
             {NK_VERTEX_COLOR, NK_FORMAT_R8G8B8A8, NK_OFFSETOF(struct nk_sdl_vertex, col)},
             {NK_VERTEX_LAYOUT_END}
         };
+
+        float now = ((float)SDL_GetTicks64()) / 1000;
+        sdl.ctx.delta_time_seconds = now - sdl.delta_time_seconds_last;
+        sdl.delta_time_seconds_last = now;
+
         NK_MEMSET(&config, 0, sizeof(config));
         config.vertex_layout = vertex_layout;
         config.vertex_size = sizeof(struct nk_sdl_vertex);


### PR DESCRIPTION
This change adds `delta_time_seconds` to a few of the renderers. Would love some help on supporting some of the others.

- [x] allegro5
- [ ] d3d11
- [ ] d3d12
- [ ] d3d9
- [ ] gdi
- [ ] gdi_native_nuklear
- [ ] gdip
- [x] glfw_opengl2
- [x] glfw_opengl3
- [x] glfw_opengl4
- [x] glfw_vulkan
- [x] sdl2surface_rawfb
- [x] sdl_opengl2
- [x] sdl_opengl3
- [x] sdl_opengles2
- [x] sdl_renderer
- [x] sfml_opengl2
- [x] sfml_opengl3
- [ ] wayland_rawfb
- [x] x11
- [x] x11_opengl2
- [x] x11_opengl3
- [ ] x11_rawfb
- [ ] wayland rawfb
- [ ] sdl rawfb
- [x] x11_xft


Fixes #627 