### PR TITLE
disables intrinsics on SDL demos

### DIFF
--- a/demo/sdl_opengl2/Makefile
+++ b/demo/sdl_opengl2/Makefile
@@ -2,7 +2,7 @@
 BIN = demo
 
 # Flags
-CFLAGS += -std=c89 -Wall -Wextra -pedantic -O2
+CFLAGS += -std=c89 -Wall -Wextra -pedantic -O2 -DSDL_DISABLE_IMMINTRIN_H
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/demo/sdl_opengl2/main.c
+++ b/demo/sdl_opengl2/main.c
@@ -34,7 +34,7 @@
  * ===============================================================*/
 /* This are some code examples to provide a small overview of what can be
  * done with this library. To try out an example uncomment the defines */
-/*#define INCLUDE_ALL */
+#define INCLUDE_ALL 
 /*#define INCLUDE_STYLE */
 /*#define INCLUDE_CALCULATOR */
 /*#define INCLUDE_CANVAS */

--- a/demo/sdl_opengl3/Makefile
+++ b/demo/sdl_opengl3/Makefile
@@ -2,7 +2,7 @@
 BIN = demo
 
 # Flags
-CFLAGS += -std=c89 -Wall -Wextra -pedantic -O2
+CFLAGS += -std=c89 -Wall -Wextra -pedantic -O2 -DSDL_DISABLE_IMMINTRIN_H
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/demo/sdl_opengles2/Makefile
+++ b/demo/sdl_opengles2/Makefile
@@ -2,7 +2,7 @@
 BIN = demo
 
 # Flags
-CFLAGS += -std=c89 -Wall -Wextra -pedantic -O2
+CFLAGS += -std=c89 -Wall -Wextra -pedantic -O2 -DSDL_DISABLE_IMMINTRIN_H
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/demo/sdl_renderer/Makefile
+++ b/demo/sdl_renderer/Makefile
@@ -2,7 +2,7 @@
 BIN = demo
 
 # Flags
-CFLAGS += -std=c89 -pedantic -O0
+CFLAGS += -std=c89 -Wall -Wextra -pedantic -O2 -DSDL_DISABLE_IMMINTRIN_H
 CFLAGS += `sdl2-config --cflags`
 
 SRC = main.c

--- a/demo/sdl_vulkan/Makefile
+++ b/demo/sdl_vulkan/Makefile
@@ -3,6 +3,7 @@ BIN = demo
 
 # Flags
 CFLAGS += -std=c89 -Wall -Wextra -pedantic -fsanitize=address -O2
+CFLAGS += -DSDL_DISABLE_IMMINTRIN_H
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/demo/x11_opengl2/Makefile
+++ b/demo/x11_opengl2/Makefile
@@ -2,7 +2,7 @@
 BIN = demo
 
 # Compiler
-CC = clang
+CC ?= clang
 DCC = gcc
 
 # Flags
@@ -13,11 +13,11 @@ OBJ = $(SRC:.c=.o)
 
 # Modes
 .PHONY: gcc
-gcc: CC = gcc
+gcc: CC ?= gcc
 gcc: $(BIN)
 
 .PHONY: clang
-clang: CC = clang
+clang: CC ?= clang
 clang: $(BIN)
 
 $(BIN):

--- a/demo/x11_opengl3/Makefile
+++ b/demo/x11_opengl3/Makefile
@@ -2,7 +2,7 @@
 BIN = demo
 
 # Compiler
-CC = clang
+CC ?= clang
 DCC = gcc
 
 # Flags
@@ -13,11 +13,11 @@ OBJ = $(SRC:.c=.o)
 
 # Modes
 .PHONY: gcc
-gcc: CC = gcc
+gcc: CC ?= gcc
 gcc: $(BIN)
 
 .PHONY: clang
-clang: CC = clang
+clang: CC ?= clang
 clang: $(BIN)
 
 $(BIN):


### PR DESCRIPTION
SDL library has an issue where it expects intrinsics headers to be provided, but intrinsics are not exactly part of a standard, so there is no guarantee that they will be available. As such, the library allows you to turn them off. I am disabling them to allow for better portability and ease of compilation.