### PR TITLE
Add NumPad Enter to other backends

### DIFF
--- a/demo/allegro5/main.c
+++ b/demo/allegro5/main.c
@@ -120,7 +120,7 @@ int main(void)
     al_register_event_source(event_queue, al_get_mouse_event_source());
     al_register_event_source(event_queue, al_get_keyboard_event_source());
 
-    font = nk_allegro5_font_create_from_file("../../../extra_font/Roboto-Regular.ttf", 12, 0);
+    font = nk_allegro5_font_create_from_file("../../extra_font/Roboto-Regular.ttf", 12, 0);
 
     ctx = nk_allegro5_init(font, display, WINDOW_WIDTH, WINDOW_HEIGHT);
 

--- a/demo/allegro5/nuklear_allegro5.h
+++ b/demo/allegro5/nuklear_allegro5.h
@@ -417,7 +417,7 @@ nk_allegro5_handle_event(ALLEGRO_EVENT *ev)
 
             if (kc == ALLEGRO_KEY_LSHIFT || kc == ALLEGRO_KEY_RSHIFT) nk_input_key(ctx, NK_KEY_SHIFT, down);
             else if (kc == ALLEGRO_KEY_DELETE)    nk_input_key(ctx, NK_KEY_DEL, down);
-            else if (kc == ALLEGRO_KEY_ENTER)     nk_input_key(ctx, NK_KEY_ENTER, down);
+            else if (kc == ALLEGRO_KEY_ENTER || kc == ALLEGRO_KEY_PAD_ENTER)     nk_input_key(ctx, NK_KEY_ENTER, down);
             else if (kc == ALLEGRO_KEY_TAB)       nk_input_key(ctx, NK_KEY_TAB, down);
             else if (kc == ALLEGRO_KEY_LEFT)      nk_input_key(ctx, NK_KEY_LEFT, down);
             else if (kc == ALLEGRO_KEY_RIGHT)     nk_input_key(ctx, NK_KEY_RIGHT, down);

--- a/demo/d3d11/nuklear_d3d11.h
+++ b/demo/d3d11/nuklear_d3d11.h
@@ -232,6 +232,7 @@ nk_d3d11_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
             return 1;
 
         case VK_RETURN:
+        case VK_SEPARATOR:
             nk_input_key(&d3d11.ctx, NK_KEY_ENTER, down);
             return 1;
 

--- a/demo/d3d12/nuklear_d3d12.h
+++ b/demo/d3d12/nuklear_d3d12.h
@@ -364,6 +364,7 @@ nk_d3d12_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
             return 1;
 
         case VK_RETURN:
+        case VK_SEPARATOR:
             nk_input_key(&d3d12.ctx, NK_KEY_ENTER, down);
             return 1;
 

--- a/demo/d3d9/nuklear_d3d9.h
+++ b/demo/d3d9/nuklear_d3d9.h
@@ -292,6 +292,7 @@ nk_d3d9_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
             return 1;
 
         case VK_RETURN:
+        case VK_SEPARATOR:
             nk_input_key(&d3d9.ctx, NK_KEY_ENTER, down);
             return 1;
 

--- a/demo/gdi/nuklear_gdi.h
+++ b/demo/gdi/nuklear_gdi.h
@@ -76,7 +76,7 @@ nk_create_image(struct nk_image * image, const char * frame_buffer, const int wi
         image->region[1] = 0;
         image->region[2] = width;
         image->region[3] = height;
-        
+
         bi.bmiHeader.biSize = sizeof(BITMAPINFOHEADER);
         bi.bmiHeader.biWidth = width;
         bi.bmiHeader.biHeight = height;
@@ -84,9 +84,9 @@ nk_create_image(struct nk_image * image, const char * frame_buffer, const int wi
         bi.bmiHeader.biBitCount = 24;
         bi.bmiHeader.biCompression = BI_RGB;
         bi.bmiHeader.biSizeImage = row * height;
-        
+
         hbm = CreateDIBSection(NULL, &bi, DIB_RGB_COLORS, (void**)&lpBuf, NULL, 0);
-        
+
         pb = lpBuf + row * height;
         for (v = 0; v < height; v++)
         {
@@ -98,7 +98,7 @@ nk_create_image(struct nk_image * image, const char * frame_buffer, const int wi
                 pb[i + 2] = src[2];
                 src += 3;
             }
-        }        
+        }
         SetDIBits(NULL, hbm, 0, height, lpBuf, &bi, DIB_RGB_COLORS);
         image->handle.ptr = hbm;
     }
