### PR TITLE
allegro5: take image region into account for NK_COMMAND_IMAGE

### DIFF
--- a/demo/allegro5/nuklear_allegro5.h
+++ b/demo/allegro5/nuklear_allegro5.h
@@ -324,9 +324,11 @@ nk_allegro5_render()
         } break;
         case NK_COMMAND_IMAGE: {
             const struct nk_command_image *i = (const struct nk_command_image *)cmd;
+            nk_ushort w = i->img.region[2],
+                h = i->img.region[3];
             al_draw_scaled_bitmap(i->img.handle.ptr,
                                   i->img.region[0], i->img.region[1],
-                                  i->img.region[2], i->img.region[3],
+                                  w ? w : i->w, h ? h : i->h,
                                   i->x, i->y, i->w, i->h, 0);
         } break;
         case NK_COMMAND_RECT_MULTI_COLOR:

--- a/demo/allegro5/nuklear_allegro5.h
+++ b/demo/allegro5/nuklear_allegro5.h
@@ -324,12 +324,17 @@ nk_allegro5_render()
         } break;
         case NK_COMMAND_IMAGE: {
             const struct nk_command_image *i = (const struct nk_command_image *)cmd;
-            nk_ushort w = i->img.region[2],
+            nk_ushort
+                x = i->img.region[0],
+                y = i->img.region[1],
+                w = i->img.region[2],
                 h = i->img.region[3];
+            if(w == 0 && h == 0)
+            {
+                x = i->x; y = i->y; w = i->w; h = i->h;
+            }
             al_draw_scaled_bitmap(i->img.handle.ptr,
-                                  i->img.region[0], i->img.region[1],
-                                  w ? w : i->w, h ? h : i->h,
-                                  i->x, i->y, i->w, i->h, 0);
+                                  x, y, w, h, i->x, i->y, i->w, i->h, 0);
         } break;
         case NK_COMMAND_RECT_MULTI_COLOR:
         default: break;

--- a/demo/allegro5/nuklear_allegro5.h
+++ b/demo/allegro5/nuklear_allegro5.h
@@ -324,7 +324,10 @@ nk_allegro5_render()
         } break;
         case NK_COMMAND_IMAGE: {
             const struct nk_command_image *i = (const struct nk_command_image *)cmd;
-            al_draw_bitmap_region(i->img.handle.ptr, 0, 0, i->w, i->h, i->x, i->y, 0);
+            al_draw_scaled_bitmap(i->img.handle.ptr,
+                                  i->img.region[0], i->img.region[1],
+                                  i->img.region[2], i->img.region[3],
+                                  i->x, i->y, i->w, i->h, 0);
         } break;
         case NK_COMMAND_RECT_MULTI_COLOR:
         default: break;


### PR DESCRIPTION
Hey. This pull request makes allegro5 backend take the image region into account for `NK_COMMAND_IMAGE` command. Without that, it is impossible to e.g. correctly render 9-slice, consider:

before:
![2024-09-17-205052_277x244_scrot](https://github.com/user-attachments/assets/869bd253-709b-44a6-9d44-74b6223c2027)

after:
![2024-09-17-205031_266x252_scrot](https://github.com/user-attachments/assets/32c3425b-c99a-4987-ae35-b408369e384e)

I suspect similar problem is present in gdi, gdi_native, gdip, rawfb, x11 and x11_xft backends, but unfortunately I lack the knowledge nor time to fix those.
