### PR TITLE
Support numpad Enter with SDL backends

### DIFF
--- a/demo/sdl_opengl2/nuklear_sdl_gl2.h
+++ b/demo/sdl_opengl2/nuklear_sdl_gl2.h
@@ -273,7 +273,10 @@ nk_sdl_handle_event(SDL_Event *evt)
                     case SDLK_RSHIFT: /* RSHIFT & LSHIFT share same routine */
                     case SDLK_LSHIFT:    nk_input_key(ctx, NK_KEY_SHIFT, down); break;
                     case SDLK_DELETE:    nk_input_key(ctx, NK_KEY_DEL, down); break;
+
+                    case SDLK_KP_ENTER:
                     case SDLK_RETURN:    nk_input_key(ctx, NK_KEY_ENTER, down); break;
+
                     case SDLK_TAB:       nk_input_key(ctx, NK_KEY_TAB, down); break;
                     case SDLK_BACKSPACE: nk_input_key(ctx, NK_KEY_BACKSPACE, down); break;
                     case SDLK_HOME:      nk_input_key(ctx, NK_KEY_TEXT_START, down);

--- a/demo/sdl_opengl3/nuklear_sdl_gl3.h
+++ b/demo/sdl_opengl3/nuklear_sdl_gl3.h
@@ -383,7 +383,10 @@ nk_sdl_handle_event(SDL_Event *evt)
                     case SDLK_RSHIFT: /* RSHIFT & LSHIFT share same routine */
                     case SDLK_LSHIFT:    nk_input_key(ctx, NK_KEY_SHIFT, down); break;
                     case SDLK_DELETE:    nk_input_key(ctx, NK_KEY_DEL, down); break;
+
+                    case SDLK_KP_ENTER:
                     case SDLK_RETURN:    nk_input_key(ctx, NK_KEY_ENTER, down); break;
+
                     case SDLK_TAB:       nk_input_key(ctx, NK_KEY_TAB, down); break;
                     case SDLK_BACKSPACE: nk_input_key(ctx, NK_KEY_BACKSPACE, down); break;
                     case SDLK_HOME:      nk_input_key(ctx, NK_KEY_TEXT_START, down);

--- a/demo/sdl_opengles2/nuklear_sdl_gles2.h
+++ b/demo/sdl_opengles2/nuklear_sdl_gles2.h
@@ -383,7 +383,10 @@ nk_sdl_handle_event(SDL_Event *evt)
                     case SDLK_RSHIFT: /* RSHIFT & LSHIFT share same routine */
                     case SDLK_LSHIFT:    nk_input_key(ctx, NK_KEY_SHIFT, down); break;
                     case SDLK_DELETE:    nk_input_key(ctx, NK_KEY_DEL, down); break;
+
+                    case SDLK_KP_ENTER:
                     case SDLK_RETURN:    nk_input_key(ctx, NK_KEY_ENTER, down); break;
+
                     case SDLK_TAB:       nk_input_key(ctx, NK_KEY_TAB, down); break;
                     case SDLK_BACKSPACE: nk_input_key(ctx, NK_KEY_BACKSPACE, down); break;
                     case SDLK_HOME:      nk_input_key(ctx, NK_KEY_TEXT_START, down);

--- a/demo/sdl_renderer/nuklear_sdl_renderer.h
+++ b/demo/sdl_renderer/nuklear_sdl_renderer.h
@@ -306,7 +306,10 @@ nk_sdl_handle_event(SDL_Event *evt)
                     case SDLK_RSHIFT: /* RSHIFT & LSHIFT share same routine */
                     case SDLK_LSHIFT:    nk_input_key(ctx, NK_KEY_SHIFT, down); break;
                     case SDLK_DELETE:    nk_input_key(ctx, NK_KEY_DEL, down); break;
+
+                    case SDLK_KP_ENTER:
                     case SDLK_RETURN:    nk_input_key(ctx, NK_KEY_ENTER, down); break;
+
                     case SDLK_TAB:       nk_input_key(ctx, NK_KEY_TAB, down); break;
                     case SDLK_BACKSPACE: nk_input_key(ctx, NK_KEY_BACKSPACE, down); break;
                     case SDLK_HOME:      nk_input_key(ctx, NK_KEY_TEXT_START, down);

--- a/demo/sdl_vulkan/nuklear_sdl_vulkan.h
+++ b/demo/sdl_vulkan/nuklear_sdl_vulkan.h
@@ -1269,6 +1269,7 @@ NK_API int nk_sdl_handle_event(SDL_Event *evt) {
             nk_input_key(ctx, NK_KEY_DEL, down);
             break;
         case SDLK_RETURN:
+        case SDLK_KP_ENTER:
             nk_input_key(ctx, NK_KEY_ENTER, down);
             break;
         case SDLK_TAB:


### PR DESCRIPTION
If you tell a user they can submit with Enter and then it doesn't work, well... they don't care that the numpad Enter is technically a different key.  They have a point, they both are labeled "Enter" on most keyboards.

I can go through the other backends adding support but before I do I want to get feedback on my approach.  I can't think of any reason we'd want/need to add NK_KEY_KP_ENTER to nuklear itself because I can't think of a case we'd actually want distinct behavior for regular Enter/Return vs Numpad Enter.  If anyone can think of a convincing case I'll make the internal changes instead.

In either case I would need help testing several of them, specifically the windows backends, but possibly some of the more esoteric ones as well.