### PR TITLE
Fix glfw_opengl4 bindless textures

### DIFF
--- a/demo/glfw_opengl4/nuklear_glfw_gl4.h
+++ b/demo/glfw_opengl4/nuklear_glfw_gl4.h
@@ -113,7 +113,6 @@ static struct nk_glfw {
 
 #define NK_SHADER_VERSION "#version 450 core\n"
 #define NK_SHADER_BINDLESS "#extension GL_ARB_bindless_texture : require\n"
-#define NK_SHADER_64BIT "#extension GL_ARB_gpu_shader_int64 : require\n"
 
 NK_API void
 nk_glfw3_device_create()
@@ -123,7 +122,6 @@ nk_glfw3_device_create()
     static const GLchar *vertex_shader =
         NK_SHADER_VERSION
         NK_SHADER_BINDLESS
-        NK_SHADER_64BIT
         "uniform mat4 ProjMtx;\n"
         "in vec2 Position;\n"
         "in vec2 TexCoord;\n"
@@ -138,15 +136,13 @@ nk_glfw3_device_create()
     static const GLchar *fragment_shader =
         NK_SHADER_VERSION
         NK_SHADER_BINDLESS
-        NK_SHADER_64BIT
         "precision mediump float;\n"
-        "uniform uint64_t Texture;\n"
+        "layout(bindless_sampler) uniform sampler2D Texture;\n"
         "in vec2 Frag_UV;\n"
         "in vec4 Frag_Color;\n"
         "out vec4 Out_Color;\n"
         "void main(){\n"
-        "   sampler2D smp = sampler2D(Texture);\n"
-        "   Out_Color = Frag_Color * texture(smp, Frag_UV.st);\n"
+        "   Out_Color = Frag_Color * texture(Texture, Frag_UV.st);\n"
         "}\n";
 
     struct nk_glfw_device *dev = &glfw.ogl;


### PR DESCRIPTION
This MR fixes some issues with the way [bindless textures](https://www.khronos.org/opengl/wiki/Bindless_Texture) are uses in the glfw_opengl4 demo.

This MR closes #190, #568 and #579

### The Issues

The current implementation leads in a few cases to segmentation faults and compile errors. Mostly on AMD cards (my guess is on intel too, nvidia should be fine). Some of them are masked behind segmentation faults in mesa:
<details><summary>Stacktrace</summary>
<pre>
(gdb) bt
#0  convert_component () at ../mesa-24.3.4/src/compiler/glsl/ast_function.cpp:1132
#1  0x0000743e99a4c7bb in ast_function_expression::hir () at ../mesa-24.3.4/src/compiler/glsl/ast_function.cpp:2405
#2  0x0000743e99a5ac82 in process_initializer () at ../mesa-24.3.4/src/compiler/glsl/ast_to_hir.cpp:4691
#3  ast_declarator_list::hir () at ../mesa-24.3.4/src/compiler/glsl/ast_to_hir.cpp:5842
#4  0x0000743e99a56edf in ast_compound_statement::hir () at ../mesa-24.3.4/src/compiler/glsl/ast_to_hir.cpp:2338
#5  0x0000743e99a5e9c1 in ast_function_definition::hir () at ../mesa-24.3.4/src/compiler/glsl/ast_to_hir.cpp:6544
#6  0x0000743e99a53980 in _mesa_ast_to_hir () at ../mesa-24.3.4/src/compiler/glsl/ast_to_hir.cpp:160
#7  0x0000743e999fc72e in _mesa_glsl_compile_shader () at ../mesa-24.3.4/src/compiler/glsl/glsl_parser_extras.cpp:2422
#8  0x0000743e999246bc in _mesa_compile_shader () at ../mesa-24.3.4/src/mesa/main/shaderapi.c:1234
#9  _mesa_compile_shader () at ../mesa-24.3.4/src/mesa/main/shaderapi.c:1200
#10 0x0000743e997b0b3b in _mesa_unmarshal_CompileShader () at src/mapi/glapi/gen/marshal_generated2.c:1309
#11 0x0000743e99685211 in glthread_unmarshal_batch () at ../mesa-24.3.4/src/mesa/main/glthread.c:141
#12 0x0000743e996858d6 in _mesa_glthread_finish () at ../mesa-24.3.4/src/mesa/main/glthread.c:422
#13 0x0000743e997a7f02 in _mesa_marshal_GetShaderiv () at src/mapi/glapi/gen/marshal_generated2.c:1513
#14 0x000058b9d979e051 in nk_glfw3_device_create () at /home/mario/programming/Nuklear/demo/glfw_opengl4/nuklear_glfw_gl4.h:161
#15 0x000058b9d979f58d in nk_glfw3_init (win=0x58ba05dcfe20, init_state=NK_GLFW3_INSTALL_CALLBACKS, max_vertex_buffer=524288, 
    max_element_buffer=131072) at /home/mario/programming/Nuklear/demo/glfw_opengl4/nuklear_glfw_gl4.h:537
#16 0x000058b9d97a7afc in main () at main.c:123
</pre>
</details> 

It is pretty clear, that should not happen in `glGetShaderiv`, but the bug in mesa seams to be triggered by a mixture of _undefined behavior_.

#### Mixing [ARB_gpu_shader_int64](https://registry.khronos.org/OpenGL/extensions/ARB/ARB_gpu_shader_int64.txt) and [ARB_bindless_texture](https://registry.khronos.org/OpenGL/extensions/ARB/ARB_bindless_texture.txt)
`glUniformHandleui64ARB` *(defined in ARB_bindless_texture)* is used to populate data into a `uint64_t` *(defined in ARB_gpu_shader_int64)* uniform. 

The ARB_bindless_texture spec actually mentions avoiding dependencies to other 64-bit integer types.

> (19) How does ARB_bindless_texture differ from NV_bindless_texture?
>
> RESOLVED:  The constructors to convert between sampler and integer types use uvec2 rather than uint64_t to avoid a dependency on the 64-bit integer types in the shader from NV_gpu_shader5.
[Source](https://registry.khronos.org/OpenGL/extensions/ARB/ARB_bindless_texture.txt)

What this implies is that `glUniformHandleui64ARB` should be used to populate `layout(bindless_sampler) uniform sampler2D` variables and `glUniform1ui64vARB` *(defined in ARB_gpu_shader_int64)* to populate `uint64_t` variables.

#### Requiring [ARB_bindless_texture](https://registry.khronos.org/OpenGL/extensions/ARB/ARB_bindless_texture.txt) but using [NV_bindless_texture](https://registry.khronos.org/OpenGL/extensions/NV/NV_bindless_texture.txt)

ARB_bindless_texture does not define a `sampler2D(uint64_t)` constructor. The one used [here](https://github.com/Immediate-Mode-UI/Nuklear/blob/master/demo/glfw_opengl4/nuklear_glfw_gl4.h#L148). `sampler2D(uint64_t)` is only defined in NV_bindless_texture. ARB_bindless_texture defines a.o. a `sampler2D(uvec2)` constructor there are also no implicit conversions.

>  (11) Should implicit conversions be supported for converting uint64-typed handles to sampler and image types?
>
> RESOLVED:  No.  An explicit constructor is provided to build a handle from uvec2 or vice versa.
[Source](https://registry.khronos.org/OpenGL/extensions/ARB/ARB_bindless_texture.txt)

### The Fix

Instead of passing `uint64_t`  values around and converting them to `sampler2D` values, just a single `sampler2D` value can be handed over to the shader. This also removes all uses of `uint64_t` types and drops the requirement of GL_ARB_gpu_shader_int64.

### Comparison to #579

* 579 does not make use of `glUniformHandleui64ARB`, but calls `glUniform2ui` with some bit shifting. Which is **completely correct** but unnecessary. 
* 579 relies on the `sampler2D(uint64_t)` constructor which is not part of the ARB_bindless_texture spec (and probably only ever available on nvidia hardware)
* 579 does not remove the dependency to ARB_gpu_shader_int64

### Testing
It is rather easy to test. If it does not seg fault, does not throw an assert error on shader compilation and draws the demo it works.

I tested it on Archlinux with an AMD RX 580 and it works. Since the types are now correct and only mechanisms from a single extension are used I'm confident that this should work on *all™* systems.

 
