### PR TITLE
fix: use precise mouse wheel info in demos

### DIFF
--- a/demo/rawfb/sdl/main.c
+++ b/demo/rawfb/sdl/main.c
@@ -216,8 +216,8 @@ int main(int argc, char **argv)
                     nk_input_button(&(context->ctx), sdl_button_to_nk(event.button.button), event.button.x, event.button.y,0);
                 break;
                 case SDL_MOUSEWHEEL:
-                    vec.x = event.wheel.x;
-                    vec.y = event.wheel.y;
+                    vec.x = event.wheel.preciseX;
+                    vec.y = event.wheel.preciseY;
                     nk_input_scroll(&(context->ctx), vec );
 
                 break;

--- a/demo/sdl_opengl2/nuklear_sdl_gl2.h
+++ b/demo/sdl_opengl2/nuklear_sdl_gl2.h
@@ -349,7 +349,7 @@ nk_sdl_handle_event(SDL_Event *evt)
             return 1;
 
         case SDL_MOUSEWHEEL:
-            nk_input_scroll(ctx,nk_vec2((float)evt->wheel.x,(float)evt->wheel.y));
+            nk_input_scroll(ctx,nk_vec2(evt->wheel.preciseX, evt->wheel.preciseY));
             return 1;
     }
     return 0;

--- a/demo/sdl_opengl3/nuklear_sdl_gl3.h
+++ b/demo/sdl_opengl3/nuklear_sdl_gl3.h
@@ -459,7 +459,7 @@ nk_sdl_handle_event(SDL_Event *evt)
             return 1;
 
         case SDL_MOUSEWHEEL:
-            nk_input_scroll(ctx,nk_vec2((float)evt->wheel.x,(float)evt->wheel.y));
+            nk_input_scroll(ctx,nk_vec2(evt->wheel.preciseX, evt->wheel.preciseY));
             return 1;
     }
     return 0;

--- a/demo/sdl_opengles2/nuklear_sdl_gles2.h
+++ b/demo/sdl_opengles2/nuklear_sdl_gles2.h
@@ -459,7 +459,7 @@ nk_sdl_handle_event(SDL_Event *evt)
             return 1;
 
         case SDL_MOUSEWHEEL:
-            nk_input_scroll(ctx,nk_vec2((float)evt->wheel.x,(float)evt->wheel.y));
+            nk_input_scroll(ctx,nk_vec2(evt->wheel.preciseX, evt->wheel.preciseY));
             return 1;
     }
     return 0;

--- a/demo/sdl_renderer/nuklear_sdl_renderer.h
+++ b/demo/sdl_renderer/nuklear_sdl_renderer.h
@@ -382,7 +382,7 @@ nk_sdl_handle_event(SDL_Event *evt)
             return 1;
 
         case SDL_MOUSEWHEEL:
-            nk_input_scroll(ctx,nk_vec2((float)evt->wheel.x,(float)evt->wheel.y));
+            nk_input_scroll(ctx,nk_vec2(evt->wheel.preciseX, evt->wheel.preciseY));
             return 1;
     }
     return 0;

--- a/demo/sdl_vulkan/nuklear_sdl_vulkan.h
+++ b/demo/sdl_vulkan/nuklear_sdl_vulkan.h
@@ -1382,7 +1382,7 @@ NK_API int nk_sdl_handle_event(SDL_Event *evt) {
     }
 
     case SDL_MOUSEWHEEL:
-        nk_input_scroll(ctx, nk_vec2((float)evt->wheel.x, (float)evt->wheel.y));
+        nk_input_scroll(ctx,nk_vec2(evt->wheel.preciseX, evt->wheel.preciseY));
         return 1;
     }
     return 0;

--- a/demo/sdl_vulkan/src/nuklear_sdl_vulkan.in.h
+++ b/demo/sdl_vulkan/src/nuklear_sdl_vulkan.in.h
@@ -1154,7 +1154,7 @@ NK_API int nk_sdl_handle_event(SDL_Event *evt) {
     }
 
     case SDL_MOUSEWHEEL:
-        nk_input_scroll(ctx, nk_vec2((float)evt->wheel.x, (float)evt->wheel.y));
+        nk_input_scroll(ctx,nk_vec2(evt->wheel.preciseX, evt->wheel.preciseY));
         return 1;
     }
     return 0;


### PR DESCRIPTION
Using the precise scroll wheel infos makes the demos (and apps) feel much more smoothly, source looks nicer additionaly.
Especially using touchpad gestures.