@@ -122,10 +122,10 @@ nk_gdi_draw_image(short x, short y, unsigned short w, unsigned short h,
     HBITMAP hbm = (HBITMAP)img.handle.ptr;
     HDC     hDCBits;
     BITMAP  bitmap;
-    
+
     if (!gdi.memory_dc || !hbm)
         return;
-    
+
     hDCBits = CreateCompatibleDC(gdi.memory_dc);
     GetObject(hbm, sizeof(BITMAP), (LPSTR)&bitmap);
     SelectObject(hDCBits, hbm);
@@ -192,7 +192,7 @@ nk_gdi_stroke_rect(HDC dc, short x, short y, unsigned short w,
     }
     SelectObject(dc, br);
 
-    if (pen) { 
+    if (pen) {
         SelectObject(dc, GetStockObject(DC_PEN));
         DeleteObject(pen);
     }
@@ -470,7 +470,7 @@ nk_gdi_stroke_circle(HDC dc, short x, short y, unsigned short w,
         pen = CreatePen(PS_SOLID, line_thickness, color);
         SelectObject(dc, pen);
     }
-    
+
     HGDIOBJ br = SelectObject(dc, GetStockObject(NULL_BRUSH));
     SetDCBrushColor(dc, OPAQUE);
     Ellipse(dc, x, y, x + w, y + h);
@@ -524,7 +524,7 @@ nk_gdi_draw_text(HDC dc, short x, short y, unsigned short w, unsigned short h,
     wsize = MultiByteToWideChar(CP_UTF8, 0, text, len, NULL, 0);
     wstr = (WCHAR*)_alloca(wsize * sizeof(wchar_t));
     MultiByteToWideChar(CP_UTF8, 0, text, len, wstr, wsize);
-    
+
     SetBkMode(dc, TRANSPARENT); /* Transparent Text Background */
     SetBkColor(dc, convert_color(cbg));
     SetTextColor(dc, convert_color(cfg));
@@ -599,14 +599,14 @@ nk_gdi_clipboard_paste(nk_handle usr, struct nk_text_edit *edit)
     (void)usr;
     if (IsClipboardFormatAvailable(CF_UNICODETEXT) && OpenClipboard(NULL))
     {
-        HGLOBAL mem = GetClipboardData(CF_UNICODETEXT); 
+        HGLOBAL mem = GetClipboardData(CF_UNICODETEXT);
         if (mem)
         {
             SIZE_T size = GlobalSize(mem) - 1;
             if (size)
             {
                 LPCWSTR wstr = (LPCWSTR)GlobalLock(mem);
-                if (wstr) 
+                if (wstr)
                 {
                     int utf8size = WideCharToMultiByte(CP_UTF8, 0, wstr, (int)(size / sizeof(wchar_t)), NULL, 0, NULL, NULL);
                     if (utf8size)
@@ -619,7 +619,7 @@ nk_gdi_clipboard_paste(nk_handle usr, struct nk_text_edit *edit)
                             free(utf8);
                         }
                     }
-                    GlobalUnlock(mem); 
+                    GlobalUnlock(mem);
                 }
             }
         }
@@ -643,9 +643,9 @@ nk_gdi_clipboard_copy(nk_handle usr, const char *text, int len)
                 {
                     MultiByteToWideChar(CP_UTF8, 0, text, len, wstr, wsize);
                     wstr[wsize] = 0;
-                    GlobalUnlock(mem); 
+                    GlobalUnlock(mem);
 
-                    SetClipboardData(CF_UNICODETEXT, mem); 
+                    SetClipboardData(CF_UNICODETEXT, mem);
                 }
             }
         }
@@ -734,6 +734,7 @@ nk_gdi_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
             return 1;
 
         case VK_RETURN:
+        case VK_SEPARATOR:
             nk_input_key(&gdi.ctx, NK_KEY_ENTER, down);
             return 1;
 
