### PR TITLE
Makefile Upgrade

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,36 +1,90 @@
 
-docs_path:=./doc
-doxyfile:=$(docs_path)/Doxyfile
+######################################################################################
+##  								 SETTINGS                                       ##
+######################################################################################
+
+## path stuff
+DOCS_PATH:=./doc
+DEMO_PATH=demo
+SRC_PATH=src
 
 
+## Documents settings
+DOXYFILE:=$(DOCS_PATH)/Doxyfile
 
-.PHONY: usage
+
+## HEADER file packing settings
+## note: source file paths are prefixed later, no need to add prefix here; just
+## give it the name.
+MACRO = NK
+INTRO =  HEADER.md
+PUB = nuklear.h
+OUTPUT = nuklear.h
+
+PRIV1 = nuklear_internal.h nuklear_math.c nuklear_util.c nuklear_color.c nuklear_utf8.c nuklear_buffer.c nuklear_string.c nuklear_draw.c nuklear_vertex.c 
+
+EXTERN =  stb_rect_pack.h stb_truetype.h 
+
+PRIV2 = nuklear_font.c nuklear_input.c nuklear_style.c nuklear_context.c nuklear_pool.c nuklear_page_element.c nuklear_table.c nuklear_panel.c nuklear_window.c nuklear_popup.c nuklear_contextual.c nuklear_menu.c nuklear_layout.c nuklear_tree.c nuklear_group.c nuklear_list_view.c nuklear_widget.c nuklear_text.c nuklear_image.c nuklear_9slice.c nuklear_button.c nuklear_toggle.c nuklear_selectable.c nuklear_slider.c nuklear_knob.c nuklear_progress.c nuklear_scrollbar.c nuklear_text_editor.c nuklear_edit.c nuklear_property.c nuklear_chart.c nuklear_color_picker.c nuklear_combo.c nuklear_tooltip.c
+
+OUTRO = LICENSE CHANGELOG CREDITS
+
+## Demo settings
+DEMO_LIST = $(shell find $(DEMO_PATH) -type f -name Makefile -printf "%h ")
+
+######################################################################################
+##  								 RECIPES                                        ##
+######################################################################################
+
+
+.PHONY: usage all demos $(DEMO_LIST)
 
 usage:
 	echo "make docs		to create documentation"
 	echo "make nuke		to rebuild the single header nuklear.h from source"
+	echo "make demos	to build all of the demos
 	echo "make all 		to re-pack the header and create documentation"
-	echo "make install 	to "install" man files"
+
+all: docs nuke demos 
+demos: $(DEMO_LIST)
 
 
-docs: $(docs_path)/html/index.html 
+########################################################################################
+##   Nuklear.h
 
-$(docs_path)/html/index.html: $(docs_path)/doxygen-awesome-css/doxygen-awesome.css $(doxyfile)
-	doxygen $(doxyfile)
+nuke: $(addprefix $(SRC_PATH)/, $(SRC))
+	python3 $(SRC_PATH)/build.py --macro $(MACRO) --intro $(addprefix $(SRC_PATH)/, $(INTRO)) --pub $(addprefix $(SRC_PATH)/, $(PUB)) --priv1 "$(addprefix $(SRC_PATH)/, $(PRIV1))" --extern "$(addprefix $(SRC_PATH)/, $(EXTERN))" --priv2 "$(addprefix $(SRC_PATH)/, $(PRIV2))" --outro "$(addprefix $(SRC_PATH)/, $(OUTRO))" > $(OUTPUT)
 
-$(doxyfile):
+
+
+
+
+########################################################################################
+##   Docs
+
+docs: $(DOCS_PATH)/html/index.html 
+
+$(DOCS_PATH)/html/index.html: $(DOCS_PATH)/doxygen-awesome-css/doxygen-awesome.css $(DOXYFILE)
+	doxygen $(DOXYFILE)
+
+$(DOXYFILE):
 	doxygen -g $@
 
-$(docs_path)/doxygen-awesome-css/doxygen-awesome.css:
-	git clone https://github.com/jothepro/doxygen-awesome-css.git $(docs_path)/doxygen-awesome-css --branch v2.3.4
+$(DOCS_PATH)/doxygen-awesome-css/doxygen-awesome.css:
+	git clone https://github.com/jothepro/doxygen-awesome-css.git $(DOCS_PATH)/doxygen-awesome-css --branch v2.3.4
 
-nuke:
-	cd ./src && ./paq.sh
 
-all: docs nuke
 
-install:
+########################################################################################
+##   Demos
+
+$(DEMO_LIST):
+	$(MAKE) -C $@
+
+
+
+########################################################################################
+##   Utility helpers
 
 clean:
-	rm -rf $(docs_path)/html
-
+	rm -rf $(DOCS_PATH)/html $(OUTPUT)

--- a/src/build.py
+++ b/src/build.py
@@ -9,6 +9,7 @@ def print_help():
 """usage: python single_header_packer.py --macro <macro> [--intro <files>] --extern <files> --pub <files> --priv1 <files> --priv2 <files> [--outro <files>]
 
        where <files> can be a comma-separated list of files. e.g. --priv *.c,inc/*.h
+       or a space separated list encapsulated in quotes. e.g. --priv1 "file.c file2.c file3.c"
 
        The 'extern' files are placed between 'priv1' and 'priv2'.
 
@@ -33,7 +34,8 @@ def print_help():
 
 def parse_files(arg):
     files = []
-    paths = arg.split(",")
+    paths = re.split(r'[,\s]', arg)
+
     for path in paths:
         if "*" in path:
             # Wildcard


### PR DESCRIPTION
The top level makefile has been upgraded to handle the building of everything in the project. Demos are recursively built, documentation is created, and Nuklear.h gets paq'd.  This does not break the previous build system, only adds a new path.

In order to make this happen, a small modification to `build.py` needed to happen to allow space delimited lists of files. Note, this change is backwards compatible.

Using the makefile at the top level for the building is not only familiar to C developers; but also provides better control and build capabilities to any automated systems. Multi-threaded building and processing, plus inherited compiler variables can help to simplify more advanced build procedures while providing a clean and common way for developers to make future adjustments.

After this update, I hope to modify the github workflow to reduce build times.
