### PR TITLE
Add delta_time_seconds to X11 and SFML renderers

### DIFF
--- a/demo/sdl_opengl2/nuklear_sdl_gl2.h
+++ b/demo/sdl_opengl2/nuklear_sdl_gl2.h
@@ -217,6 +217,7 @@ nk_sdl_init(SDL_Window *win)
     sdl.ctx.clip.paste = nk_sdl_clipboard_paste;
     sdl.ctx.clip.userdata = nk_handle_ptr(0);
     nk_buffer_init_default(&sdl.ogl.cmds);
+    sdl.time_of_last_frame = ((float)SDL_GetTicks64()) / 1000;
     return &sdl.ctx;
 }
 

--- a/demo/sdl_opengl3/nuklear_sdl_gl3.h
+++ b/demo/sdl_opengl3/nuklear_sdl_gl3.h
@@ -326,6 +326,7 @@ nk_sdl_init(SDL_Window *win)
     sdl.ctx.clip.paste = nk_sdl_clipboard_paste;
     sdl.ctx.clip.userdata = nk_handle_ptr(0);
     nk_sdl_device_create();
+    sdl.time_of_last_frame = ((float)SDL_GetTicks64()) / 1000;
     return &sdl.ctx;
 }
 

--- a/demo/sdl_opengles2/nuklear_sdl_gles2.h
+++ b/demo/sdl_opengles2/nuklear_sdl_gles2.h
@@ -326,6 +326,7 @@ nk_sdl_init(SDL_Window *win)
     sdl.ctx.clip.paste = nk_sdl_clipboard_paste;
     sdl.ctx.clip.userdata = nk_handle_ptr(0);
     nk_sdl_device_create();
+    sdl.time_of_last_frame = ((float)SDL_GetTicks64()) / 1000;
     return &sdl.ctx;
 }
 

--- a/demo/x11_opengl2/nuklear_xlib_gl2.h
+++ b/demo/x11_opengl2/nuklear_xlib_gl2.h
@@ -46,10 +46,10 @@ NK_API void                 nk_x11_shutdown(void);
 #include <GL/gl.h>
 
 #ifndef NK_X11_DOUBLE_CLICK_LO
-#define NK_X11_DOUBLE_CLICK_LO 20
+#define NK_X11_DOUBLE_CLICK_LO 0.02
 #endif
 #ifndef NK_X11_DOUBLE_CLICK_HI
-#define NK_X11_DOUBLE_CLICK_HI 200
+#define NK_X11_DOUBLE_CLICK_HI 0.20
 #endif
 
 struct nk_x11_vertex {
@@ -71,15 +71,16 @@ static struct nk_x11 {
     Cursor cursor;
     Display *dpy;
     Window win;
-    long last_button_click;
+    double last_button_click;
+    double time_of_last_frame;
 } x11;
 
-NK_INTERN long
-nk_timestamp(void)
+NK_INTERN double
+nk_get_time(void)
 {
     struct timeval tv;
     if (gettimeofday(&tv, NULL) < 0) return 0;
-    return (long)((long)tv.tv_sec * 1000 + (long)tv.tv_usec/1000);
+    return ((double)tv.tv_sec + (double)tv.tv_usec/1000000);
 }
 
 NK_INTERN void
@@ -101,6 +102,10 @@ nk_x11_render(enum nk_anti_aliasing AA, int max_vertex_buffer, int max_element_b
     struct nk_x11_device *dev = &x11.ogl;
     int width, height;
     XWindowAttributes attr;
+
+    double now = nk_get_time();
+    x11.ctx.delta_time_seconds = now - x11.time_of_last_frame;
+    x11.time_of_last_frame = now;
 
     NK_UNUSED(max_vertex_buffer);
     NK_UNUSED(max_element_buffer);
@@ -311,10 +316,10 @@ nk_x11_handle_event(XEvent *evt)
         const int x = evt->xbutton.x, y = evt->xbutton.y;
         if (evt->xbutton.button == Button1) {
             if (down) { /* Double-Click Button handler */
-                long dt = nk_timestamp() - x11.last_button_click;
+                float dt = nk_get_time() - x11.last_button_click;
                 if (dt > NK_X11_DOUBLE_CLICK_LO && dt < NK_X11_DOUBLE_CLICK_HI)
                     nk_input_button(ctx, NK_BUTTON_DOUBLE, x, y, nk_true);
-                x11.last_button_click = nk_timestamp();
+                x11.last_button_click = nk_get_time();
             } else nk_input_button(ctx, NK_BUTTON_DOUBLE, x, y, nk_false);
             nk_input_button(ctx, NK_BUTTON_LEFT, x, y, down);
         } else if (evt->xbutton.button == Button2)
@@ -363,6 +368,7 @@ nk_x11_init(Display *dpy, Window win)
 
     nk_buffer_init_default(&x11.ogl.cmds);
     nk_init_default(&x11.ctx, 0);
+    x11.time_of_last_frame = nk_get_time();
     return &x11.ctx;
 }
 


### PR DESCRIPTION
Adds delta_time_seconds for the following.
1. x11
2. x11_opengl2
3. x11_opengl3
4. x11_xft
5. sfml_opengl2
6. sfml_opengl3