### PR TITLE
Update proggyfont urls

### DIFF
--- a/src/nuklear_font.c
+++ b/src/nuklear_font.c
@@ -567,8 +567,8 @@ nk_font_init(struct nk_font *font, float pixel_height,
  *
  * ProggyClean.ttf
  * Copyright (c) 2004, 2005 Tristan Grimmer
- * MIT license (see License.txt in http://www.upperbounds.net/download/ProggyClean.ttf.zip)
- * Download and more information at http://upperbounds.net
+ * MIT license https://github.com/bluescan/proggyfonts/blob/master/LICENSE
+ * Download and more information at https://github.com/bluescan/proggyfonts
  *-----------------------------------------------------------------------------*/
 #ifdef __clang__
 #pragma clang diagnostic push


### PR DESCRIPTION
Original website was compromised and is serving malware

Changed it for the author's github page instead