### PR TITLE
Use built-in motion handler to circumvent FPS-limit/VSync issue

### DIFF
--- a/demo/sdl3/nuklear_sdl3_renderer.h
+++ b/demo/sdl3/nuklear_sdl3_renderer.h
@@ -342,11 +342,7 @@ nk_sdl_handle_event(struct nk_context* ctx, SDL_Event *evt)
             return 1;
 
         case SDL_EVENT_MOUSE_MOTION:
-            ctx->input.mouse.prev = ctx->input.mouse.pos;
-            ctx->input.mouse.delta.x = evt->motion.xrel;
-            ctx->input.mouse.delta.y = evt->motion.yrel;
-            ctx->input.mouse.pos.x = evt->motion.x;
-            ctx->input.mouse.pos.y = evt->motion.y;
+            nk_input_motion(ctx, evt->motion.x, evt->motion.y);
             return 1;
 
         case SDL_EVENT_TEXT_INPUT:


### PR DESCRIPTION
The mouse delta when using the current nk_sdl_handle_event is inaccurate.  
This is apparent if you limit FPS or enable VSync, then move a window around, the window will lag behind the mouse in certain environments and desync immediately. (Tested on GNOME/Mutter on wayland)  
  
Essentially, the current solution seems to treat the mouse delta as being a guesstimated 20% lower than it is.  
  
The fix is using Nuklear's nk_input_motion instead
