### PR TITLE
removed global object in SDL2 demo, more C++-friendly API

### DIFF
--- a/demo/sdl_opengl2/main.c
+++ b/demo/sdl_opengl2/main.c
@@ -79,13 +79,14 @@ int
 main(int argc, char *argv[])
 {
     /* Platform */
+    struct nk_sdl sdl;
     SDL_Window *win;
     SDL_GLContext glContext;
     int win_width, win_height;
     int running = 1;
 
     /* GUI */
-    struct nk_context *ctx;
+    struct nk_context ctx;
     struct nk_colorf bg;
 
     #ifdef INCLUDE_CONFIGURATOR
@@ -111,18 +112,18 @@ main(int argc, char *argv[])
     SDL_GetWindowSize(win, &win_width, &win_height);
 
     /* GUI */
-    ctx = nk_sdl_init(win);
+    nk_sdl_init(&ctx, &sdl);
     /* Load Fonts: if none of these are loaded a default font will be used  */
     /* Load Cursor: if you uncomment cursor loading please hide the cursor */
-    {struct nk_font_atlas *atlas;
-    nk_sdl_font_stash_begin(&atlas);
-    /*struct nk_font *droid = nk_font_atlas_add_from_file(atlas, "../../../extra_font/DroidSans.ttf", 14, 0);*/
-    /*struct nk_font *roboto = nk_font_atlas_add_from_file(atlas, "../../../extra_font/Roboto-Regular.ttf", 16, 0);*/
-    /*struct nk_font *future = nk_font_atlas_add_from_file(atlas, "../../../extra_font/kenvector_future_thin.ttf", 13, 0);*/
-    /*struct nk_font *clean = nk_font_atlas_add_from_file(atlas, "../../../extra_font/ProggyClean.ttf", 12, 0);*/
-    /*struct nk_font *tiny = nk_font_atlas_add_from_file(atlas, "../../../extra_font/ProggyTiny.ttf", 10, 0);*/
-    /*struct nk_font *cousine = nk_font_atlas_add_from_file(atlas, "../../../extra_font/Cousine-Regular.ttf", 13, 0);*/
-    nk_sdl_font_stash_end();
+    {
+    nk_sdl_font_stash_begin(&sdl);
+    /*struct nk_font *droid = nk_font_atlas_add_from_file(sdl.atlas, "../../../extra_font/DroidSans.ttf", 14, 0);*/
+    /*struct nk_font *roboto = nk_font_atlas_add_from_file(sdl.atlas, "../../../extra_font/Roboto-Regular.ttf", 16, 0);*/
+    /*struct nk_font *future = nk_font_atlas_add_from_file(sdl.atlas, "../../../extra_font/kenvector_future_thin.ttf", 13, 0);*/
+    /*struct nk_font *clean = nk_font_atlas_add_from_file(sdl.atlas, "../../../extra_font/ProggyClean.ttf", 12, 0);*/
+    /*struct nk_font *tiny = nk_font_atlas_add_from_file(sdl.atlas, "../../../extra_font/ProggyTiny.ttf", 10, 0);*/
+    /*struct nk_font *cousine = nk_font_atlas_add_from_file(sdl.atlas, "../../../extra_font/Cousine-Regular.ttf", 13, 0);*/
+    nk_sdl_font_stash_end(&ctx, &sdl);
     /*nk_style_load_all_cursors(ctx, atlas->cursors);*/
     /*nk_style_set_font(ctx, &roboto->handle)*/;}
 
@@ -131,16 +132,16 @@ main(int argc, char *argv[])
     {
         /* Input */
         SDL_Event evt;
-        nk_input_begin(ctx);
+        nk_input_begin(&ctx);
         while (SDL_PollEvent(&evt)) {
             if (evt.type == SDL_QUIT) goto cleanup;
-            nk_sdl_handle_event(&evt);
+            nk_sdl_handle_event(&ctx, &evt);
         }
-        nk_sdl_handle_grab(); /* optional grabbing behavior */
-        nk_input_end(ctx);
+        nk_sdl_handle_grab(&ctx, win); /* optional grabbing behavior */
+        nk_input_end(&ctx);
 
         /* GUI */
-        if (nk_begin(ctx, "Demo", nk_rect(50, 50, 230, 250),
+        if (nk_begin(&ctx, "Demo", nk_rect(50, 50, 230, 250),
             NK_WINDOW_BORDER|NK_WINDOW_MOVABLE|NK_WINDOW_SCALABLE|
             NK_WINDOW_MINIMIZABLE|NK_WINDOW_TITLE))
         {
@@ -148,46 +149,46 @@ main(int argc, char *argv[])
             static int op = EASY;
             static int property = 20;
 
-            nk_layout_row_static(ctx, 30, 80, 1);
-            if (nk_button_label(ctx, "button"))
+            nk_layout_row_static(&ctx, 30, 80, 1);
+            if (nk_button_label(&ctx, "button"))
                 fprintf(stdout, "button pressed\n");
-            nk_layout_row_dynamic(ctx, 30, 2);
-            if (nk_option_label(ctx, "easy", op == EASY)) op = EASY;
-            if (nk_option_label(ctx, "hard", op == HARD)) op = HARD;
-            nk_layout_row_dynamic(ctx, 25, 1);
-            nk_property_int(ctx, "Compression:", 0, &property, 100, 10, 1);
+            nk_layout_row_dynamic(&ctx, 30, 2);
+            if (nk_option_label(&ctx, "easy", op == EASY)) op = EASY;
+            if (nk_option_label(&ctx, "hard", op == HARD)) op = HARD;
+            nk_layout_row_dynamic(&ctx, 25, 1);
+            nk_property_int(&ctx, "Compression:", 0, &property, 100, 10, 1);
 
-            nk_layout_row_dynamic(ctx, 20, 1);
-            nk_label(ctx, "background:", NK_TEXT_LEFT);
-            nk_layout_row_dynamic(ctx, 25, 1);
-            if (nk_combo_begin_color(ctx, nk_rgb_cf(bg), nk_vec2(nk_widget_width(ctx),400))) {
-                nk_layout_row_dynamic(ctx, 120, 1);
-                bg = nk_color_picker(ctx, bg, NK_RGBA);
-                nk_layout_row_dynamic(ctx, 25, 1);
-                bg.r = nk_propertyf(ctx, "#R:", 0, bg.r, 1.0f, 0.01f,0.005f);
-                bg.g = nk_propertyf(ctx, "#G:", 0, bg.g, 1.0f, 0.01f,0.005f);
-                bg.b = nk_propertyf(ctx, "#B:", 0, bg.b, 1.0f, 0.01f,0.005f);
-                bg.a = nk_propertyf(ctx, "#A:", 0, bg.a, 1.0f, 0.01f,0.005f);
-                nk_combo_end(ctx);
+            nk_layout_row_dynamic(&ctx, 20, 1);
+            nk_label(&ctx, "background:", NK_TEXT_LEFT);
+            nk_layout_row_dynamic(&ctx, 25, 1);
+            if (nk_combo_begin_color(&ctx, nk_rgb_cf(bg), nk_vec2(nk_widget_width(&ctx),400))) {
+                nk_layout_row_dynamic(&ctx, 120, 1);
+                bg = nk_color_picker(&ctx, bg, NK_RGBA);
+                nk_layout_row_dynamic(&ctx, 25, 1);
+                bg.r = nk_propertyf(&ctx, "#R:", 0, bg.r, 1.0f, 0.01f,0.005f);
+                bg.g = nk_propertyf(&ctx, "#G:", 0, bg.g, 1.0f, 0.01f,0.005f);
+                bg.b = nk_propertyf(&ctx, "#B:", 0, bg.b, 1.0f, 0.01f,0.005f);
+                bg.a = nk_propertyf(&ctx, "#A:", 0, bg.a, 1.0f, 0.01f,0.005f);
+                nk_combo_end(&ctx);
             }
         }
-        nk_end(ctx);
+        nk_end(&ctx);
 
         /* -------------- EXAMPLES ---------------- */
         #ifdef INCLUDE_CALCULATOR
-          calculator(ctx);
+          calculator(&ctx);
         #endif
         #ifdef INCLUDE_CANVAS
-          canvas(ctx);
+          canvas(&ctx);
         #endif
         #ifdef INCLUDE_OVERVIEW
-          overview(ctx);
+          overview(&ctx);
         #endif
         #ifdef INCLUDE_CONFIGURATOR
-          style_configurator(ctx, color_table);
+          style_configurator(&ctx, color_table);
         #endif
         #ifdef INCLUDE_NODE_EDITOR
-          node_editor(ctx);
+          node_editor(&ctx);
         #endif
         /* ----------------------------------------- */
 
@@ -201,15 +202,14 @@ main(int argc, char *argv[])
          * defaults everything back into a default state.
          * Make sure to either a.) save and restore or b.) reset your own state after
          * rendering the UI. */
-        nk_sdl_render(NK_ANTI_ALIASING_ON);
+        nk_sdl_render(&ctx, &sdl, win, NK_ANTI_ALIASING_ON);
         SDL_GL_SwapWindow(win);
     }
 
 cleanup:
-    nk_sdl_shutdown();
+    nk_sdl_shutdown(&ctx, &sdl);
     SDL_GL_DeleteContext(glContext);
     SDL_DestroyWindow(win);
     SDL_Quit();
     return 0;
 }
-


### PR DESCRIPTION
I have modified SDL2 demo to 1) remove the global object 2) make interface more open and C++-friendly (most notably `nk_context` and `SDL_Window` are no longer a part of `nk_sdl`). Ideally I would remove the `nk_sdl` entirely or move all "official" `nk_` types out of it so that one can use them independently. My C++ code builds separate classes for `nk_context`, `nk_font_atlas` etc so if any demo/example code assumes certain layout of them (or stores them in a global object) it causes API incompatibility problems. Best if the C code just takes pointers and allows the callee to manage lifetime.

This is not a final state of the code I envision, it's more of a proof of concept that such API is possible. I want Nuklear examples to follow it's library design which means:

- no global or hidden state
- never assuming ownership of provided data
- not forcing the caller to any particular composition of data (everything as much separate as possible, passed by pointers)