@@ -776,7 +777,7 @@ nk_gdi_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
         case VK_PRIOR:
             nk_input_key(&gdi.ctx, NK_KEY_SCROLL_UP, down);
             return 1;
-                
+
         case 'A':
             if (ctrl) {
                 nk_input_key(&gdi.ctx, NK_KEY_TEXT_SELECT_ALL, down);

--- a/demo/gdi_native_nuklear/nuklear_gdi.h
+++ b/demo/gdi_native_nuklear/nuklear_gdi.h
@@ -2,11 +2,11 @@
  * Nuklear - 1.32.0 - public domain
  * no warrenty implied; use at your own risk.
  * authored from 2015-2016 by Micha Mettke
- * 
+ *
  * Modified GDI backend 2022
  * Now based on a context that is required for each API function call.
  * Removes the global state --> you can have multiple windows :-)
- * 
+ *
  */
  /*
   * ==============================================================
@@ -698,6 +698,7 @@ nk_gdi_handle_event(nk_gdi_ctx gdi, HWND wnd, UINT msg, WPARAM wparam, LPARAM lp
             return 1;
 
         case VK_RETURN:
+        case VK_SEPARATOR:
             nk_input_key(&gdi->ctx, NK_KEY_ENTER, down);
             return 1;
 

--- a/demo/gdip/nuklear_gdip.h
+++ b/demo/gdip/nuklear_gdip.h
@@ -92,7 +92,7 @@ typedef enum {
     StringFormatFlagsMeasureTrailingSpaces   = 0x00000800,
     StringFormatFlagsNoWrap                  = 0x00001000,
     StringFormatFlagsLineLimit               = 0x00002000,
-    StringFormatFlagsNoClip                  = 0x00004000 
+    StringFormatFlagsNoClip                  = 0x00004000
 } StringFormatFlags;
 
 typedef enum
@@ -272,25 +272,25 @@ GdipSetStringFormatFlags(GpStringFormat *format, INT flags);
 GpStatus WINGDIPAPI
 GdipDeleteStringFormat(GpStringFormat *format);
 
-GpStatus WINGDIPAPI 
-GdipPrivateAddMemoryFont(GpFontCollection* fontCollection, 
+GpStatus WINGDIPAPI
+GdipPrivateAddMemoryFont(GpFontCollection* fontCollection,
                          GDIPCONST void* memory, INT length);
 
-GpStatus WINGDIPAPI 
-GdipPrivateAddFontFile(GpFontCollection* fontCollection, 
+GpStatus WINGDIPAPI
+GdipPrivateAddFontFile(GpFontCollection* fontCollection,
                        GDIPCONST WCHAR* filename);
 
-GpStatus WINGDIPAPI 
+GpStatus WINGDIPAPI
 GdipNewPrivateFontCollection(GpFontCollection** fontCollection);
 
-GpStatus WINGDIPAPI 
+GpStatus WINGDIPAPI
 GdipDeletePrivateFontCollection(GpFontCollection** fontCollection);
 
-GpStatus WINGDIPAPI 
-GdipGetFontCollectionFamilyList(GpFontCollection* fontCollection, 
+GpStatus WINGDIPAPI
+GdipGetFontCollectionFamilyList(GpFontCollection* fontCollection,
                         INT numSought, GpFontFamily* gpfamilies[], INT* numFound);
 
-GpStatus WINGDIPAPI 
+GpStatus WINGDIPAPI
 GdipGetFontCollectionFamilyCount(GpFontCollection* fontCollection, INT* numFound);
 
 
@@ -374,8 +374,8 @@ GdipGraphicsClear(GpGraphics *graphics, ARGB color);
 GpStatus WINGDIPAPI
 GdipDrawImageI(GpGraphics *graphics, GpImage *image, INT x, INT y);
 
-GpStatus WINGDIPAPI 
-GdipDrawImageRectI(GpGraphics *graphics, GpImage *image, INT x, INT y, 
+GpStatus WINGDIPAPI
+GdipDrawImageRectI(GpGraphics *graphics, GpImage *image, INT x, INT y,
                    INT width, INT height);
 
 GpStatus WINGDIPAPI
@@ -673,7 +673,7 @@ nk_gdip_load_image_from_memory(const void *membuf, nk_uint membufSize)
     IStream *stream = SHCreateMemStream((const BYTE*)membuf, membufSize);
     if (!stream)
         return nk_image_id(0);
-    
+
     status = GdipLoadImageFromStream(stream, &image);
     stream->lpVtbl->Release(stream);
 
@@ -709,7 +709,7 @@ nk_gdipfont_create(const char *name, int size)
     return font;
 }
 
-GpFontCollection* 
+GpFontCollection*
 nk_gdip_getCurFontCollection(){
     return gdip.fontCollection[gdip.curFontCollection];
 }
@@ -744,7 +744,7 @@ nk_gdipfont_create_from_file(const WCHAR* filename, int size)
 {
     if( !nk_gdip_getCurFontCollection() )
         if( GdipNewPrivateFontCollection(&gdip.fontCollection[gdip.curFontCollection]) ) return NULL;
-    if( GdipPrivateAddFontFile(nk_gdip_getCurFontCollection(), filename) ) return NULL;    
+    if( GdipPrivateAddFontFile(nk_gdip_getCurFontCollection(), filename) ) return NULL;
     return nk_gdipfont_create_from_collection(size);
 }
 
@@ -849,7 +849,7 @@ nk_gdip_init(HWND hwnd, unsigned int width, unsigned int height)
     GdipCreatePen1(0, 1.0f, UnitPixel, &gdip.pen);
     GdipCreateSolidFill(0, &gdip.brush);
     GdipStringFormatGetGenericTypographic(&gdip.format);
-    GdipSetStringFormatFlags(gdip.format, StringFormatFlagsNoFitBlackBox | 
+    GdipSetStringFormatFlags(gdip.format, StringFormatFlagsNoFitBlackBox |
         StringFormatFlagsMeasureTrailingSpaces | StringFormatFlagsNoWrap |
         StringFormatFlagsNoClip);
 
@@ -924,6 +924,7 @@ nk_gdip_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
             return 1;
 
         case VK_RETURN:
+        case VK_SEPARATOR:
             nk_input_key(&gdip.ctx, NK_KEY_ENTER, down);
             return 1;
 

--- a/demo/glfw_opengl2/main.c
+++ b/demo/glfw_opengl2/main.c
@@ -42,7 +42,7 @@
 /* #define INCLUDE_CALCULATOR   */
 /* #define INCLUDE_CANVAS       */
 /* #define INCLUDE_FILE_BROWSER */
