### PR TITLE
RFC: Inline text instructions

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -7629,10 +7629,6 @@ nk_text_calculate_text_bounds(const struct nk_user_font *font,
     if (!begin || byte_len <= 0 || !font)
         return nk_vec2(0,row_height);
 
-//    glyph_len = nk_utf_decode(begin, &unicode, byte_len);
-//    if (!glyph_len) return text_size;
-//    glyph_width = font->width(font->userdata, font->height, begin, glyph_len);
-
     *glyphs = 0;
     do {
         glyph_len = nk_utf_decode(begin + text_len, &unicode, byte_len-text_len);

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -201,6 +201,22 @@ typedef nk_uint nk_hash;
 typedef nk_uint nk_flags;
 typedef nk_uint nk_rune;
 
+/* UTF8 Private Use Area in the Basic Multilingual Plane
+   (codepoints U+E000 -> U+F8FF) are used by Nuklear to pass instructions
+   within text to modify rendering settings on the fly */
+#define NK_UTF_IS_INSTRUCTION(codepoint) \
+    (((nk_rune)(codepoint)) >= 0xE000 && ((nk_rune)(codepoint)) <= 0xF8FF)
+
+/* C89 does not support unicode literals so hex literals are used */
+#define NK_INSTRUCT_CODEPOINT_SET_RGB 0xE000
+#define NK_INSTRUCT_SET_RGB "\xEE\x80\x80"
+
+#define NK_INSTRUCT_CODEPOINT_SET_RGBA 0xE001
+#define NK_INSTRUCT_SET_RGBA "\xEE\x80\x81"
+
+#define NK_INSTRUCT_CODEPOINT_RESET_COLOR 0xE002
+#define NK_INSTRUCT_RESET_COLOR "\xEE\x80\x82"
+
 /* Make sure correct type size:
  * This will fire with a negative subscript error if the type sizes
  * are set incorrectly by the compiler, and compile out if not */
@@ -3617,6 +3633,23 @@ NK_API int nk_utf_decode(const char*, nk_rune*, int);
 NK_API int nk_utf_encode(nk_rune, char*, int);
 NK_API int nk_utf_len(const char*, int byte_len);
 NK_API const char* nk_utf_at(const char *buffer, int length, int index, nk_rune *unicode, int *len);
+/*/// #### nk_utf_filter_instructions
+/// Reads text from input, and writes to output while filtering out inline instructions and their payloads.
+/// input may be equal to output.
+///
+/// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~c
+/// int nk_utf_filter_instructions(char *output, const char *input, int len);
+/// ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+///
+/// Parameter   | Description
+/// ------------|-----------------------------------------------------------
+/// __output__  | Address to write to
+/// __input__   | Address to read from
+/// __len__     | Length of input (in bytes)
+///
+/// Returns the length (in bytes) of output
+*/
+NK_API int nk_utf_filter_instructions(char *output, const char *input, int len);
 /* ===============================================================
  *
  *                          FONT

--- a/src/nuklear_edit.c
+++ b/src/nuklear_edit.c
@@ -124,12 +124,24 @@ nk_edit_draw_text(struct nk_command_buffer *out,
             glyph_len = nk_utf_decode(text + text_len, &unicode, (int)(byte_len-text_len));
             continue;
         }
+
         if (unicode == '\r') {
             text_len++;
             glyph_len = nk_utf_decode(text + text_len, &unicode, byte_len-text_len);
             continue;
         }
-        glyph_width = font->width(font->userdata, font->height, text+text_len, glyph_len);
+
+        if (NK_UTF_IS_INSTRUCTION(unicode)) {
+            int payload_size = nk_utf_instruction_payload_size(unicode);
+            glyph_width = 0;
+
+            /* invalid payload */
+            if(payload_size == -1) break;
+
+            glyph_len += payload_size;
+        } else
+            glyph_width = font->width(font->userdata, font->height, text+text_len, glyph_len);
+
         line_width += (float)glyph_width;
         text_len += glyph_len;
         glyph_len = nk_utf_decode(text + text_len, &unicode, byte_len-text_len);

--- a/src/nuklear_internal.h
+++ b/src/nuklear_internal.h
@@ -234,6 +234,9 @@ struct nk_text {
 NK_LIB void nk_widget_text(struct nk_command_buffer *o, struct nk_rect b, const char *string, int len, const struct nk_text *t, nk_flags a, const struct nk_user_font *f);
 NK_LIB void nk_widget_text_wrap(struct nk_command_buffer *o, struct nk_rect b, const char *string, int len, const struct nk_text *t, const struct nk_user_font *f);
 
+/* UTF-8 */
+NK_LIB int nk_utf_instruction_payload_size(nk_rune unicode);
+
 /* button */
 NK_LIB nk_bool nk_button_behavior(nk_flags *state, struct nk_rect r, const struct nk_input *i, enum nk_button_behavior behavior);
 NK_LIB const struct nk_style_item* nk_draw_button(struct nk_command_buffer *out, const struct nk_rect *bounds, nk_flags state, const struct nk_style_button *style);


### PR DESCRIPTION
An alternative method to achieve something similar to #560

The idea is to use the UTF-8 [Private Use Area](https://en.wikipedia.org/wiki/Private_Use_Areas) ( U+E000 -> U+F8FF ) to pass instructions to the text renderer in a manner similar to ANSI escape codes.

I've implemented hex RGB (`\uE000`), hex RGBA (`\uE001`) and color reset (`\uE002`) instructions.

Each instruction has a hardcoded value(payload) length.
RGB expects 6 ascii bytes containing a color in hex format
while color reset expects no payload

Backends using `nk_convert` will only require minimal, if any, modification to take advantage of this feature while any other backends will need to implement the instructions for them to function.  A function is provided to filter  out the inlined instructions along with their payloads (`nk_utf_filter_instructions`) for use in copy/cut/paste operations. Selecting text in `nk_edit_string` (including `NK_EDIT_BOX`) has been adjusted and copying text works as intended. Cut and paste have not been tested on text containing these instructions.

```c
nk_label(ctx,
	NK_INSTRUCT_SET_RGB  "FF0000"   "N"
	NK_INSTRUCT_SET_RGB  "00FF00"   "u"
	NK_INSTRUCT_SET_RGB  "0000FF"   "k"
	NK_INSTRUCT_SET_RGB  "00FFFF"   "l"
	NK_INSTRUCT_SET_RGB  "FF00FF"   "e"
	NK_INSTRUCT_SET_RGB  "FFFF00"   "a"
	NK_INSTRUCT_SET_RGBA "FFFFFF88" "r"
	NK_INSTRUCT_RESET_COLOR, NK_TEXT_LEFT);
```
looks like

![glfw_opengl3](https://github.com/user-attachments/assets/a1d54a09-9cb6-4823-b38a-13315c5b24c5)

The following backends have been tested

- [x] glfw_opengl3
