### PR TITLE
demo: Rename zahnrad binaries to demo

### DIFF
--- a/demo/rawfb/x11/Makefile
+++ b/demo/rawfb/x11/Makefile
@@ -1,5 +1,5 @@
 # Install
-BIN = zahnrad
+BIN = demo
 
 # Flags
 CFLAGS += -std=c89 -Wall -Wextra -pedantic -Wno-unused-function -O2

--- a/demo/x11/Makefile
+++ b/demo/x11/Makefile
@@ -1,5 +1,5 @@
 # Install
-BIN = zahnrad
+BIN = demo
 
 # Flags
 CFLAGS += -std=c89 -Wall -Wextra -pedantic -Wno-unused-function -O2

--- a/demo/x11_xft/Makefile
+++ b/demo/x11_xft/Makefile
@@ -1,5 +1,5 @@
 # Install
-BIN = zahnrad
+BIN = demo
 
 # Flags
 CFLAGS += -std=c89 -Wall -Wextra -pedantic -Wno-unused-function -O2


### PR DESCRIPTION
Some of the demos built out their binaries as `zahnrad`, which doesn't match the rest of the `demo` builds. This consolidates them to `demo`.
