### PR TITLE
Restore documentation on github pages with Doxygen generated doc

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,26 @@
+name: Documentation on github.io
+
+on:
+  push:
+    branches: [ github.io ]
+
+jobs:
+  build-documentation:
+    runs-on: ubuntu-latest
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4
+    - name: apt-update
+      run: sudo apt-get update -qq
+    - name: apt-get doxygen
+      run: sudo apt-get install -y doxygen
+    - name: build doc
+      run: make docs
+    - name: deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs/html/
+        enable_jekyll: false
+        allow_empty_commit: false
+        force_orphan: true

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Documentation on github.io
 
 on:
   push:
-    branches: [ github.io ]
+    branches: [ master ]
 
 jobs:
   build-documentation:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -17,10 +17,10 @@ jobs:
     - name: build doc
       run: make docs
     - name: deploy
-      uses: peaceiris/actions-gh-pages@v3
+      uses: peaceiris/actions-gh-pages@v4
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./docs/html/
+        publish_dir: ./doc/html/
         enable_jekyll: false
         allow_empty_commit: false
         force_orphan: true

--- a/Readme.md
+++ b/Readme.md
@@ -25,7 +25,7 @@ render backends, it focuses only on the actual UI.
 - No global or hidden state
 - Customizable library modules (you can compile and use only what you need)
 - Optional font baker and vertex buffer output
-- [Documentation](https://Immediate-Mode-UI.github.io/Nuklear/doc/nuklear.html)
+- [Documentation](https://Immediate-Mode-UI.github.io/Nuklear/)
 
 ## Building
 

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -907,8 +907,7 @@ WARN_LOGFILE           =
 # Note: If this tag is empty the current directory is searched.
 
 INPUT                  =    "./src" \
-                            "./src/HEADER.md" \
-                            "./Readme.md"
+                            "./src/HEADER.md"
 
 
 
@@ -1001,7 +1000,7 @@ RECURSIVE              = NO
 
 EXCLUDE                = "./src/Readme.md" \
                             "./src/paq.sh" \
-                            "./src/paq.bat" 
+                            "./src/paq.bat"
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded

--- a/doc/Doxyfile
+++ b/doc/Doxyfile
@@ -1109,7 +1109,7 @@ FILTER_SOURCE_PATTERNS =
 # (index.html). This can be useful if you have a project on for instance GitHub
 # and want to reuse the introduction page also for the doxygen output.
 
-USE_MDFILE_AS_MAINPAGE = Readme.md
+USE_MDFILE_AS_MAINPAGE = src/HEADER.md
 
 #---------------------------------------------------------------------------
 # Configuration options related to source browsing


### PR DESCRIPTION
This is an attempt to fix issue #730 since the original `gh-pages` branch is not fed anymore (with `.gitignore` changes).

I'm not an expert at all with Doxygen and github actions, so that might need more work (help is welcome).

With this, a few hints:
* I have removed README.md as start page, because it was not giving much and the _Documentation_ link was conflicting, instead the start page is made from `src/HEADER.md`
* The build generates a lot of warnings and errors. I suppose warnings can be fixed in the future from source files. Errors seem to come from the missing `dot` command (an additional package might be added to the required docker image before running doxygen)
* Once merged, `Pages` settings of the repository need to be changed because the generated doc is done in the root of the `gh-pages` branch (and not `/docs` anymore). This is how I have setup my fork :

![Change in the folder to be used as root for pages](https://i.imgur.com/zUBmsTp.png)

The result can be [seen on my fork](https://riri.github.io/Nuklear/index.html) deployed pages :)
