### PR TITLE
Fix: property border uses same color as its background

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -28737,7 +28737,7 @@ nk_draw_property(struct nk_command_buffer *out, const struct nk_style_property *
         case NK_STYLE_ITEM_COLOR:
             text.background = background->data.color;
             nk_fill_rect(out, *bounds, style->rounding, nk_rgb_factor(background->data.color, style->color_factor));
-            nk_stroke_rect(out, *bounds, style->rounding, style->border, nk_rgb_factor(background->data.color, style->color_factor));
+            nk_stroke_rect(out, *bounds, style->rounding, style->border, nk_rgb_factor(style->border_color, style->color_factor));
             break;
     }
 

--- a/src/nuklear_property.c
+++ b/src/nuklear_property.c
@@ -100,7 +100,7 @@ nk_draw_property(struct nk_command_buffer *out, const struct nk_style_property *
         case NK_STYLE_ITEM_COLOR:
             text.background = background->data.color;
             nk_fill_rect(out, *bounds, style->rounding, nk_rgb_factor(background->data.color, style->color_factor));
-            nk_stroke_rect(out, *bounds, style->rounding, style->border, nk_rgb_factor(background->data.color, style->color_factor));
+            nk_stroke_rect(out, *bounds, style->rounding, style->border, nk_rgb_factor(style->border_color, style->color_factor));
             break;
     }
 


### PR DESCRIPTION
Got across this small bug in code where the border color of the property widget matches the color of its background rendering it invisible. This PR should fix this bug.

### Expected behavior
Property draws its border as i defined it in styles
![Property with borders](https://github.com/user-attachments/assets/e3605838-3cb0-478b-81e5-0ee528bff828)

### Actual behavior
Property draws its border with the same color making it not visible
![Property with bugged borders](https://github.com/user-attachments/assets/8a0a7f3c-cda5-4ab1-9176-2333a3caea51)

This becomes more apparent with wider borders
![Property with large bugged borders](https://github.com/user-attachments/assets/742b371b-77f5-4a36-b800-c638806de961)
