### PR TITLE
Fix rounding of panels

### DIFF
--- a/src/nuklear_panel.c
+++ b/src/nuklear_panel.c
@@ -309,7 +309,7 @@ nk_panel_begin(struct nk_context *ctx, const char *title, enum nk_panel_type pan
                 nk_draw_nine_slice(out, body, &style->window.fixed_background.data.slice, nk_white);
                 break;
             case NK_STYLE_ITEM_COLOR:
-                nk_fill_rect(out, body, 0, style->window.fixed_background.data.color);
+                nk_fill_rect(out, body, style->window.rounding, style->window.fixed_background.data.color);
                 break;
         }
     }
@@ -505,7 +505,7 @@ nk_panel_end(struct nk_context *ctx)
                 : (window->bounds.y + window->bounds.h));
         struct nk_rect b = window->bounds;
         b.h = padding_y - window->bounds.y;
-        nk_stroke_rect(out, b, 0, layout->border, border_color);
+        nk_stroke_rect(out, b, style->window.rounding, layout->border, border_color);
     }
 
     /* scaler */


### PR DESCRIPTION
example:

nk_style_push_float(ctx, &ctx->style.window.rounding, your_value);
nk_begin(...);
nk_end(...);
nk_style_pop_float(ctx);

![image](https://github.com/Immediate-Mode-UI/Nuklear/assets/67759165/ee051277-73bb-42ae-8f75-38215a11008e)
