### PR TITLE
Fix text input behavior

### DIFF
--- a/clib.json
+++ b/clib.json
@@ -1,6 +1,6 @@
 {
   "name": "nuklear",
-  "version": "4.12.6",
+  "version": "4.12.7",
   "repo": "Immediate-Mode-UI/Nuklear",
   "description": "A small ANSI C gui toolkit",
   "keywords": ["gl", "ui", "toolkit"],

--- a/demo/glfw_opengl3/Makefile
+++ b/demo/glfw_opengl3/Makefile
@@ -2,7 +2,7 @@
 BIN = demo
 
 # Flags
-CFLAGS += -std=c89 -Wall -Wextra -pedantic
+CFLAGS += -g -std=c89 -Wall -Wextra -pedantic
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/demo/glfw_opengl3/main.c
+++ b/demo/glfw_opengl3/main.c
@@ -8,6 +8,7 @@
 #include <assert.h>
 #include <limits.h>
 #include <time.h>
+#include <ctype.h>
 
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
@@ -21,6 +22,7 @@
 #define NK_INCLUDE_DEFAULT_FONT
 #define NK_IMPLEMENTATION
 #define NK_GLFW_GL3_IMPLEMENTATION
+/*#define NK_IS_WORD_BOUNDARY(c) (!isalnum(c))*/
 #include "../../nuklear.h"
 #include "nuklear_glfw_gl3.h"
 

--- a/demo/glfw_opengl3/main.c
+++ b/demo/glfw_opengl3/main.c
@@ -8,7 +8,6 @@
 #include <assert.h>
 #include <limits.h>
 #include <time.h>
-#include <ctype.h>
 
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
@@ -22,7 +21,6 @@
 #define NK_INCLUDE_DEFAULT_FONT
 #define NK_IMPLEMENTATION
 #define NK_GLFW_GL3_IMPLEMENTATION
-/*#define NK_IS_WORD_BOUNDARY(c) (!isalnum(c))*/
 #include "../../nuklear.h"
 #include "nuklear_glfw_gl3.h"
 

--- a/nuklear.h
+++ b/nuklear.h
@@ -30717,6 +30717,7 @@ nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)
 ///   - [y]: Minor version with non-breaking API and library changes
 ///   - [z]: Patch version with no direct changes to the API
 ///
+/// - 2025/04/06 (4.12.7) - Fix text input navigation and mouse scrolling
 /// - 2025/03/29 (4.12.6) - Fix unitialized data in nk_input_char
 /// - 2025/03/05 (4.12.5) - Fix scrolling knob also scrolling parent window, remove dead code
 /// - 2024/12/11 (4.12.4) - Fix array subscript [0, 0] is outside array bounds of ‘char[1]’

--- a/nuklear.h
+++ b/nuklear.h
@@ -27058,9 +27058,8 @@ nk_is_word_boundary( struct nk_text_edit *state, int idx)
     if (idx < 0) return 1;
     if (!nk_str_at_rune(&state->string, idx, &c, &len)) return 1;
 #ifndef NK_IS_WORD_BOUNDARY
-    return (c == ' ' || c == '\t' ||c == 0x3000 || c == ',' || c == ';' ||
-            c == '(' || c == ')' || c == '{' || c == '}' || c == '[' || c == ']' ||
-            c == '|');
+    return (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' ||
+            c == '\v' || c == 0x3000);
 #else
     return NK_IS_WORD_BOUNDARY(c);
 #endif

