### PR TITLE
Fix for NK_OFFSETOF on Emscripten

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -5804,7 +5804,7 @@ struct nk_context {
 #define NK_ALIGN_PTR_BACK(x, mask)\
     (NK_UINT_TO_PTR((NK_PTR_TO_UINT((nk_byte*)(x)) & ~(mask-1))))
 
-#if (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
+#if ((defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)) && !defined(EMSCRIPTEN)
 #define NK_OFFSETOF(st,m) (__builtin_offsetof(st,m))
 #else
 #define NK_OFFSETOF(st,m) ((nk_ptr)&(((st*)0)->m))

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -5582,7 +5582,7 @@ struct nk_context {
 #define NK_ALIGN_PTR_BACK(x, mask)\
     (NK_UINT_TO_PTR((NK_PTR_TO_UINT((nk_byte*)(x)) & ~(mask-1))))
 
-#if (defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)
+#if ((defined(__GNUC__) && __GNUC__ >= 4) || defined(__clang__)) && !defined(EMSCRIPTEN)
 #define NK_OFFSETOF(st,m) (__builtin_offsetof(st,m))
 #else
 #define NK_OFFSETOF(st,m) ((nk_ptr)&(((st*)0)->m))


### PR DESCRIPTION
Getting the following error with Emscripten, complaining that __builtin_offset isn't available. This disables the usage of it when on Emscripten...

```
nuklear.h:8978:38: error: defining a type within '__builtin_offsetof' is a C23 extension [-Werror,-Wc23-extensions]
 8978 |     NK_STORAGE const nk_size align = NK_ALIGNOF(struct nk_command);
```