### PR TITLE
Add printf formatting macros for nk data types

### DIFF
--- a/demo/common/overview.c
+++ b/demo/common/overview.c
@@ -444,7 +444,7 @@ overview(struct nk_context *ctx)
                 }
                 /* progressbar combobox */
                 sum = prog_a + prog_b + prog_c + prog_d;
-                sprintf(buffer, "%" NK_SIZE_TYPE_FMT, sum);
+                sprintf(buffer, "%" NK_FMT_SIZE, sum);
                 if (nk_combo_begin_label(ctx, buffer, nk_vec2(200,200))) {
                     nk_layout_row_dynamic(ctx, 30, 1);
                     nk_progress(ctx, &prog_a, 100, NK_MODIFIABLE);
@@ -456,7 +456,7 @@ overview(struct nk_context *ctx)
 
                 /* checkbox combobox */
                 sum = (size_t)(check_values[0] + check_values[1] + check_values[2] + check_values[3] + check_values[4]);
-                sprintf(buffer, "%" NK_SIZE_TYPE_FMT, sum);
+                sprintf(buffer, "%" NK_FMT_SIZE, sum);
                 if (nk_combo_begin_label(ctx, buffer, nk_vec2(200,200))) {
                     nk_layout_row_dynamic(ctx, 30, 1);
                     nk_checkbox_label(ctx, weapons[0], &check_values[0]);

--- a/demo/common/overview.c
+++ b/demo/common/overview.c
@@ -444,7 +444,7 @@ overview(struct nk_context *ctx)
                 }
                 /* progressbar combobox */
                 sum = prog_a + prog_b + prog_c + prog_d;
-                sprintf(buffer, "%lu", sum);
+                sprintf(buffer, "%" NK_SIZE_TYPE_FMT, sum);
                 if (nk_combo_begin_label(ctx, buffer, nk_vec2(200,200))) {
                     nk_layout_row_dynamic(ctx, 30, 1);
                     nk_progress(ctx, &prog_a, 100, NK_MODIFIABLE);
@@ -456,7 +456,7 @@ overview(struct nk_context *ctx)
 
                 /* checkbox combobox */
                 sum = (size_t)(check_values[0] + check_values[1] + check_values[2] + check_values[3] + check_values[4]);
-                sprintf(buffer, "%lu", sum);
+                sprintf(buffer, "%" NK_SIZE_TYPE_FMT, sum);
                 if (nk_combo_begin_label(ctx, buffer, nk_vec2(200,200))) {
                     nk_layout_row_dynamic(ctx, 30, 1);
                     nk_checkbox_label(ctx, weapons[0], &check_values[0]);

--- a/nuklear.h
+++ b/nuklear.h
@@ -480,6 +480,16 @@ extern "C" {
   #endif
 #endif
 
+#define NK_FMT_CHAR NK_INT8_FMT
+#define NK_FMT_UCHAR NK_UINT8_FMT
+#define NK_FMT_BYTE NK_UINT8_FMT
+#define NK_FMT_SHORT NK_INT16_FMT
+#define NK_FMT_USHORT NK_UINT16_FMT
+#define NK_FMT_INT NK_INT32_FMT
+#define NK_FMT_UINT NK_UINT32_FMT
+#define NK_FMT_SIZE NK_SIZE_TYPE_FMT
+#define NK_FMT_PTR NK_POINTER_TYPE_FMT
+
 typedef NK_INT8 nk_char;
 typedef NK_UINT8 nk_uchar;
 typedef NK_UINT8 nk_byte;

--- a/nuklear.h
+++ b/nuklear.h
@@ -337,8 +337,9 @@ extern "C" {
  *
  * ===============================================================
  */
- #ifdef NK_INCLUDE_FIXED_TYPES
+#ifdef NK_INCLUDE_FIXED_TYPES
  #include <stdint.h>
+ #include <inttypes.h>
  #define NK_INT8 int8_t
  #define NK_UINT8 uint8_t
  #define NK_INT16 int16_t
@@ -347,18 +348,38 @@ extern "C" {
  #define NK_UINT32 uint32_t
  #define NK_SIZE_TYPE uintptr_t
  #define NK_POINTER_TYPE uintptr_t
+ #define NK_INT8_FMT PRIi8
+ #define NK_UINT8_FMT PRIu8
+ #define NK_INT16_FMT PRIi16
+ #define NK_UINT16_FMT PRIu16
+ #define NK_INT32_FMT PRIi32
+ #define NK_UINT32_FMT PRIu32
+ #define NK_SIZE_TYPE_FMT PRIuPTR
+ #define NK_POINTER_TYPE_FMT PRIuPTR
 #else
   #ifndef NK_INT8
     #define NK_INT8 signed char
   #endif
+  #ifndef NK_INT8_FMT
+    #define NK_INT8_FMT "hhi"
+  #endif
   #ifndef NK_UINT8
     #define NK_UINT8 unsigned char
+  #endif
+  #ifndef NK_UINT8_FMT
+    #define NK_UINT8_FMT "hhu"
   #endif
   #ifndef NK_INT16
     #define NK_INT16 signed short
   #endif
+  #ifndef NK_INT16_FMT
+    #define NK_INT16_FMT "hi"
+  #endif
   #ifndef NK_UINT16
     #define NK_UINT16 unsigned short
+  #endif
+  #ifndef NK_UINT16_FMT
+    #define NK_UINT16_FMT "hu"
   #endif
   #ifndef NK_INT32
     #if defined(_MSC_VER)
@@ -367,11 +388,25 @@ extern "C" {
       #define NK_INT32 signed int
     #endif
   #endif
+  #ifndef NK_INT32_FMT
+    #if defined(_MSC_VER) /* long is 32bit on Windows */
+      #define NK_INT32_FMT "li"
+    #else
+      #define NK_INT32_FMT "i"
+    #endif
+  #endif
   #ifndef NK_UINT32
     #if defined(_MSC_VER)
       #define NK_UINT32 unsigned __int32
     #else
       #define NK_UINT32 unsigned int
+    #endif
+  #endif
+  #ifndef NK_UINT32_FMT
+    #if defined(_MSC_VER) /* long is 32bit on Windows */
+      #define NK_UINT32_FMT "lu"
+    #else
+      #define NK_UINT32_FMT "u"
     #endif
   #endif
   #ifndef NK_SIZE_TYPE
@@ -389,6 +424,21 @@ extern "C" {
       #define NK_SIZE_TYPE unsigned long
     #endif
   #endif
+  #ifndef NK_SIZE_TYPE_FMT
+    #if defined(_WIN64) && defined(_MSC_VER)
+      #define NK_SIZE_TYPE_FMT "I64u"
+    #elif (defined(_WIN32) || defined(WIN32)) && defined(_MSC_VER)
+      #define NK_SIZE_TYPE_FMT "I32u"
+    #elif defined(__GNUC__) || defined(__clang__)
+      #if defined(__x86_64__) || defined(__ppc64__) || defined(__PPC64__) || defined(__aarch64__)
+        #define NK_SIZE_TYPE_FMT "lu"
+      #else
+        #define NK_SIZE_TYPE_FMT "u"
+      #endif
+    #else
+      #define NK_SIZE_TYPE_FMT "lu"
+    #endif
+  #endif
   #ifndef NK_POINTER_TYPE
     #if defined(_WIN64) && defined(_MSC_VER)
       #define NK_POINTER_TYPE unsigned __int64
@@ -402,6 +452,21 @@ extern "C" {
       #endif
     #else
       #define NK_POINTER_TYPE unsigned long
+    #endif
+  #endif
+  #ifndef NK_POINTER_TYPE_FMT
+    #if defined(_WIN64) && defined(_MSC_VER)
+      #define NK_POINTER_TYPE_FMT "I64u"
+    #elif (defined(_WIN32) || defined(WIN32)) && defined(_MSC_VER)
+      #define NK_POINTER_TYPE_FMT "I32u"
+    #elif defined(__GNUC__) || defined(__clang__)
+      #if defined(__x86_64__) || defined(__ppc64__) || defined(__PPC64__) || defined(__aarch64__)
+        #define NK_POINTER_TYPE_FMT "lu"
+      #else
+        #define NK_POINTER_TYPE_FMT "u"
+      #endif
+    #else
+      #define NK_POINTER_TYPE_FMT "lu"
     #endif
   #endif
 #endif

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -115,8 +115,9 @@ extern "C" {
  *
  * ===============================================================
  */
- #ifdef NK_INCLUDE_FIXED_TYPES
+#ifdef NK_INCLUDE_FIXED_TYPES
  #include <stdint.h>
+ #include <inttypes.h>
  #define NK_INT8 int8_t
  #define NK_UINT8 uint8_t
  #define NK_INT16 int16_t
@@ -125,18 +126,38 @@ extern "C" {
  #define NK_UINT32 uint32_t
  #define NK_SIZE_TYPE uintptr_t
  #define NK_POINTER_TYPE uintptr_t
+ #define NK_INT8_FMT PRIi8
+ #define NK_UINT8_FMT PRIu8
+ #define NK_INT16_FMT PRIi16
+ #define NK_UINT16_FMT PRIu16
+ #define NK_INT32_FMT PRIi32
+ #define NK_UINT32_FMT PRIu32
+ #define NK_SIZE_TYPE_FMT PRIuPTR
+ #define NK_POINTER_TYPE_FMT PRIuPTR
 #else
   #ifndef NK_INT8
     #define NK_INT8 signed char
   #endif
+  #ifndef NK_INT8_FMT
+    #define NK_INT8_FMT "hhi"
+  #endif
   #ifndef NK_UINT8
     #define NK_UINT8 unsigned char
+  #endif
+  #ifndef NK_UINT8_FMT
+    #define NK_UINT8_FMT "hhu"
   #endif
   #ifndef NK_INT16
     #define NK_INT16 signed short
   #endif
+  #ifndef NK_INT16_FMT
+    #define NK_INT16_FMT "hi"
+  #endif
   #ifndef NK_UINT16
     #define NK_UINT16 unsigned short
+  #endif
+  #ifndef NK_UINT16_FMT
+    #define NK_UINT16_FMT "hu"
   #endif
   #ifndef NK_INT32
     #if defined(_MSC_VER)
@@ -145,11 +166,25 @@ extern "C" {
       #define NK_INT32 signed int
     #endif
   #endif
+  #ifndef NK_INT32_FMT
+    #if defined(_MSC_VER) /* long is 32bit on Windows */
+      #define NK_INT32_FMT "li"
+    #else
+      #define NK_INT32_FMT "i"
+    #endif
+  #endif
   #ifndef NK_UINT32
     #if defined(_MSC_VER)
       #define NK_UINT32 unsigned __int32
     #else
       #define NK_UINT32 unsigned int
+    #endif
+  #endif
+  #ifndef NK_UINT32_FMT
+    #if defined(_MSC_VER) /* long is 32bit on Windows */
+      #define NK_UINT32_FMT "lu"
+    #else
+      #define NK_UINT32_FMT "u"
     #endif
   #endif
   #ifndef NK_SIZE_TYPE
@@ -167,6 +202,21 @@ extern "C" {
       #define NK_SIZE_TYPE unsigned long
     #endif
   #endif
+  #ifndef NK_SIZE_TYPE_FMT
+    #if defined(_WIN64) && defined(_MSC_VER)
+      #define NK_SIZE_TYPE_FMT "I64u"
+    #elif (defined(_WIN32) || defined(WIN32)) && defined(_MSC_VER)
+      #define NK_SIZE_TYPE_FMT "I32u"
+    #elif defined(__GNUC__) || defined(__clang__)
+      #if defined(__x86_64__) || defined(__ppc64__) || defined(__PPC64__) || defined(__aarch64__)
+        #define NK_SIZE_TYPE_FMT "lu"
+      #else
+        #define NK_SIZE_TYPE_FMT "u"
+      #endif
+    #else
+      #define NK_SIZE_TYPE_FMT "lu"
+    #endif
+  #endif
   #ifndef NK_POINTER_TYPE
     #if defined(_WIN64) && defined(_MSC_VER)
       #define NK_POINTER_TYPE unsigned __int64
@@ -180,6 +230,21 @@ extern "C" {
       #endif
     #else
       #define NK_POINTER_TYPE unsigned long
+    #endif
+  #endif
+  #ifndef NK_POINTER_TYPE_FMT
+    #if defined(_WIN64) && defined(_MSC_VER)
+      #define NK_POINTER_TYPE_FMT "I64u"
+    #elif (defined(_WIN32) || defined(WIN32)) && defined(_MSC_VER)
+      #define NK_POINTER_TYPE_FMT "I32u"
+    #elif defined(__GNUC__) || defined(__clang__)
+      #if defined(__x86_64__) || defined(__ppc64__) || defined(__PPC64__) || defined(__aarch64__)
+        #define NK_POINTER_TYPE_FMT "lu"
+      #else
+        #define NK_POINTER_TYPE_FMT "u"
+      #endif
+    #else
+      #define NK_POINTER_TYPE_FMT "lu"
     #endif
   #endif
 #endif

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -258,6 +258,16 @@ extern "C" {
   #endif
 #endif
 
+#define NK_FMT_CHAR NK_INT8_FMT
+#define NK_FMT_UCHAR NK_UINT8_FMT
+#define NK_FMT_BYTE NK_UINT8_FMT
+#define NK_FMT_SHORT NK_INT16_FMT
+#define NK_FMT_USHORT NK_UINT16_FMT
+#define NK_FMT_INT NK_INT32_FMT
+#define NK_FMT_UINT NK_UINT32_FMT
+#define NK_FMT_SIZE NK_SIZE_TYPE_FMT
+#define NK_FMT_PTR NK_POINTER_TYPE_FMT
+
 typedef NK_INT8 nk_char;
 typedef NK_UINT8 nk_uchar;
 typedef NK_UINT8 nk_byte;


### PR DESCRIPTION
Adds macros from formatting the nk data types
| Macro | Type |
|-|-|
| NK_FMT_CHAR | nk_char |
| NK_FMT_UCHAR | nk_uchar |
| NK_FMT_BYTE | nk_byte |
| NK_FMT_SHORT | nk_short |
| NK_FMT_USHORT | nk_ushort |
| NK_FMT_INT | nk_int |
| NK_FMT_UINT | nk_uint |
| NK_FMT_SIZE | nk_size |
| NK_FMT_PTR | nk_ptr |

This won't completely prevent issues like #727 but it should help.

Needs to be tested on Windows.