### PR TITLE
Make slider behave like progress bar

### DIFF
--- a/clib.json
+++ b/clib.json
@@ -1,6 +1,6 @@
 {
   "name": "nuklear",
-  "version": "4.12.7",
+  "version": "4.12.8",
   "repo": "Immediate-Mode-UI/Nuklear",
   "description": "A small ANSI C gui toolkit",
   "keywords": ["gl", "ui", "toolkit"],

--- a/nuklear.h
+++ b/nuklear.h
@@ -25923,6 +25923,7 @@ nk_do_slider(nk_flags *state,
 
     struct nk_rect visual_cursor;
     struct nk_rect logical_cursor;
+    struct nk_rect cursor;
 
     NK_ASSERT(style);
     NK_ASSERT(out);
@@ -25986,8 +25987,13 @@ nk_do_slider(nk_flags *state,
     visual_cursor.y = (bounds.y + bounds.h*0.5f) - visual_cursor.h*0.5f;
     visual_cursor.x = logical_cursor.x - visual_cursor.w*0.5f;
 
-    slider_value = nk_slider_behavior(state, &logical_cursor, &visual_cursor,
-        in, bounds, slider_min, slider_max, slider_value, step, slider_steps);
+    cursor.w = NK_MAX(bounds.w, 2 * style->padding.x + 2 * style->border);
+    cursor.h = NK_MAX(bounds.h, 2 * style->padding.y + 2 * style->border);
+    cursor = nk_pad_rect(bounds, nk_vec2(style->padding.x + style->border, style->padding.y + style->border));
+
+    NK_UNUSED(nk_slider_behavior);
+    slider_value = (nk_float)nk_progress_behavior(state, in, bounds, cursor,
+        (nk_size)(slider_max - slider_min), (nk_size)(slider_value - slider_min), nk_true) + slider_min;
     visual_cursor.x = logical_cursor.x - visual_cursor.w*0.5f;
 
     /* draw slider */
@@ -30716,6 +30722,7 @@ nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)
 ///   - [y]: Minor version with non-breaking API and library changes
 ///   - [z]: Patch version with no direct changes to the API
 ///
+/// - 2025/04/19 (4.12.8) - Make slider behave like progress bar
 /// - 2025/04/06 (4.12.7) - Fix text input navigation and mouse scrolling
 /// - 2025/03/29 (4.12.6) - Fix unitialized data in nk_input_char
 /// - 2025/03/05 (4.12.5) - Fix scrolling knob also scrolling parent window, remove dead code

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -7,6 +7,7 @@
 ///   - [y]: Minor version with non-breaking API and library changes
 ///   - [z]: Patch version with no direct changes to the API
 ///
+/// - 2025/04/19 (4.12.8) - Make slider behave like progress bar
 /// - 2025/04/06 (4.12.7) - Fix text input navigation and mouse scrolling
 /// - 2025/03/29 (4.12.6) - Fix unitialized data in nk_input_char
 /// - 2025/03/05 (4.12.5) - Fix scrolling knob also scrolling parent window, remove dead code

--- a/src/nuklear_slider.c
+++ b/src/nuklear_slider.c
@@ -131,6 +131,7 @@ nk_do_slider(nk_flags *state,
 
     struct nk_rect visual_cursor;
     struct nk_rect logical_cursor;
+    struct nk_rect cursor;
 
     NK_ASSERT(style);
     NK_ASSERT(out);
@@ -194,8 +195,13 @@ nk_do_slider(nk_flags *state,
     visual_cursor.y = (bounds.y + bounds.h*0.5f) - visual_cursor.h*0.5f;
     visual_cursor.x = logical_cursor.x - visual_cursor.w*0.5f;
 
-    slider_value = nk_slider_behavior(state, &logical_cursor, &visual_cursor,
-        in, bounds, slider_min, slider_max, slider_value, step, slider_steps);
+    cursor.w = NK_MAX(bounds.w, 2 * style->padding.x + 2 * style->border);
+    cursor.h = NK_MAX(bounds.h, 2 * style->padding.y + 2 * style->border);
+    cursor = nk_pad_rect(bounds, nk_vec2(style->padding.x + style->border, style->padding.y + style->border));
+
+    NK_UNUSED(nk_slider_behavior);
+    slider_value = (nk_float)nk_progress_behavior(state, in, bounds, cursor,
+        (nk_size)(slider_max - slider_min), (nk_size)(slider_value - slider_min), nk_true) + slider_min;
     visual_cursor.x = logical_cursor.x - visual_cursor.w*0.5f;
 
     /* draw slider */


### PR DESCRIPTION
I thought that the slider widget was very annoying to use because you have to put your mouse exactly on the knob to "drag" it along the axis of the widget:

![gif1](https://github.com/user-attachments/assets/2fe6a1ed-a882-4664-b8d1-a210e500ca5d)

A much smoother behavior is the one of the progress bar, where you can click anywhere on the widget, and the knob will automatically be changed to this position. So I simply reused the progress bar behavior inside for the slider and it works perfectly smooth and is much more pleasant to use:

![gif2](https://github.com/user-attachments/assets/b2005060-d6ff-48d9-bc2f-a58f799e79b0)


