### PR TITLE
Split `NK_WINDOW_NO_SCROLLBAR` into 2 flags

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -1457,7 +1457,9 @@ NK_API const struct nk_draw_command* nk__draw_next(const struct nk_draw_command*
 /// NK_WINDOW_SCALABLE          | The scalable flag indicates that a window can be scaled by user input by dragging a scaler icon at the button of the window
 /// NK_WINDOW_CLOSABLE          | Adds a closable icon into the header
 /// NK_WINDOW_MINIMIZABLE       | Adds a minimize icon into the header
-/// NK_WINDOW_NO_SCROLLBAR      | Removes the scrollbar from the window
+/// NK_WINDOW_NO_SCROLLBAR_H    | Removes the horizontal scrollbar from the window
+/// NK_WINDOW_NO_SCROLLBAR_V    | Removes the vertical scrollbar from the window
+/// NK_WINDOW_NO_SCROLLBAR      | Removes both scrollbars from the window
 /// NK_WINDOW_TITLE             | Forces a header at the top at the window showing the title
 /// NK_WINDOW_SCROLL_AUTO_HIDE  | Automatically hides the window scrollbar if no user interaction: also requires delta time in `nk_context` to be set each frame
 /// NK_WINDOW_BACKGROUND        | Always keep window in the background
@@ -1477,12 +1479,14 @@ enum nk_panel_flags {
     NK_WINDOW_SCALABLE          = NK_FLAG(2),
     NK_WINDOW_CLOSABLE          = NK_FLAG(3),
     NK_WINDOW_MINIMIZABLE       = NK_FLAG(4),
-    NK_WINDOW_NO_SCROLLBAR      = NK_FLAG(5),
-    NK_WINDOW_TITLE             = NK_FLAG(6),
-    NK_WINDOW_SCROLL_AUTO_HIDE  = NK_FLAG(7),
-    NK_WINDOW_BACKGROUND        = NK_FLAG(8),
-    NK_WINDOW_SCALE_LEFT        = NK_FLAG(9),
-    NK_WINDOW_NO_INPUT          = NK_FLAG(10)
+    NK_WINDOW_NO_SCROLLBAR_H    = NK_FLAG(5),
+    NK_WINDOW_NO_SCROLLBAR_V    = NK_FLAG(6),
+    NK_WINDOW_NO_SCROLLBAR      = NK_WINDOW_NO_SCROLLBAR_H | NK_WINDOW_NO_SCROLLBAR_V,
+    NK_WINDOW_TITLE             = NK_FLAG(7),
+    NK_WINDOW_SCROLL_AUTO_HIDE  = NK_FLAG(8),
+    NK_WINDOW_BACKGROUND        = NK_FLAG(9),
+    NK_WINDOW_SCALE_LEFT        = NK_FLAG(10),
+    NK_WINDOW_NO_INPUT          = NK_FLAG(11)
 };
 /*/// #### nk_begin
 /// Starts a new window; needs to be called every frame for every
@@ -19904,11 +19908,11 @@ nk_panel_begin(struct nk_context *ctx, const char *title, enum nk_panel_type pan
     layout->row.tree_depth = 0;
     layout->row.height = panel_padding.y;
     layout->has_scrolling = nk_true;
-    if (!(win->flags & NK_WINDOW_NO_SCROLLBAR))
+    if (!(win->flags & NK_WINDOW_NO_SCROLLBAR_V))
         layout->bounds.w -= scrollbar_size.x;
     if (!nk_panel_is_nonblock(panel_type)) {
         layout->footer_height = 0;
-        if (!(win->flags & NK_WINDOW_NO_SCROLLBAR) || win->flags & NK_WINDOW_SCALABLE)
+        if (!(win->flags & NK_WINDOW_NO_SCROLLBAR_H) || win->flags & NK_WINDOW_SCALABLE)
             layout->footer_height = scrollbar_size.y;
         layout->bounds.h -= layout->footer_height;
     }
@@ -20114,7 +20118,7 @@ nk_panel_end(struct nk_context *ctx)
         empty_space.y = layout->bounds.y;
         empty_space.w = panel_padding.x + layout->border;
         empty_space.h = layout->bounds.h;
-        if (*layout->offset_y == 0 && !(layout->flags & NK_WINDOW_NO_SCROLLBAR))
+        if (*layout->offset_y == 0 && !(layout->flags & NK_WINDOW_NO_SCROLLBAR_V))
             empty_space.w += scrollbar_size.x;
         nk_fill_rect(out, empty_space, 0, style->window.background);
 
@@ -20129,9 +20133,9 @@ nk_panel_end(struct nk_context *ctx)
     }
 
     /* scrollbars */
-    if (!(layout->flags & NK_WINDOW_NO_SCROLLBAR) &&
-        !(layout->flags & NK_WINDOW_MINIMIZED) &&
-        window->scrollbar_hiding_timer < NK_SCROLLBAR_HIDING_TIMEOUT)
+    if ((layout->flags & NK_WINDOW_NO_SCROLLBAR) != NK_WINDOW_NO_SCROLLBAR &&
+       !(layout->flags & NK_WINDOW_MINIMIZED) &&
+         window->scrollbar_hiding_timer < NK_SCROLLBAR_HIDING_TIMEOUT)
     {
         struct nk_rect scroll;
         int scroll_has_scrolling;
@@ -20150,6 +20154,7 @@ nk_panel_end(struct nk_context *ctx)
                 root_panel = root_panel->parent;
             while (root_window->parent)
                 root_window = root_window->parent;
+
 
             /* only allow scrolling if parent window is active */
             scroll_has_scrolling = 0;
@@ -20177,7 +20182,7 @@ nk_panel_end(struct nk_context *ctx)
             else window->scrolled = nk_false;
         } else scroll_has_scrolling = nk_false;
 
-        {
+        if (!(layout->flags & NK_WINDOW_NO_SCROLLBAR_V)) {
             /* vertical scrollbar */
             nk_flags state = 0;
             scroll.x = layout->bounds.x + layout->bounds.w + panel_padding.x;
@@ -20186,17 +20191,19 @@ nk_panel_end(struct nk_context *ctx)
             scroll.h = layout->bounds.h;
 
             scroll_offset = (float)*layout->offset_y;
-            scroll_step = scroll.h * 0.10f;
-            scroll_inc = scroll.h * 0.01f;
             scroll_target = (float)(int)(layout->at_y - scroll.y);
+            scroll_step   = scroll.h * 0.10f;
+            scroll_inc    = scroll.h * 0.01f;
             scroll_offset = nk_do_scrollbarv(&state, out, scroll, scroll_has_scrolling,
                 scroll_offset, scroll_target, scroll_step, scroll_inc,
                 &ctx->style.scrollv, in, style->font);
+
             *layout->offset_y = (nk_uint)scroll_offset;
+
             if (in && scroll_has_scrolling)
                 in->mouse.scroll_delta.y = 0;
         }
-        {
+        if (!(layout->flags & NK_WINDOW_NO_SCROLLBAR_H)) {
             /* horizontal scrollbar */
             nk_flags state = 0;
             scroll.x = layout->bounds.x;
@@ -20206,11 +20213,13 @@ nk_panel_end(struct nk_context *ctx)
 
             scroll_offset = (float)*layout->offset_x;
             scroll_target = (float)(int)(layout->max_x - scroll.x);
-            scroll_step = layout->max_x * 0.05f;
-            scroll_inc = layout->max_x * 0.005f;
+            scroll_step   = layout->max_x * 0.05f;
+            scroll_inc    = layout->max_x * 0.005f;
+
             scroll_offset = nk_do_scrollbarh(&state, out, scroll, scroll_has_scrolling,
                 scroll_offset, scroll_target, scroll_step, scroll_inc,
                 &ctx->style.scrollh, in, style->font);
+
             *layout->offset_x = (nk_uint)scroll_offset;
         }
     }
@@ -20250,7 +20259,7 @@ nk_panel_end(struct nk_context *ctx)
         if (layout->flags & NK_WINDOW_SCALE_LEFT)
             scaler.x = layout->bounds.x - panel_padding.x * 0.5f;
         else scaler.x = layout->bounds.x + layout->bounds.w + panel_padding.x;
-        if (layout->flags & NK_WINDOW_NO_SCROLLBAR)
+        if (layout->flags & NK_WINDOW_NO_SCROLLBAR_H)
             scaler.x -= scaler.w;
 
         /* draw scaler */
@@ -23036,10 +23045,12 @@ nk_group_scrolled_end(struct nk_context *ctx)
         pan.bounds.w += 2*g->border;
         pan.bounds.h += 2*g->border;
     }
-    if (!(g->flags & NK_WINDOW_NO_SCROLLBAR)) {
+    if (!(g->flags & NK_WINDOW_NO_SCROLLBAR_V))
         pan.bounds.w += ctx->style.window.scrollbar_size.x;
+
+    if (!(g->flags & NK_WINDOW_NO_SCROLLBAR_H))
         pan.bounds.h += ctx->style.window.scrollbar_size.y;
-    }
+
     pan.scrollbar.x = *g->offset_x;
     pan.scrollbar.y = *g->offset_y;
     pan.flags = g->flags;

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -1235,7 +1235,9 @@ NK_API const struct nk_draw_command* nk__draw_next(const struct nk_draw_command*
 /// NK_WINDOW_SCALABLE          | The scalable flag indicates that a window can be scaled by user input by dragging a scaler icon at the button of the window
 /// NK_WINDOW_CLOSABLE          | Adds a closable icon into the header
 /// NK_WINDOW_MINIMIZABLE       | Adds a minimize icon into the header
-/// NK_WINDOW_NO_SCROLLBAR      | Removes the scrollbar from the window
+/// NK_WINDOW_NO_SCROLLBAR_H    | Removes the horizontal scrollbar from the window
+/// NK_WINDOW_NO_SCROLLBAR_V    | Removes the vertical scrollbar from the window
+/// NK_WINDOW_NO_SCROLLBAR      | Removes all scrollbars from the window
 /// NK_WINDOW_TITLE             | Forces a header at the top at the window showing the title
 /// NK_WINDOW_SCROLL_AUTO_HIDE  | Automatically hides the window scrollbar if no user interaction: also requires delta time in `nk_context` to be set each frame
 /// NK_WINDOW_BACKGROUND        | Always keep window in the background
@@ -1255,12 +1257,14 @@ enum nk_panel_flags {
     NK_WINDOW_SCALABLE          = NK_FLAG(2),
     NK_WINDOW_CLOSABLE          = NK_FLAG(3),
     NK_WINDOW_MINIMIZABLE       = NK_FLAG(4),
-    NK_WINDOW_NO_SCROLLBAR      = NK_FLAG(5),
-    NK_WINDOW_TITLE             = NK_FLAG(6),
-    NK_WINDOW_SCROLL_AUTO_HIDE  = NK_FLAG(7),
-    NK_WINDOW_BACKGROUND        = NK_FLAG(8),
-    NK_WINDOW_SCALE_LEFT        = NK_FLAG(9),
-    NK_WINDOW_NO_INPUT          = NK_FLAG(10)
+    NK_WINDOW_NO_SCROLLBAR_H    = NK_FLAG(5),
+    NK_WINDOW_NO_SCROLLBAR_V    = NK_FLAG(6),
+    NK_WINDOW_NO_SCROLLBAR      = NK_WINDOW_NO_SCROLLBAR_H | NK_WINDOW_NO_SCROLLBAR_V,
+    NK_WINDOW_TITLE             = NK_FLAG(7),
+    NK_WINDOW_SCROLL_AUTO_HIDE  = NK_FLAG(8),
+    NK_WINDOW_BACKGROUND        = NK_FLAG(9),
+    NK_WINDOW_SCALE_LEFT        = NK_FLAG(10),
+    NK_WINDOW_NO_INPUT          = NK_FLAG(11)
 };
 /*/// #### nk_begin
 /// Starts a new window; needs to be called every frame for every

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -1237,7 +1237,7 @@ NK_API const struct nk_draw_command* nk__draw_next(const struct nk_draw_command*
 /// NK_WINDOW_MINIMIZABLE       | Adds a minimize icon into the header
 /// NK_WINDOW_NO_SCROLLBAR_H    | Removes the horizontal scrollbar from the window
 /// NK_WINDOW_NO_SCROLLBAR_V    | Removes the vertical scrollbar from the window
-/// NK_WINDOW_NO_SCROLLBAR      | Removes all scrollbars from the window
+/// NK_WINDOW_NO_SCROLLBAR      | Removes both scrollbars from the window
 /// NK_WINDOW_TITLE             | Forces a header at the top at the window showing the title
 /// NK_WINDOW_SCROLL_AUTO_HIDE  | Automatically hides the window scrollbar if no user interaction: also requires delta time in `nk_context` to be set each frame
 /// NK_WINDOW_BACKGROUND        | Always keep window in the background

--- a/src/nuklear_group.c
+++ b/src/nuklear_group.c
@@ -92,10 +92,12 @@ nk_group_scrolled_end(struct nk_context *ctx)
         pan.bounds.w += 2*g->border;
         pan.bounds.h += 2*g->border;
     }
-    if (!(g->flags & NK_WINDOW_NO_SCROLLBAR)) {
+    if (!(g->flags & NK_WINDOW_NO_SCROLLBAR_V))
         pan.bounds.w += ctx->style.window.scrollbar_size.x;
+
+    if (!(g->flags & NK_WINDOW_NO_SCROLLBAR_H))
         pan.bounds.h += ctx->style.window.scrollbar_size.y;
-    }
+
     pan.scrollbar.x = *g->offset_x;
     pan.scrollbar.y = *g->offset_y;
     pan.flags = g->flags;


### PR DESCRIPTION
Splits `NK_WINDOW_NO_SCROLLBAR` into separate horizontal and vertical flags.

```c
/* Removes the horizontal scrollbar from the window */
NK_WINDOW_NO_SCROLLBAR_H = NK_FLAG(5)
/* Removes the vertical scrollbar from the window */
NK_WINDOW_NO_SCROLLBAR_V = NK_FLAG(6)
/* Removes both scrollbars from the window */
NK_WINDOW_NO_SCROLLBAR   = NK_WINDOW_NO_SCROLLBAR_H | NK_WINDOW_NO_SCROLLBAR_V
```

Needs more testing.