### PR TITLE
Add support for right control to sdl backends

### DIFF
--- a/demo/sdl_opengl2/nuklear_sdl_gl2.h
+++ b/demo/sdl_opengl2/nuklear_sdl_gl2.h
@@ -263,6 +263,7 @@ NK_API int
 nk_sdl_handle_event(SDL_Event *evt)
 {
     struct nk_context *ctx = &sdl.ctx;
+    int ctrl_down = SDL_GetModState() & (KMOD_LCTRL | KMOD_RCTRL);
 
     switch(evt->type)
     {
@@ -270,7 +271,6 @@ nk_sdl_handle_event(SDL_Event *evt)
         case SDL_KEYDOWN:
             {
                 int down = evt->type == SDL_KEYDOWN;
-                const Uint8* state = SDL_GetKeyboardState(0);
                 switch(evt->key.keysym.sym)
                 {
                     case SDLK_RSHIFT: /* RSHIFT & LSHIFT share same routine */
@@ -288,26 +288,26 @@ nk_sdl_handle_event(SDL_Event *evt)
                                          nk_input_key(ctx, NK_KEY_SCROLL_END, down); break;
                     case SDLK_PAGEDOWN:  nk_input_key(ctx, NK_KEY_SCROLL_DOWN, down); break;
                     case SDLK_PAGEUP:    nk_input_key(ctx, NK_KEY_SCROLL_UP, down); break;
-                    case SDLK_z:         nk_input_key(ctx, NK_KEY_TEXT_UNDO, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_r:         nk_input_key(ctx, NK_KEY_TEXT_REDO, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_c:         nk_input_key(ctx, NK_KEY_COPY, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_v:         nk_input_key(ctx, NK_KEY_PASTE, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_x:         nk_input_key(ctx, NK_KEY_CUT, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_b:         nk_input_key(ctx, NK_KEY_TEXT_LINE_START, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_e:         nk_input_key(ctx, NK_KEY_TEXT_LINE_END, down && state[SDL_SCANCODE_LCTRL]); break;
+                    case SDLK_z:         nk_input_key(ctx, NK_KEY_TEXT_UNDO, down && ctrl_down); break;
+                    case SDLK_r:         nk_input_key(ctx, NK_KEY_TEXT_REDO, down && ctrl_down); break;
+                    case SDLK_c:         nk_input_key(ctx, NK_KEY_COPY, down && ctrl_down); break;
+                    case SDLK_v:         nk_input_key(ctx, NK_KEY_PASTE, down && ctrl_down); break;
+                    case SDLK_x:         nk_input_key(ctx, NK_KEY_CUT, down && ctrl_down); break;
+                    case SDLK_b:         nk_input_key(ctx, NK_KEY_TEXT_LINE_START, down && ctrl_down); break;
+                    case SDLK_e:         nk_input_key(ctx, NK_KEY_TEXT_LINE_END, down && ctrl_down); break;
                     case SDLK_UP:        nk_input_key(ctx, NK_KEY_UP, down); break;
                     case SDLK_DOWN:      nk_input_key(ctx, NK_KEY_DOWN, down); break;
                     case SDLK_a:
-                        if(state[SDL_SCANCODE_LCTRL])
+                        if (ctrl_down)
                             nk_input_key(ctx,NK_KEY_TEXT_SELECT_ALL, down);
                         break;
                     case SDLK_LEFT:
-                        if (state[SDL_SCANCODE_LCTRL])
+                        if (ctrl_down)
                             nk_input_key(ctx, NK_KEY_TEXT_WORD_LEFT, down);
                         else nk_input_key(ctx, NK_KEY_LEFT, down);
                         break;
                     case SDLK_RIGHT:
-                        if (state[SDL_SCANCODE_LCTRL])
+                        if (ctrl_down)
                             nk_input_key(ctx, NK_KEY_TEXT_WORD_RIGHT, down);
                         else nk_input_key(ctx, NK_KEY_RIGHT, down);
                         break;

--- a/demo/sdl_opengl3/nuklear_sdl_gl3.h
+++ b/demo/sdl_opengl3/nuklear_sdl_gl3.h
@@ -373,6 +373,7 @@ NK_API int
 nk_sdl_handle_event(SDL_Event *evt)
 {
     struct nk_context *ctx = &sdl.ctx;
+    int ctrl_down = SDL_GetModState() & (KMOD_LCTRL | KMOD_RCTRL);
 
     switch(evt->type)
     {
@@ -380,7 +381,6 @@ nk_sdl_handle_event(SDL_Event *evt)
         case SDL_KEYDOWN:
             {
                 int down = evt->type == SDL_KEYDOWN;
-                const Uint8* state = SDL_GetKeyboardState(0);
                 switch(evt->key.keysym.sym)
                 {
                     case SDLK_RSHIFT: /* RSHIFT & LSHIFT share same routine */
@@ -398,26 +398,26 @@ nk_sdl_handle_event(SDL_Event *evt)
                                          nk_input_key(ctx, NK_KEY_SCROLL_END, down); break;
                     case SDLK_PAGEDOWN:  nk_input_key(ctx, NK_KEY_SCROLL_DOWN, down); break;
                     case SDLK_PAGEUP:    nk_input_key(ctx, NK_KEY_SCROLL_UP, down); break;
-                    case SDLK_z:         nk_input_key(ctx, NK_KEY_TEXT_UNDO, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_r:         nk_input_key(ctx, NK_KEY_TEXT_REDO, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_c:         nk_input_key(ctx, NK_KEY_COPY, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_v:         nk_input_key(ctx, NK_KEY_PASTE, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_x:         nk_input_key(ctx, NK_KEY_CUT, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_b:         nk_input_key(ctx, NK_KEY_TEXT_LINE_START, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_e:         nk_input_key(ctx, NK_KEY_TEXT_LINE_END, down && state[SDL_SCANCODE_LCTRL]); break;
+                    case SDLK_z:         nk_input_key(ctx, NK_KEY_TEXT_UNDO, down && ctrl_down); break;
+                    case SDLK_r:         nk_input_key(ctx, NK_KEY_TEXT_REDO, down && ctrl_down); break;
+                    case SDLK_c:         nk_input_key(ctx, NK_KEY_COPY, down && ctrl_down); break;
+                    case SDLK_v:         nk_input_key(ctx, NK_KEY_PASTE, down && ctrl_down); break;
+                    case SDLK_x:         nk_input_key(ctx, NK_KEY_CUT, down && ctrl_down); break;
+                    case SDLK_b:         nk_input_key(ctx, NK_KEY_TEXT_LINE_START, down && ctrl_down); break;
+                    case SDLK_e:         nk_input_key(ctx, NK_KEY_TEXT_LINE_END, down && ctrl_down); break;
                     case SDLK_UP:        nk_input_key(ctx, NK_KEY_UP, down); break;
                     case SDLK_DOWN:      nk_input_key(ctx, NK_KEY_DOWN, down); break;
                     case SDLK_a:
-                        if(state[SDL_SCANCODE_LCTRL])
+                        if (ctrl_down)
                             nk_input_key(ctx,NK_KEY_TEXT_SELECT_ALL, down);
                         break;
                     case SDLK_LEFT:
-                        if (state[SDL_SCANCODE_LCTRL])
+                        if (ctrl_down)
                             nk_input_key(ctx, NK_KEY_TEXT_WORD_LEFT, down);
                         else nk_input_key(ctx, NK_KEY_LEFT, down);
                         break;
                     case SDLK_RIGHT:
-                        if (state[SDL_SCANCODE_LCTRL])
+                        if (ctrl_down)
                             nk_input_key(ctx, NK_KEY_TEXT_WORD_RIGHT, down);
                         else nk_input_key(ctx, NK_KEY_RIGHT, down);
                         break;

--- a/demo/sdl_opengles2/nuklear_sdl_gles2.h
+++ b/demo/sdl_opengles2/nuklear_sdl_gles2.h
@@ -373,6 +373,7 @@ NK_API int
 nk_sdl_handle_event(SDL_Event *evt)
 {
     struct nk_context *ctx = &sdl.ctx;
+    int ctrl_down = SDL_GetModState() & (KMOD_LCTRL | KMOD_RCTRL);
 
     switch(evt->type)
     {
@@ -380,7 +381,6 @@ nk_sdl_handle_event(SDL_Event *evt)
         case SDL_KEYDOWN:
             {
                 int down = evt->type == SDL_KEYDOWN;
-                const Uint8* state = SDL_GetKeyboardState(0);
                 switch(evt->key.keysym.sym)
                 {
                     case SDLK_RSHIFT: /* RSHIFT & LSHIFT share same routine */
@@ -398,26 +398,26 @@ nk_sdl_handle_event(SDL_Event *evt)
                                          nk_input_key(ctx, NK_KEY_SCROLL_END, down); break;
                     case SDLK_PAGEDOWN:  nk_input_key(ctx, NK_KEY_SCROLL_DOWN, down); break;
                     case SDLK_PAGEUP:    nk_input_key(ctx, NK_KEY_SCROLL_UP, down); break;
-                    case SDLK_z:         nk_input_key(ctx, NK_KEY_TEXT_UNDO, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_r:         nk_input_key(ctx, NK_KEY_TEXT_REDO, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_c:         nk_input_key(ctx, NK_KEY_COPY, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_v:         nk_input_key(ctx, NK_KEY_PASTE, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_x:         nk_input_key(ctx, NK_KEY_CUT, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_b:         nk_input_key(ctx, NK_KEY_TEXT_LINE_START, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_e:         nk_input_key(ctx, NK_KEY_TEXT_LINE_END, down && state[SDL_SCANCODE_LCTRL]); break;
+                    case SDLK_z:         nk_input_key(ctx, NK_KEY_TEXT_UNDO, down && ctrl_down); break;
+                    case SDLK_r:         nk_input_key(ctx, NK_KEY_TEXT_REDO, down && ctrl_down); break;
+                    case SDLK_c:         nk_input_key(ctx, NK_KEY_COPY, down && ctrl_down); break;
+                    case SDLK_v:         nk_input_key(ctx, NK_KEY_PASTE, down && ctrl_down); break;
+                    case SDLK_x:         nk_input_key(ctx, NK_KEY_CUT, down && ctrl_down); break;
+                    case SDLK_b:         nk_input_key(ctx, NK_KEY_TEXT_LINE_START, down && ctrl_down); break;
+                    case SDLK_e:         nk_input_key(ctx, NK_KEY_TEXT_LINE_END, down && ctrl_down); break;
                     case SDLK_UP:        nk_input_key(ctx, NK_KEY_UP, down); break;
                     case SDLK_DOWN:      nk_input_key(ctx, NK_KEY_DOWN, down); break;
                     case SDLK_a:
-                        if(state[SDL_SCANCODE_LCTRL])
+                        if (ctrl_down)
                             nk_input_key(ctx,NK_KEY_TEXT_SELECT_ALL, down);
                         break;
                     case SDLK_LEFT:
-                        if (state[SDL_SCANCODE_LCTRL])
+                        if (ctrl_down)
                             nk_input_key(ctx, NK_KEY_TEXT_WORD_LEFT, down);
                         else nk_input_key(ctx, NK_KEY_LEFT, down);
                         break;
                     case SDLK_RIGHT:
-                        if (state[SDL_SCANCODE_LCTRL])
+                        if (ctrl_down)
                             nk_input_key(ctx, NK_KEY_TEXT_WORD_RIGHT, down);
                         else nk_input_key(ctx, NK_KEY_RIGHT, down);
                         break;

--- a/demo/sdl_renderer/nuklear_sdl_renderer.h
+++ b/demo/sdl_renderer/nuklear_sdl_renderer.h
@@ -296,6 +296,7 @@ NK_API int
 nk_sdl_handle_event(SDL_Event *evt)
 {
     struct nk_context *ctx = &sdl.ctx;
+    int ctrl_down = SDL_GetModState() & (KMOD_LCTRL | KMOD_RCTRL);
 
     switch(evt->type)
     {
@@ -303,7 +304,6 @@ nk_sdl_handle_event(SDL_Event *evt)
         case SDL_KEYDOWN:
             {
                 int down = evt->type == SDL_KEYDOWN;
-                const Uint8* state = SDL_GetKeyboardState(0);
                 switch(evt->key.keysym.sym)
                 {
                     case SDLK_RSHIFT: /* RSHIFT & LSHIFT share same routine */
@@ -321,26 +321,26 @@ nk_sdl_handle_event(SDL_Event *evt)
                                          nk_input_key(ctx, NK_KEY_SCROLL_END, down); break;
                     case SDLK_PAGEDOWN:  nk_input_key(ctx, NK_KEY_SCROLL_DOWN, down); break;
                     case SDLK_PAGEUP:    nk_input_key(ctx, NK_KEY_SCROLL_UP, down); break;
-                    case SDLK_z:         nk_input_key(ctx, NK_KEY_TEXT_UNDO, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_r:         nk_input_key(ctx, NK_KEY_TEXT_REDO, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_c:         nk_input_key(ctx, NK_KEY_COPY, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_v:         nk_input_key(ctx, NK_KEY_PASTE, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_x:         nk_input_key(ctx, NK_KEY_CUT, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_b:         nk_input_key(ctx, NK_KEY_TEXT_LINE_START, down && state[SDL_SCANCODE_LCTRL]); break;
-                    case SDLK_e:         nk_input_key(ctx, NK_KEY_TEXT_LINE_END, down && state[SDL_SCANCODE_LCTRL]); break;
+                    case SDLK_z:         nk_input_key(ctx, NK_KEY_TEXT_UNDO, down && ctrl_down); break;
+                    case SDLK_r:         nk_input_key(ctx, NK_KEY_TEXT_REDO, down && ctrl_down); break;
+                    case SDLK_c:         nk_input_key(ctx, NK_KEY_COPY, down && ctrl_down); break;
+                    case SDLK_v:         nk_input_key(ctx, NK_KEY_PASTE, down && ctrl_down); break;
+                    case SDLK_x:         nk_input_key(ctx, NK_KEY_CUT, down && ctrl_down); break;
+                    case SDLK_b:         nk_input_key(ctx, NK_KEY_TEXT_LINE_START, down && ctrl_down); break;
+                    case SDLK_e:         nk_input_key(ctx, NK_KEY_TEXT_LINE_END, down && ctrl_down); break;
                     case SDLK_UP:        nk_input_key(ctx, NK_KEY_UP, down); break;
                     case SDLK_DOWN:      nk_input_key(ctx, NK_KEY_DOWN, down); break;
                     case SDLK_a:
-                        if(state[SDL_SCANCODE_LCTRL])
+                        if (ctrl_down)
                             nk_input_key(ctx,NK_KEY_TEXT_SELECT_ALL, down);
                         break;
                     case SDLK_LEFT:
-                        if (state[SDL_SCANCODE_LCTRL])
+                        if (ctrl_down)
                             nk_input_key(ctx, NK_KEY_TEXT_WORD_LEFT, down);
                         else nk_input_key(ctx, NK_KEY_LEFT, down);
                         break;
                     case SDLK_RIGHT:
-                        if (state[SDL_SCANCODE_LCTRL])
+                        if (ctrl_down)
                             nk_input_key(ctx, NK_KEY_TEXT_WORD_RIGHT, down);
                         else nk_input_key(ctx, NK_KEY_RIGHT, down);
                         break;

--- a/demo/sdl_vulkan/nuklear_sdl_vulkan.h
+++ b/demo/sdl_vulkan/nuklear_sdl_vulkan.h
@@ -1254,12 +1254,12 @@ NK_API void nk_sdl_handle_grab(void) {
 
 NK_API int nk_sdl_handle_event(SDL_Event *evt) {
     struct nk_context *ctx = &sdl.ctx;
+    int ctrl_down = SDL_GetModState() & (KMOD_LCTRL | KMOD_RCTRL);
 
     switch (evt->type) {
     case SDL_KEYUP: /* KEYUP & KEYDOWN share same routine */
     case SDL_KEYDOWN: {
         int down = evt->type == SDL_KEYDOWN;
-        const Uint8 *state = SDL_GetKeyboardState(0);
         switch (evt->key.keysym.sym) {
         case SDLK_RSHIFT: /* RSHIFT & LSHIFT share same routine */
         case SDLK_LSHIFT:
@@ -1294,28 +1294,28 @@ NK_API int nk_sdl_handle_event(SDL_Event *evt) {
             break;
         case SDLK_z:
             nk_input_key(ctx, NK_KEY_TEXT_UNDO,
-                         down && state[SDL_SCANCODE_LCTRL]);
+                         down && ctrl_down);
             break;
         case SDLK_r:
             nk_input_key(ctx, NK_KEY_TEXT_REDO,
-                         down && state[SDL_SCANCODE_LCTRL]);
+                         down && ctrl_down);
             break;
         case SDLK_c:
-            nk_input_key(ctx, NK_KEY_COPY, down && state[SDL_SCANCODE_LCTRL]);
+            nk_input_key(ctx, NK_KEY_COPY, down && ctrl_down);
             break;
         case SDLK_v:
-            nk_input_key(ctx, NK_KEY_PASTE, down && state[SDL_SCANCODE_LCTRL]);
+            nk_input_key(ctx, NK_KEY_PASTE, down && ctrl_down);
             break;
         case SDLK_x:
-            nk_input_key(ctx, NK_KEY_CUT, down && state[SDL_SCANCODE_LCTRL]);
+            nk_input_key(ctx, NK_KEY_CUT, down && ctrl_down);
             break;
         case SDLK_b:
             nk_input_key(ctx, NK_KEY_TEXT_LINE_START,
-                         down && state[SDL_SCANCODE_LCTRL]);
+                         down && ctrl_down);
             break;
         case SDLK_e:
             nk_input_key(ctx, NK_KEY_TEXT_LINE_END,
-                         down && state[SDL_SCANCODE_LCTRL]);
+                         down && ctrl_down);
             break;
         case SDLK_UP:
             nk_input_key(ctx, NK_KEY_UP, down);
@@ -1324,17 +1324,17 @@ NK_API int nk_sdl_handle_event(SDL_Event *evt) {
             nk_input_key(ctx, NK_KEY_DOWN, down);
             break;
         case SDLK_a:
-            if(state[SDL_SCANCODE_LCTRL])
+            if(ctrl_down)
                 nk_input_key(ctx,NK_KEY_TEXT_SELECT_ALL, down);
             break;
         case SDLK_LEFT:
-            if (state[SDL_SCANCODE_LCTRL])
+            if (ctrl_down)
                 nk_input_key(ctx, NK_KEY_TEXT_WORD_LEFT, down);
             else
                 nk_input_key(ctx, NK_KEY_LEFT, down);
             break;
         case SDLK_RIGHT:
-            if (state[SDL_SCANCODE_LCTRL])
+            if (ctrl_down)
                 nk_input_key(ctx, NK_KEY_TEXT_WORD_RIGHT, down);
             else
                 nk_input_key(ctx, NK_KEY_RIGHT, down);


### PR DESCRIPTION
Can't believe I never noticed this issue before.

Pretty self explanatory: use SDL_GetModState() to get whether either control is down and use that instead of the key state array.