### PR TITLE
Quickfix glfw shift-key handling

### DIFF
--- a/demo/glfw_opengl2/nuklear_glfw_gl2.h
+++ b/demo/glfw_opengl2/nuklear_glfw_gl2.h
@@ -350,7 +350,6 @@ nk_glfw3_new_frame(void)
         nk_input_key(ctx, NK_KEY_COPY, 0);
         nk_input_key(ctx, NK_KEY_PASTE, 0);
         nk_input_key(ctx, NK_KEY_CUT, 0);
-        nk_input_key(ctx, NK_KEY_SHIFT, 0);
     }
 
     glfwGetCursorPos(win, &x, &y);

--- a/demo/glfw_opengl3/nuklear_glfw_gl3.h
+++ b/demo/glfw_opengl3/nuklear_glfw_gl3.h
@@ -468,7 +468,6 @@ nk_glfw3_new_frame(struct nk_glfw* glfw)
         nk_input_key(ctx, NK_KEY_COPY, 0);
         nk_input_key(ctx, NK_KEY_PASTE, 0);
         nk_input_key(ctx, NK_KEY_CUT, 0);
-        nk_input_key(ctx, NK_KEY_SHIFT, 0);
     }
 
     glfwGetCursorPos(win, &x, &y);

--- a/demo/glfw_opengl4/nuklear_glfw_gl4.h
+++ b/demo/glfw_opengl4/nuklear_glfw_gl4.h
@@ -619,7 +619,6 @@ nk_glfw3_new_frame(void)
         nk_input_key(ctx, NK_KEY_COPY, 0);
         nk_input_key(ctx, NK_KEY_PASTE, 0);
         nk_input_key(ctx, NK_KEY_CUT, 0);
-        nk_input_key(ctx, NK_KEY_SHIFT, 0);
     }
 
     glfwGetCursorPos(win, &x, &y);

--- a/demo/glfw_vulkan/nuklear_glfw_vulkan.h
+++ b/demo/glfw_vulkan/nuklear_glfw_vulkan.h
@@ -1322,7 +1322,6 @@ NK_API void nk_glfw3_new_frame(void) {
         nk_input_key(ctx, NK_KEY_COPY, 0);
         nk_input_key(ctx, NK_KEY_PASTE, 0);
         nk_input_key(ctx, NK_KEY_CUT, 0);
-        nk_input_key(ctx, NK_KEY_SHIFT, 0);
     }
 
     glfwGetCursorPos(win, &x, &y);

--- a/demo/glfw_vulkan/src/nuklear_glfw_vulkan.in.h
+++ b/demo/glfw_vulkan/src/nuklear_glfw_vulkan.in.h
@@ -1099,7 +1099,6 @@ NK_API void nk_glfw3_new_frame(void) {
         nk_input_key(ctx, NK_KEY_COPY, 0);
         nk_input_key(ctx, NK_KEY_PASTE, 0);
         nk_input_key(ctx, NK_KEY_CUT, 0);
-        nk_input_key(ctx, NK_KEY_SHIFT, 0);
     }
 
     glfwGetCursorPos(win, &x, &y);


### PR DESCRIPTION
All of the glfw demo headers unset shift keypresses when the ctrl key is not also down.
I can't think of a reason this would be desired and it appears no other demo code does this.
Unless I'm mistaken, simply removing these lines leaves us with the desired behaviour.