### PR TITLE
Remove unnecessary assert

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -20789,7 +20789,6 @@ nk_window_set_bounds(struct nk_context *ctx,
     if (!ctx) return;
     win = nk_window_find(ctx, name);
     if (!win) return;
-    NK_ASSERT(ctx->current != win && "You cannot update a currently in procecss window");
     win->bounds = bounds;
 }
 NK_API void

--- a/src/nuklear_window.c
+++ b/src/nuklear_window.c
@@ -567,7 +567,6 @@ nk_window_set_bounds(struct nk_context *ctx,
     if (!ctx) return;
     win = nk_window_find(ctx, name);
     if (!win) return;
-    NK_ASSERT(ctx->current != win && "You cannot update a currently in procecss window");
     win->bounds = bounds;
 }
 NK_API void


### PR DESCRIPTION
`nk_window_set_position` and `nk_window_set_size` allow updating an in process window while `nk_window_set_bounds` does not even though the effect is equivalent.