-/* #define INCLUDE_OVERVIEW     */
+#define INCLUDE_OVERVIEW
 /* #define INCLUDE_CONFIGURATOR */
 /* #define INCLUDE_NODE_EDITOR  */
 

--- a/demo/glfw_opengl2/nuklear_glfw_gl2.h
+++ b/demo/glfw_opengl2/nuklear_glfw_gl2.h
@@ -327,7 +327,9 @@ nk_glfw3_new_frame(void)
         glfwSetInputMode(glfw.win, GLFW_CURSOR, GLFW_CURSOR_NORMAL);
 
     nk_input_key(ctx, NK_KEY_DEL, glfwGetKey(win, GLFW_KEY_DELETE) == GLFW_PRESS);
-    nk_input_key(ctx, NK_KEY_ENTER, glfwGetKey(win, GLFW_KEY_ENTER) == GLFW_PRESS);
+    nk_input_key(ctx, NK_KEY_ENTER, glfwGetKey(win, GLFW_KEY_ENTER) == GLFW_PRESS ||
+                                    glfwGetKey(win, GLFW_KEY_KP_ENTER) == GLFW_PRESS);
+
     nk_input_key(ctx, NK_KEY_TAB, glfwGetKey(win, GLFW_KEY_TAB) == GLFW_PRESS);
     nk_input_key(ctx, NK_KEY_BACKSPACE, glfwGetKey(win, GLFW_KEY_BACKSPACE) == GLFW_PRESS);
     nk_input_key(ctx, NK_KEY_UP, glfwGetKey(win, GLFW_KEY_UP) == GLFW_PRESS);

