### PR TITLE
 Add delta_time_seconds to a 3 more renderers #627

### DIFF
--- a/demo/sdl_opengl2/nuklear_sdl_gl2.h
+++ b/demo/sdl_opengl2/nuklear_sdl_gl2.h
@@ -51,7 +51,7 @@ static struct nk_sdl {
     struct nk_sdl_device ogl;
     struct nk_context ctx;
     struct nk_font_atlas atlas;
-    double time_of_last_frame;
+    float time_of_last_frame;
 } sdl;
 
 NK_INTERN void
@@ -75,7 +75,7 @@ nk_sdl_render(enum nk_anti_aliasing AA)
     int display_width, display_height;
     struct nk_vec2 scale;
 
-    double now = ((double)SDL_GetTicks64()) / 1000;
+    float now = ((float)SDL_GetTicks64()) / 1000;
     sdl.ctx.delta_time_seconds = now - sdl.time_of_last_frame;
     sdl.time_of_last_frame = now;
 

--- a/demo/sdl_opengl2/nuklear_sdl_gl2.h
+++ b/demo/sdl_opengl2/nuklear_sdl_gl2.h
@@ -51,6 +51,7 @@ static struct nk_sdl {
     struct nk_sdl_device ogl;
     struct nk_context ctx;
     struct nk_font_atlas atlas;
+    double time_of_last_frame;
 } sdl;
 
 NK_INTERN void
@@ -73,6 +74,10 @@ nk_sdl_render(enum nk_anti_aliasing AA)
     int width, height;
     int display_width, display_height;
     struct nk_vec2 scale;
+
+    double now = ((double)SDL_GetTicks64()) / 1000;
+    sdl.ctx.delta_time_seconds = now - sdl.time_of_last_frame;
+    sdl.time_of_last_frame = now;
 
     SDL_GetWindowSize(sdl.win, &width, &height);
     SDL_GL_GetDrawableSize(sdl.win, &display_width, &display_height);

--- a/demo/sdl_opengl3/nuklear_sdl_gl3.h
+++ b/demo/sdl_opengl3/nuklear_sdl_gl3.h
@@ -67,6 +67,7 @@ static struct nk_sdl {
     struct nk_sdl_device ogl;
     struct nk_context ctx;
     struct nk_font_atlas atlas;
+    double time_of_last_frame;
 } sdl;
 
 #ifdef __APPLE__
@@ -192,11 +193,16 @@ nk_sdl_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_b
     int display_width, display_height;
     struct nk_vec2 scale;
     GLfloat ortho[4][4] = {
-        {2.0f, 0.0f, 0.0f, 0.0f},
-        {0.0f,-2.0f, 0.0f, 0.0f},
-        {0.0f, 0.0f,-1.0f, 0.0f},
-        {-1.0f,1.0f, 0.0f, 1.0f},
+        {  2.0f,  0.0f,  0.0f, 0.0f },
+        {  0.0f, -2.0f,  0.0f, 0.0f },
+        {  0.0f,  0.0f, -1.0f, 0.0f },
+        { -1.0f,  1.0f,  0.0f, 1.0f },
     };
+
+    double now = ((double)SDL_GetTicks64()) / 1000;
+    sdl.ctx.delta_time_seconds = now - sdl.time_of_last_frame;
+    sdl.time_of_last_frame = now;
+
     SDL_GetWindowSize(sdl.win, &width, &height);
     SDL_GL_GetDrawableSize(sdl.win, &display_width, &display_height);
     ortho[0][0] /= (GLfloat)width;

--- a/demo/sdl_opengl3/nuklear_sdl_gl3.h
+++ b/demo/sdl_opengl3/nuklear_sdl_gl3.h
@@ -67,7 +67,7 @@ static struct nk_sdl {
     struct nk_sdl_device ogl;
     struct nk_context ctx;
     struct nk_font_atlas atlas;
-    double time_of_last_frame;
+    float time_of_last_frame;
 } sdl;
 
 #ifdef __APPLE__
@@ -199,7 +199,7 @@ nk_sdl_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_b
         { -1.0f,  1.0f,  0.0f, 1.0f },
     };
 
-    double now = ((double)SDL_GetTicks64()) / 1000;
+    float now = ((float)SDL_GetTicks64()) / 1000;
     sdl.ctx.delta_time_seconds = now - sdl.time_of_last_frame;
     sdl.time_of_last_frame = now;
 

--- a/demo/sdl_opengles2/nuklear_sdl_gles2.h
+++ b/demo/sdl_opengles2/nuklear_sdl_gles2.h
@@ -71,6 +71,7 @@ static struct nk_sdl {
     struct nk_sdl_device ogl;
     struct nk_context ctx;
     struct nk_font_atlas atlas;
+    double time_of_last_frame;
 } sdl;
 
 
@@ -180,11 +181,16 @@ nk_sdl_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_b
     int display_width, display_height;
     struct nk_vec2 scale;
     GLfloat ortho[4][4] = {
-        {2.0f, 0.0f, 0.0f, 0.0f},
-        {0.0f,-2.0f, 0.0f, 0.0f},
-        {0.0f, 0.0f,-1.0f, 0.0f},
-        {-1.0f,1.0f, 0.0f, 1.0f},
+        {  2.0f,  0.0f,  0.0f, 0.0f },
+        {  0.0f, -2.0f,  0.0f, 0.0f },
+        {  0.0f,  0.0f, -1.0f, 0.0f },
+        { -1.0f,  1.0f,  0.0f, 1.0f },
     };
+
+    double now = ((double)SDL_GetTicks64()) / 1000;
+    sdl.ctx.delta_time_seconds = now - sdl.time_of_last_frame;
+    sdl.time_of_last_frame = now;
+
     SDL_GetWindowSize(sdl.win, &width, &height);
     SDL_GL_GetDrawableSize(sdl.win, &display_width, &display_height);
     ortho[0][0] /= (GLfloat)width;

--- a/demo/sdl_opengles2/nuklear_sdl_gles2.h
+++ b/demo/sdl_opengles2/nuklear_sdl_gles2.h
@@ -71,7 +71,7 @@ static struct nk_sdl {
     struct nk_sdl_device ogl;
     struct nk_context ctx;
     struct nk_font_atlas atlas;
-    double time_of_last_frame;
+    float time_of_last_frame;
 } sdl;
 
 
@@ -187,7 +187,7 @@ nk_sdl_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_b
         { -1.0f,  1.0f,  0.0f, 1.0f },
     };
 
-    double now = ((double)SDL_GetTicks64()) / 1000;
+    float now = ((float)SDL_GetTicks64()) / 1000;
     sdl.ctx.delta_time_seconds = now - sdl.time_of_last_frame;
     sdl.time_of_last_frame = now;
 


### PR DESCRIPTION
Adds delta_time_seconds for the following.
1. sdl_opengl2
2. sdl_opengl3
3. sdl_opengles2