### PR TITLE
Add up/down/ctrl-b/ctrl-e key handling to d3d11 demo

### DIFF
--- a/demo/d3d11/nuklear_d3d11.h
+++ b/demo/d3d11/nuklear_d3d11.h
@@ -239,6 +239,14 @@ nk_d3d11_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
             nk_input_key(&d3d11.ctx, NK_KEY_TAB, down);
             return 1;
 
+        case VK_UP:
+            nk_input_key(&d3d11.ctx, NK_KEY_UP, down);
+            return 1;
+
+        case VK_DOWN:
+            nk_input_key(&d3d11.ctx, NK_KEY_DOWN, down);
+            return 1;
+
         case VK_LEFT:
             if (ctrl)
                 nk_input_key(&d3d11.ctx, NK_KEY_TEXT_WORD_LEFT, down);
@@ -274,6 +282,20 @@ nk_d3d11_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
         case VK_PRIOR:
             nk_input_key(&d3d11.ctx, NK_KEY_SCROLL_UP, down);
             return 1;
+
+        case 'B':
+            if (ctrl) {
+                nk_input_key(&d3d11.ctx, NK_KEY_TEXT_LINE_START, down);
+                return 1;
+            }
+            break;
+
+        case 'E':
+            if (ctrl) {
+                nk_input_key(&d3d11.ctx, NK_KEY_TEXT_LINE_END, down);
+                return 1;
+            }
+            break;
 
         case 'C':
             if (ctrl) {


### PR DESCRIPTION
Behaviors match the ones in sdl demos.

I may add hi-dpi support to the d3d demo in similar fashion to how the sdl opengl ones work. That will be a separate PR.