--- a/demo/glfw_opengl3/nuklear_glfw_gl3.h
+++ b/demo/glfw_opengl3/nuklear_glfw_gl3.h
@@ -445,7 +445,9 @@ nk_glfw3_new_frame(struct nk_glfw* glfw)
 #endif
 
     nk_input_key(ctx, NK_KEY_DEL, glfwGetKey(win, GLFW_KEY_DELETE) == GLFW_PRESS);
-    nk_input_key(ctx, NK_KEY_ENTER, glfwGetKey(win, GLFW_KEY_ENTER) == GLFW_PRESS);
+    nk_input_key(ctx, NK_KEY_ENTER, glfwGetKey(win, GLFW_KEY_ENTER) == GLFW_PRESS ||
+                                    glfwGetKey(win, GLFW_KEY_KP_ENTER) == GLFW_PRESS);
+
     nk_input_key(ctx, NK_KEY_TAB, glfwGetKey(win, GLFW_KEY_TAB) == GLFW_PRESS);
     nk_input_key(ctx, NK_KEY_BACKSPACE, glfwGetKey(win, GLFW_KEY_BACKSPACE) == GLFW_PRESS);
     nk_input_key(ctx, NK_KEY_UP, glfwGetKey(win, GLFW_KEY_UP) == GLFW_PRESS);

--- a/demo/glfw_opengl4/Makefile
+++ b/demo/glfw_opengl4/Makefile
@@ -2,7 +2,7 @@
 BIN = demo
 
 # Flags
-CFLAGS += -std=c89 -Wall -Wextra -pedantic
+CFLAGS += -g -std=c89 -Wall -Wextra -pedantic
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/demo/glfw_opengl4/nuklear_glfw_gl4.h
+++ b/demo/glfw_opengl4/nuklear_glfw_gl4.h
@@ -587,7 +587,9 @@ nk_glfw3_new_frame(void)
 #endif
 
     nk_input_key(ctx, NK_KEY_DEL, glfwGetKey(win, GLFW_KEY_DELETE) == GLFW_PRESS);
-    nk_input_key(ctx, NK_KEY_ENTER, glfwGetKey(win, GLFW_KEY_ENTER) == GLFW_PRESS);
+    nk_input_key(ctx, NK_KEY_ENTER, glfwGetKey(win, GLFW_KEY_ENTER) == GLFW_PRESS ||
+                                    glfwGetKey(win, GLFW_KEY_KP_ENTER) == GLFW_PRESS);
+
     nk_input_key(ctx, NK_KEY_TAB, glfwGetKey(win, GLFW_KEY_TAB) == GLFW_PRESS);
     nk_input_key(ctx, NK_KEY_BACKSPACE, glfwGetKey(win, GLFW_KEY_BACKSPACE) == GLFW_PRESS);
     nk_input_key(ctx, NK_KEY_UP, glfwGetKey(win, GLFW_KEY_UP) == GLFW_PRESS);

--- a/demo/glfw_vulkan/main.c
+++ b/demo/glfw_vulkan/main.c
@@ -39,7 +39,7 @@
 /*#define INCLUDE_STYLE */
 /*#define INCLUDE_CALCULATOR */
 /*#define INCLUDE_CANVAS */
-/*#define INCLUDE_OVERVIEW*/
+#define INCLUDE_OVERVIEW
 /*#define INCLUDE_CONFIGURATOR */
 /*#define INCLUDE_NODE_EDITOR */
 

--- a/demo/glfw_vulkan/nuklear_glfw_vulkan.h
+++ b/demo/glfw_vulkan/nuklear_glfw_vulkan.h
@@ -1272,7 +1272,9 @@ NK_API void nk_glfw3_new_frame(void) {
     nk_input_key(ctx, NK_KEY_DEL,
                  glfwGetKey(win, GLFW_KEY_DELETE) == GLFW_PRESS);
     nk_input_key(ctx, NK_KEY_ENTER,
-                 glfwGetKey(win, GLFW_KEY_ENTER) == GLFW_PRESS);
+                 glfwGetKey(win, GLFW_KEY_ENTER) == GLFW_PRESS ||
+                 glfwGetKey(win, GLFW_KEY_KP_ENTER) == GLFW_PRESS);
+
     nk_input_key(ctx, NK_KEY_TAB, glfwGetKey(win, GLFW_KEY_TAB) == GLFW_PRESS);
     nk_input_key(ctx, NK_KEY_BACKSPACE,
                  glfwGetKey(win, GLFW_KEY_BACKSPACE) == GLFW_PRESS);

