### PR TITLE
Fix nk_property not focusing when clicking mouse when the clicked property box is before the currently focused property box in the current window

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -6773,7 +6773,7 @@ nk_strtoi(const char *str, char **endptr)
         p++;
     }
     if (endptr)
-        *endptr = p;
+        *endptr = (char *)p;
     return neg*value;
 }
 NK_API double
@@ -6830,7 +6830,7 @@ nk_strtod(const char *str, char **endptr)
     }
     number = value * neg;
     if (endptr)
-        *endptr = p;
+        *endptr = (char *)p;
     return number;
 }
 NK_API float

--- a/nuklear.h
+++ b/nuklear.h
@@ -3834,11 +3834,11 @@ NK_API struct nk_vec2 nk_rect_size(struct nk_rect);
 NK_API int nk_strlen(const char *str);
 NK_API int nk_stricmp(const char *s1, const char *s2);
 NK_API int nk_stricmpn(const char *s1, const char *s2, int n);
-NK_API int nk_strtoi(const char *str, const char **endptr);
-NK_API float nk_strtof(const char *str, const char **endptr);
+NK_API int nk_strtoi(const char *str, char **endptr);
+NK_API float nk_strtof(const char *str, char **endptr);
 #ifndef NK_STRTOD
 #define NK_STRTOD nk_strtod
-NK_API double nk_strtod(const char *str, const char **endptr);
+NK_API double nk_strtod(const char *str, char **endptr);
 #endif
 NK_API int nk_strfilter(const char *text, const char *regexp);
 NK_API int nk_strmatch_fuzzy_string(char const *str, char const *pattern, int *out_score);
@@ -6753,7 +6753,7 @@ nk_strlen(const char *str)
     return siz;
 }
 NK_API int
-nk_strtoi(const char *str, const char **endptr)
+nk_strtoi(const char *str, char **endptr)
 {
     int neg = 1;
     const char *p = str;
@@ -6777,7 +6777,7 @@ nk_strtoi(const char *str, const char **endptr)
     return neg*value;
 }
 NK_API double
-nk_strtod(const char *str, const char **endptr)
+nk_strtod(const char *str, char **endptr)
 {
     double m;
     double neg = 1.0;
@@ -6834,7 +6834,7 @@ nk_strtod(const char *str, const char **endptr)
     return number;
 }
 NK_API float
-nk_strtof(const char *str, const char **endptr)
+nk_strtof(const char *str, char **endptr)
 {
     float float_value;
     double double_value;
@@ -28869,7 +28869,7 @@ nk_property(struct nk_context *ctx, const char *name, struct nk_property_variant
         select_end, &style->property, filter, in, style->font, &ctx->text_edit,
         ctx->button_behavior);
 
-    if (in && *state != NK_PROPERTY_DEFAULT && !win->property.active) {
+    if (in && *state != NK_PROPERTY_DEFAULT && !(win->property.active && hash == win->property.name)) {
         /* current property is now hot */
         win->property.active = 1;
         NK_MEMCPY(win->property.buffer, buffer, (nk_size)*len);

--- a/src/nuklear_property.c
+++ b/src/nuklear_property.c
@@ -395,7 +395,7 @@ nk_property(struct nk_context *ctx, const char *name, struct nk_property_variant
         select_end, &style->property, filter, in, style->font, &ctx->text_edit,
         ctx->button_behavior);
 
-    if (in && *state != NK_PROPERTY_DEFAULT && !win->property.active) {
+    if (in && *state != NK_PROPERTY_DEFAULT && !(win->property.active && hash == win->property.name)) {
         /* current property is now hot */
         win->property.active = 1;
         NK_MEMCPY(win->property.buffer, buffer, (nk_size)*len);

--- a/src/nuklear_util.c
+++ b/src/nuklear_util.c
@@ -161,7 +161,7 @@ nk_strtoi(const char *str, char **endptr)
         p++;
     }
     if (endptr)
-        *endptr = p;
+        *endptr = (char *)p;
     return neg*value;
 }
 NK_API double
@@ -218,7 +218,7 @@ nk_strtod(const char *str, char **endptr)
     }
     number = value * neg;
     if (endptr)
-        *endptr = p;
+        *endptr = (char *)p;
     return number;
 }
 NK_API float


### PR DESCRIPTION
As titled.

Demonstration:

Current (notice when clicking the first box after the second one is focused, it immediately loses focus)
https://github.com/user-attachments/assets/a04e6fb8-e638-4b7f-b0d6-fee5c297a657

Fixed (this PR):
https://github.com/user-attachments/assets/e482c328-1bf3-4751-979c-6f7e63292b7a

Also ran paq.sh and added casts to match the changes in a previous PR (#682) to get rid of the type warnings introduced in that previous PR.