### PR TITLE
property: Allow optional labels for properties with #

### DIFF
--- a/demo/common/overview.c
+++ b/demo/common/overview.c
@@ -212,6 +212,7 @@ overview(struct nk_context *ctx)
                 static int range_int_value = 2048;
                 static int range_int_max = 4096;
                 static const float ratio[] = {120, 150};
+                static int range_int_value_hidden = 2048;
 
                 nk_layout_row_dynamic(ctx, 0, 1);
                 nk_checkbox_label(ctx, "CheckLeft TextLeft", &checkbox_left_text_left);
@@ -256,6 +257,10 @@ overview(struct nk_context *ctx)
                 nk_property_int(ctx, "#min:", INT_MIN, &range_int_min, range_int_max, 1, 10);
                 nk_property_int(ctx, "#neg:", range_int_min, &range_int_value, range_int_max, 1, 10);
                 nk_property_int(ctx, "#max:", range_int_min, &range_int_max, INT_MAX, 1, 10);
+
+                nk_layout_row_dynamic(ctx, 0, 2);
+                nk_label(ctx, "Hidden Label:", NK_TEXT_LEFT);
+                nk_property_int(ctx, "##Hidden Label", range_int_min, &range_int_value_hidden, INT_MAX, 1, 10);
 
                 nk_tree_pop(ctx);
             }

--- a/nuklear.h
+++ b/nuklear.h
@@ -28180,7 +28180,9 @@ nk_draw_property(struct nk_command_buffer *out, const struct nk_style_property *
 
     /* draw label */
     text.padding = nk_vec2(0,0);
-    nk_widget_text(out, *label, name, len, &text, NK_TEXT_CENTERED, font);
+    if (name && name[0] != '#') {
+        nk_widget_text(out, *label, name, len, &text, NK_TEXT_CENTERED, font);
+    }
 }
 NK_LIB void
 nk_do_property(nk_flags *ws,
@@ -28198,7 +28200,7 @@ nk_do_property(nk_flags *ws,
         nk_filter_float
     };
     nk_bool active, old;
-    int num_len = 0, name_len;
+    int num_len = 0, name_len = 0;
     char string[NK_MAX_NUMBER_BUFFER];
     float size;
 
@@ -28218,7 +28220,9 @@ nk_do_property(nk_flags *ws,
     left.y = property.y + style->border + property.h/2.0f - left.h/2;
 
     /* text label */
-    name_len = nk_strlen(name);
+    if (name && name[0] != '#') {
+        name_len = nk_strlen(name);
+    }
     size = font->width(font->userdata, font->height, name, name_len);
     label.x = left.x + left.w + style->padding.x;
     label.w = (float)size + 2 * style->padding.x;

--- a/src/nuklear_property.c
+++ b/src/nuklear_property.c
@@ -106,7 +106,9 @@ nk_draw_property(struct nk_command_buffer *out, const struct nk_style_property *
 
     /* draw label */
     text.padding = nk_vec2(0,0);
-    nk_widget_text(out, *label, name, len, &text, NK_TEXT_CENTERED, font);
+    if (name && name[0] != '#') {
+        nk_widget_text(out, *label, name, len, &text, NK_TEXT_CENTERED, font);
+    }
 }
 NK_LIB void
 nk_do_property(nk_flags *ws,
@@ -124,7 +126,7 @@ nk_do_property(nk_flags *ws,
         nk_filter_float
     };
     nk_bool active, old;
-    int num_len = 0, name_len;
+    int num_len = 0, name_len = 0;
     char string[NK_MAX_NUMBER_BUFFER];
     float size;
 
@@ -144,7 +146,9 @@ nk_do_property(nk_flags *ws,
     left.y = property.y + style->border + property.h/2.0f - left.h/2;
 
     /* text label */
-    name_len = nk_strlen(name);
+    if (name && name[0] != '#') {
+        name_len = nk_strlen(name);
+    }
     size = font->width(font->userdata, font->height, name, name_len);
     label.x = left.x + left.w + style->padding.x;
     label.w = (float)size + 2 * style->padding.x;


### PR DESCRIPTION
This adds the ability to use `##` as a prefix for a property name to have the label not show at all. Also adds a demonstration in the overview demo.

![Screenshot from 2024-04-10 13-46-22](https://github.com/Immediate-Mode-UI/Nuklear/assets/25086/eb0c5f90-21f8-4732-a5fb-fcd443614f46)