--- a/demo/sfml_opengl2/Makefile
+++ b/demo/sfml_opengl2/Makefile
@@ -22,7 +22,7 @@ else
 	ifeq ($(UNAME_S),Darwin)
 		LIBS = -lsfml-window -lsfml-system -pthread -framework OpenGL
 	else
-		LIBS = -DSFML_STATIC -lsfml-window-s -lsfml-system-s -pthread -ludev -lGL -lX11 -lXrandr
+		LIBS = -DSFML_STATIC -lsfml-window -lsfml-system -pthread -ludev -lGL -lX11 -lXrandr
 	endif
 endif
 

--- a/demo/sfml_opengl2/nuklear_sfml_gl2.h
+++ b/demo/sfml_opengl2/nuklear_sfml_gl2.h
@@ -279,7 +279,7 @@ nk_sfml_handle_event(sf::Event* evt)
             nk_input_key(ctx, NK_KEY_SHIFT, down);
         else if(key == sf::Keyboard::Delete)
             nk_input_key(ctx, NK_KEY_DEL, down);
-        else if(key == sf::Keyboard::Return)
+        else if(key == sf::Keyboard::Enter)
             nk_input_key(ctx, NK_KEY_ENTER, down);
         else if(key == sf::Keyboard::Tab)
             nk_input_key(ctx, NK_KEY_TAB, down);

--- a/demo/sfml_opengl3/nuklear_sfml_gl3.h
+++ b/demo/sfml_opengl3/nuklear_sfml_gl3.h
@@ -386,7 +386,7 @@ nk_sfml_handle_event(sf::Event* evt)
             nk_input_key(ctx, NK_KEY_SHIFT, down);
         else if(key == sf::Keyboard::Delete)
             nk_input_key(ctx, NK_KEY_DEL, down);
-        else if(key == sf::Keyboard::Return)
+        else if(key == sf::Keyboard::Enter)
             nk_input_key(ctx, NK_KEY_ENTER, down);
         else if(key == sf::Keyboard::Tab)
             nk_input_key(ctx, NK_KEY_TAB, down);

--- a/demo/x11/nuklear_xlib.h
+++ b/demo/x11/nuklear_xlib.h
@@ -739,7 +739,7 @@ nk_xlib_handle_event(Display *dpy, int screen, Window win, XEvent *evt)
         if (*code == XK_Shift_L || *code == XK_Shift_R) nk_input_key(ctx, NK_KEY_SHIFT, down);
         else if (*code == XK_Control_L || *code == XK_Control_R) nk_input_key(ctx, NK_KEY_CTRL, down);
         else if (*code == XK_Delete)    nk_input_key(ctx, NK_KEY_DEL, down);
-        else if (*code == XK_Return)    nk_input_key(ctx, NK_KEY_ENTER, down);
+        else if (*code == XK_Return || *code == XK_KP_Enter)    nk_input_key(ctx, NK_KEY_ENTER, down);
         else if (*code == XK_Tab)       nk_input_key(ctx, NK_KEY_TAB, down);
         else if (*code == XK_Left)      nk_input_key(ctx, NK_KEY_LEFT, down);
         else if (*code == XK_Right)     nk_input_key(ctx, NK_KEY_RIGHT, down);

--- a/demo/x11_opengl2/nuklear_xlib_gl2.h
+++ b/demo/x11_opengl2/nuklear_xlib_gl2.h
@@ -260,7 +260,7 @@ nk_x11_handle_event(XEvent *evt)
         if (*code == XK_Shift_L || *code == XK_Shift_R) nk_input_key(ctx, NK_KEY_SHIFT, down);
         else if (*code == XK_Control_L || *code == XK_Control_R) nk_input_key(ctx, NK_KEY_CTRL, down);
         else if (*code == XK_Delete)    nk_input_key(ctx, NK_KEY_DEL, down);