--- a/nuklear.h
+++ b/nuklear.h
@@ -27070,7 +27070,7 @@ nk_textedit_move_to_word_previous(struct nk_text_edit *state)
    int c = state->cursor - 1;
    if (c > 0) {
       if (nk_is_word_boundary(state, c)) {
-         while (c >= 0 && nk_is_word_boundary(state, --c));
+         while (c > 0 && nk_is_word_boundary(state, --c));
       }
       while (!nk_is_word_boundary(state, --c));
       c++;
@@ -28006,7 +28006,6 @@ nk_do_edit(nk_flags *state, struct nk_command_buffer *out,
 
     /* update edit state */
     prev_state = (char)edit->active;
-    is_hovered = (char)nk_input_is_mouse_hovering_rect(in, bounds);
     if (in && in->mouse.buttons[NK_BUTTON_LEFT].clicked && in->mouse.buttons[NK_BUTTON_LEFT].down) {
         edit->active = NK_INBOX(in->mouse.pos.x, in->mouse.pos.y,
                                 bounds.x, bounds.y, bounds.w, bounds.h);
@@ -28326,11 +28325,11 @@ nk_do_edit(nk_flags *state, struct nk_command_buffer *out,
                 scroll_step = scroll.h * 0.10f;
                 scroll_inc = scroll.h * 0.01f;
                 scroll_target = text_size.y;
-                edit->scrollbar.y = nk_do_scrollbarv(&ws, out, scroll, edit->active && in,
+                edit->scrollbar.y = nk_do_scrollbarv(&ws, out, scroll, is_hovered,
                         scroll_offset, scroll_target, scroll_step, scroll_inc,
                         &style->scrollbar, in, font);
                 /* Eat mouse scroll if we're active */
-                if (edit->active && in && in->mouse.scroll_delta.y) {
+                if (is_hovered && in->mouse.scroll_delta.y) {
                     in->mouse.scroll_delta.y = 0;
                 }
             }

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -7,6 +7,7 @@
 ///   - [y]: Minor version with non-breaking API and library changes
 ///   - [z]: Patch version with no direct changes to the API
 ///
+/// - 2025/04/06 (4.12.7) - Fix text input navigation and mouse scrolling
 /// - 2025/03/29 (4.12.6) - Fix unitialized data in nk_input_char
 /// - 2025/03/05 (4.12.5) - Fix scrolling knob also scrolling parent window, remove dead code
 /// - 2024/12/11 (4.12.4) - Fix array subscript [0, 0] is outside array bounds of ‘char[1]’

--- a/src/HEADER.md
+++ b/src/HEADER.md
@@ -108,6 +108,7 @@ NK_BUTTON_TRIGGER_ON_RELEASE    | Different platforms require button clicks occu
 NK_ZERO_COMMAND_MEMORY          | Defining this will zero out memory for each drawing command added to a drawing queue (inside nk_command_buffer_push). Zeroing command memory is very useful for fast checking (using memcmp) if command buffers are equal and avoid drawing frames when nothing on screen has changed since previous frame.
 NK_UINT_DRAW_INDEX              | Defining this will set the size of vertex index elements when using NK_VERTEX_BUFFER_OUTPUT to 32bit instead of the default of 16bit
 NK_KEYSTATE_BASED_INPUT         | Define this if your backend uses key state for each frame rather than key press/release events
+NK_IS_WORD_BOUNDARY(c)          | Define this to a function macro that takes a single nk_rune (nk_uint) and returns true if it's a word separator. If not defined, uses the default definition (see nk_is_word_boundary())
 
 !!! WARNING
     The following flags will pull in the standard C library:

--- a/src/nuklear_edit.c
+++ b/src/nuklear_edit.c
@@ -188,7 +188,6 @@ nk_do_edit(nk_flags *state, struct nk_command_buffer *out,
 
     /* update edit state */
     prev_state = (char)edit->active;
-    is_hovered = (char)nk_input_is_mouse_hovering_rect(in, bounds);
     if (in && in->mouse.buttons[NK_BUTTON_LEFT].clicked && in->mouse.buttons[NK_BUTTON_LEFT].down) {
         edit->active = NK_INBOX(in->mouse.pos.x, in->mouse.pos.y,
                                 bounds.x, bounds.y, bounds.w, bounds.h);
@@ -508,11 +507,11 @@ nk_do_edit(nk_flags *state, struct nk_command_buffer *out,
                 scroll_step = scroll.h * 0.10f;
                 scroll_inc = scroll.h * 0.01f;
                 scroll_target = text_size.y;
-                edit->scrollbar.y = nk_do_scrollbarv(&ws, out, scroll, edit->active && in,
+                edit->scrollbar.y = nk_do_scrollbarv(&ws, out, scroll, is_hovered,
                         scroll_offset, scroll_target, scroll_step, scroll_inc,
                         &style->scrollbar, in, font);
                 /* Eat mouse scroll if we're active */
-                if (edit->active && in && in->mouse.scroll_delta.y) {
+                if (is_hovered && in->mouse.scroll_delta.y) {
                     in->mouse.scroll_delta.y = 0;
                 }
             }

--- a/src/nuklear_edit.c
+++ b/src/nuklear_edit.c
@@ -480,10 +480,12 @@ nk_do_edit(nk_flags *state, struct nk_command_buffer *out,
                 } else edit->scrollbar.x = 0;
 
                 if (flags & NK_EDIT_MULTILINE) {
-                    /* vertical scroll */
+                    /* vertical scroll: like horizontal, it only adjusts if the
+                     * cursor leaves the visible area, and then only just enough
+                     * to keep it visible */
                     if (cursor_pos.y < edit->scrollbar.y)
-                        edit->scrollbar.y = NK_MAX(0.0f, cursor_pos.y - row_height);
-                    if (cursor_pos.y >= edit->scrollbar.y + row_height)
+                        edit->scrollbar.y = NK_MAX(0.0f, cursor_pos.y);
+                    if (cursor_pos.y > edit->scrollbar.y + area.h - row_height)
                         edit->scrollbar.y = edit->scrollbar.y + row_height;
                 } else edit->scrollbar.y = 0;
             }
@@ -506,9 +508,13 @@ nk_do_edit(nk_flags *state, struct nk_command_buffer *out,
                 scroll_step = scroll.h * 0.10f;
                 scroll_inc = scroll.h * 0.01f;
                 scroll_target = text_size.y;
-                edit->scrollbar.y = nk_do_scrollbarv(&ws, out, scroll, 0,
+                edit->scrollbar.y = nk_do_scrollbarv(&ws, out, scroll, edit->active && in,
                         scroll_offset, scroll_target, scroll_step, scroll_inc,
                         &style->scrollbar, in, font);
+                /* Eat mouse scroll if we're active */
+                if (edit->active && in && in->mouse.scroll_delta.y) {
+                    in->mouse.scroll_delta.y = 0;
+                }
             }
         }
 

--- a/src/nuklear_text_editor.c
+++ b/src/nuklear_text_editor.c
@@ -280,9 +280,8 @@ nk_is_word_boundary( struct nk_text_edit *state, int idx)
     if (idx < 0) return 1;
     if (!nk_str_at_rune(&state->string, idx, &c, &len)) return 1;
 #ifndef NK_IS_WORD_BOUNDARY
-    return (c == ' ' || c == '\t' ||c == 0x3000 || c == ',' || c == ';' ||
-            c == '(' || c == ')' || c == '{' || c == '}' || c == '[' || c == ']' ||
-            c == '|');
+    return (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' ||
+            c == '\v' || c == 0x3000);
 #else
     return NK_IS_WORD_BOUNDARY(c);
 #endif

--- a/src/nuklear_text_editor.c
+++ b/src/nuklear_text_editor.c
@@ -499,7 +499,7 @@ retry:
     case NK_KEY_TEXT_WORD_LEFT:
         if (shift_mod) {
             if( !NK_TEXT_HAS_SELECTION( state ) )
-            nk_textedit_prep_selection_at_cursor(state);
+                nk_textedit_prep_selection_at_cursor(state);
             state->cursor = nk_textedit_move_to_word_previous(state);
             state->select_end = state->cursor;
             nk_textedit_clamp(state );

--- a/src/nuklear_text_editor.c
+++ b/src/nuklear_text_editor.c
@@ -292,7 +292,7 @@ nk_textedit_move_to_word_previous(struct nk_text_edit *state)
    int c = state->cursor - 1;
    if (c > 0) {
       if (nk_is_word_boundary(state, c)) {
-         while (c >= 0 && nk_is_word_boundary(state, --c));
+         while (c > 0 && nk_is_word_boundary(state, --c));
       }
       while (!nk_is_word_boundary(state, --c));
       c++;


### PR DESCRIPTION
This does a few things.

1. It fixes the behavior of CTRL + LEFT/RIGHT to be both more standard and configurable.  By default it now jumps to the beginning of words with whitespace being the separator, roughly in line with other text editors.  Secondly the user can define NK_IS_WORD_BOUNDARY(c), a function style macro that takes a nk_rune aka nk_uint and returns true/1 if that character should be treated as a boundary, false otherwise.  Of course I did all this before I realized/remembered that nk_text_editor.c is adapted from stb_textedit.h 1.8 in 2016. Since then user configurable word boundaries was added as well as several other fixes up through current 1.14.  Sometime someone should review those changes and apply any we need or could benefit from.
2. It fixes mouse scrolling.  Like with the knobs, scrolling with the mousewheel was broken for multi-line text boxes. It might have been by design originally (based on 0 being passed for has_scrolling) but the behavior for the user was very inconsistent.  Now it matches other subpanel behavior and user expectations.  Horizontal scrolling is not handled as it's sort of a special case and there's no horizontal scrollbar even when there could/should be.  Not a big deal either way imo.
3. It makes the scrolling behavior follow the cursor in a consistent manner going both up and down.  Before it would only scroll up if you went out of view, but it would jump down in increments every time you moved till it couldn't go further. Now going down works the same as up; the scrollbar doesn't move in either direction unless the cursor goes off the page.

In doing this work I saw another existing issue that is still there but is less important and will take more thinking.  Clicking and dragging, the scrollbar follows the cursor enabling you to drag select the entire text.  Theoretically.  In reality you can't really drag upward past the top line of your current scroll position because the cursor is based on the mouse position and there's no way for the mouse to hover over a line that's not visible.  The way to work around this is to just use the mouse wheel to scroll up while you hold the left button.  Going down below the bottom can work and does in the Overview demo because the text box is not evenly divisible by the row height so you can actually hover just past the end of the last full line of text triggering the cursor to the next line and triggering the scrollbar to shift down.

I don't think this is a huge issue but if I had to fix it I might add a flag parameter to nk_textedit_locate_coord() to indicate it's a drag and and detect if you're in the top or bottom row and automatically jump up/down.

PS. I haven't really given up on the nk_image work but my idea to solve the backends that only support 1 to 1 image blitting problem led me to doing a lot of experimenting/research and it'll take me a few weeks at least before I have something somewhat polished and fast enough to try.