-        else if (*code == XK_Return)    nk_input_key(ctx, NK_KEY_ENTER, down);
+        else if (*code == XK_Return || *code == XK_KP_Enter)    nk_input_key(ctx, NK_KEY_ENTER, down);
         else if (*code == XK_Tab)       nk_input_key(ctx, NK_KEY_TAB, down);
         else if (*code == XK_Left)      nk_input_key(ctx, NK_KEY_LEFT, down);
         else if (*code == XK_Right)     nk_input_key(ctx, NK_KEY_RIGHT, down);

--- a/demo/x11_opengl3/nuklear_xlib_gl3.h
+++ b/demo/x11_opengl3/nuklear_xlib_gl3.h
@@ -627,7 +627,7 @@ nk_x11_handle_event(XEvent *evt)
         if (*code == XK_Shift_L || *code == XK_Shift_R) nk_input_key(ctx, NK_KEY_SHIFT, down);
         else if (*code == XK_Control_L || *code == XK_Control_R) nk_input_key(ctx, NK_KEY_CTRL, down);
         else if (*code == XK_Delete)    nk_input_key(ctx, NK_KEY_DEL, down);
-        else if (*code == XK_Return)    nk_input_key(ctx, NK_KEY_ENTER, down);
+        else if (*code == XK_Return || *code == XK_KP_Enter)    nk_input_key(ctx, NK_KEY_ENTER, down);
         else if (*code == XK_Tab)       nk_input_key(ctx, NK_KEY_TAB, down);
         else if (*code == XK_Left)      nk_input_key(ctx, NK_KEY_LEFT, down);
         else if (*code == XK_Right)     nk_input_key(ctx, NK_KEY_RIGHT, down);

--- a/demo/x11_xft/nuklear_xlib.h
+++ b/demo/x11_xft/nuklear_xlib.h
@@ -824,7 +824,7 @@ nk_xlib_handle_event(Display *dpy, int screen, Window win, XEvent *evt)
         if (*code == XK_Shift_L || *code == XK_Shift_R) nk_input_key(ctx, NK_KEY_SHIFT, down);
         else if (*code == XK_Control_L || *code == XK_Control_R) nk_input_key(ctx, NK_KEY_CTRL, down);
         else if (*code == XK_Delete)    nk_input_key(ctx, NK_KEY_DEL, down);
-        else if (*code == XK_Return)    nk_input_key(ctx, NK_KEY_ENTER, down);
+        else if (*code == XK_Return || *code == XK_KP_Enter)    nk_input_key(ctx, NK_KEY_ENTER, down);
         else if (*code == XK_Tab)       nk_input_key(ctx, NK_KEY_TAB, down);
         else if (*code == XK_Left)      nk_input_key(ctx, NK_KEY_LEFT, down);
         else if (*code == XK_Right)     nk_input_key(ctx, NK_KEY_RIGHT, down);

--- a/demo/xcb_cairo/nuklear_xcb.h
+++ b/demo/xcb_cairo/nuklear_xcb.h
@@ -114,13 +114,13 @@ NK_API void nk_xcb_resize_cairo_surface(struct nk_xcb_context *xcb_ctx, void *su
 #define NK_XCB_TO_CAIRO(x) ((double) x / 255.0)
 #define NK_XCB_DEG_TO_RAD(x) ((double) x * NK_XCB_PI / 180.0)
 
-typedef struct xkb_context xkb_context; 
+typedef struct xkb_context xkb_context;
 typedef struct xkb_keymap xkb_keymap;
 typedef struct xkb_state xkb_state;
 typedef struct xkbcommon_context xkbcommon_context;
 typedef struct nk_xcb_context nk_xcb_context;
 
-struct xkbcommon_context 
+struct xkbcommon_context
 {
 	struct xkb_context *ctx;
 	struct xkb_keymap *keymap;
@@ -260,7 +260,7 @@ NK_API int nk_xcb_handle_event(struct nk_xcb_context *xcb_ctx, struct nk_context
                 xcb_key_press_event_t *kp = (xcb_key_press_event_t *)event;
                 /* xcb_keysym_t sym = xcb_key_symbols_get_keysym(xcb_ctx->key_symbols, kp->detail, kp->state);*/
                 xcb_keysym_t sym = keycode_to_keysym(xcb_ctx, kp->detail, press);
-                
+
                 switch (sym) {
                 case XK_Shift_L:
                 case XK_Shift_R:
@@ -274,6 +274,7 @@ NK_API int nk_xcb_handle_event(struct nk_xcb_context *xcb_ctx, struct nk_context
                     nk_input_key(nk_ctx, NK_KEY_DEL, press);
                     break;
                 case XK_Return:
+                case XK_KP_Enter:
                     nk_input_key(nk_ctx, NK_KEY_ENTER, press);
                     break;
                 case XK_Tab:
@@ -873,7 +874,7 @@ NK_INTERN xkbcommon_context *xkbcommon_init(xcb_connection_t *conn)
 {
 	xkbcommon_context *kbdctx;
 	int32_t device_id;
-	
+
 	int ret = xkb_x11_setup_xkb_extension(conn,
 		XKB_X11_MIN_MAJOR_XKB_VERSION,
 		XKB_X11_MIN_MINOR_XKB_VERSION,
@@ -884,26 +885,26 @@ NK_INTERN xkbcommon_context *xkbcommon_init(xcb_connection_t *conn)
 	{
 		return NULL;
 	}
-	
+
 	kbdctx = (xkbcommon_context *)malloc(sizeof(xkbcommon_context));
 	kbdctx->ctx = NULL;
 	kbdctx->keymap = NULL;
 	kbdctx->state = NULL;
-	
+
 	kbdctx->ctx = xkb_context_new(XKB_CONTEXT_NO_FLAGS);
     if (!kbdctx->ctx)
 	{
 		xkbcommon_free(kbdctx);
 		return NULL;
 	}
-	
+
 	device_id = xkb_x11_get_core_keyboard_device_id(conn);
 	if (device_id == -1)
 	{
 		xkbcommon_free(kbdctx);
 		return NULL;
 	}
-	
+
 	kbdctx->keymap = xkb_x11_keymap_new_from_device(kbdctx->ctx, conn, device_id, XKB_KEYMAP_COMPILE_NO_FLAGS);
 	if (!kbdctx->keymap)
 	{
@@ -927,12 +928,12 @@ NK_INTERN void xkbcommon_free(xkbcommon_context *kbdctx)
 	{
 		if (kbdctx->state) xkb_state_unref(kbdctx->state);
 		if (kbdctx->keymap) xkb_keymap_unref(kbdctx->keymap);
-		if (kbdctx->ctx) xkb_context_unref(kbdctx->ctx);	
+		if (kbdctx->ctx) xkb_context_unref(kbdctx->ctx);
 
 		kbdctx->ctx = NULL;
 		kbdctx->keymap = NULL;
 		kbdctx->state = NULL;
-		
+
 		free(kbdctx);
 	}
 }
@@ -941,7 +942,7 @@ NK_INTERN xkb_keysym_t keycode_to_keysym(nk_xcb_context *ctx, xkb_keycode_t keyc
 {
 	xkb_keysym_t keysym;
 	xkbcommon_context *kbdctx = ctx->xkbcommon_ctx;
-	
+
 	if (kbdctx != NULL)
 	{
 		keysym = xkb_state_key_get_one_sym(kbdctx->state, keycode);
@@ -953,7 +954,7 @@ NK_INTERN xkb_keysym_t keycode_to_keysym(nk_xcb_context *ctx, xkb_keycode_t keyc
 	{
 		keysym = 0;
 	}
-	
+
 	return keysym;
 }
 


### PR DESCRIPTION
@RobLoach you merged my last pull request so I'm taking that as approval to make similar changes to the other backends as appropriate.  I've done so to all except rawfb since that's kind of special/unfinished.

As I said before, I'm unable to easily test the Windows backends but they all use the same input method so if one works they should all work.

In the process of going through everything I found a couple issues I hope someone else can verify:

* glfw_gl4 demo crashes, something to do with the shaders, I didn't dig into it
* SFML Makefiles fail on linux, removing the "-s" suffixes on the libraries fixes it for me
* All SFML backends have a weird input bug