### PR TITLE
Fix insert replace reset etc.

### DIFF
--- a/demo/allegro5/nuklear_allegro5.h
+++ b/demo/allegro5/nuklear_allegro5.h
@@ -347,6 +347,7 @@ NK_API int
 nk_allegro5_handle_event(ALLEGRO_EVENT *ev)
 {
     struct nk_context *ctx = &allegro5.ctx;
+    static int insert_toggle = 0;
     switch (ev->type) {
         case ALLEGRO_EVENT_DISPLAY_RESIZE: {
             allegro5.width = (unsigned int)ev->display.width;
@@ -427,7 +428,16 @@ nk_allegro5_handle_event(ALLEGRO_EVENT *ev)
             else if (kc == ALLEGRO_KEY_ESCAPE)    nk_input_key(ctx, NK_KEY_TEXT_RESET_MODE, down);
             else if (kc == ALLEGRO_KEY_PGUP)      nk_input_key(ctx, NK_KEY_SCROLL_UP, down);
             else if (kc == ALLEGRO_KEY_PGDN)      nk_input_key(ctx, NK_KEY_SCROLL_DOWN, down);
-            else if (kc == ALLEGRO_KEY_HOME) {
+            else if (kc == ALLEGRO_KEY_INSERT) {
+                if (down) insert_toggle = !insert_toggle;
+                if (insert_toggle) {
+                    nk_input_key(ctx, NK_KEY_TEXT_INSERT_MODE, down);
+                    /* nk_input_key(ctx, NK_KEY_TEXT_REPLACE_MODE, !down); */
+                } else {
+                    nk_input_key(ctx, NK_KEY_TEXT_REPLACE_MODE, down);
+                    /* nk_input_key(ctx, NK_KEY_TEXT_INSERT_MODE, !down); */
+                }
+            } else if (kc == ALLEGRO_KEY_HOME) {
                 nk_input_key(ctx, NK_KEY_TEXT_START, down);
                 nk_input_key(ctx, NK_KEY_SCROLL_START, down);
             } else if (kc == ALLEGRO_KEY_END) {
@@ -464,6 +474,7 @@ nk_allegro5_handle_event(ALLEGRO_EVENT *ev)
                     kc != ALLEGRO_KEY_ENTER &&
                     kc != ALLEGRO_KEY_END &&
                     kc != ALLEGRO_KEY_ESCAPE &&
+                    kc != ALLEGRO_KEY_INSERT &&
                     kc != ALLEGRO_KEY_PGDN &&
                     kc != ALLEGRO_KEY_PGUP) {
                     nk_input_unicode(ctx, ev->keyboard.unichar);

--- a/demo/allegro5/nuklear_allegro5.h
+++ b/demo/allegro5/nuklear_allegro5.h
@@ -416,15 +416,8 @@ nk_allegro5_handle_event(ALLEGRO_EVENT *ev)
             int kc = ev->keyboard.keycode;
             int down = ev->type == ALLEGRO_EVENT_KEY_DOWN;
 
+            /* do we need this? */
             if (kc == ALLEGRO_KEY_LSHIFT || kc == ALLEGRO_KEY_RSHIFT) nk_input_key(ctx, NK_KEY_SHIFT, down);
-            else if (kc == ALLEGRO_KEY_DELETE)    nk_input_key(ctx, NK_KEY_DEL, down);
-            else if (kc == ALLEGRO_KEY_ENTER || kc == ALLEGRO_KEY_PAD_ENTER)     nk_input_key(ctx, NK_KEY_ENTER, down);
-            else if (kc == ALLEGRO_KEY_TAB)       nk_input_key(ctx, NK_KEY_TAB, down);
-            else if (kc == ALLEGRO_KEY_LEFT)      nk_input_key(ctx, NK_KEY_LEFT, down);
-            else if (kc == ALLEGRO_KEY_RIGHT)     nk_input_key(ctx, NK_KEY_RIGHT, down);
-            else if (kc == ALLEGRO_KEY_UP)        nk_input_key(ctx, NK_KEY_UP, down);
-            else if (kc == ALLEGRO_KEY_DOWN)      nk_input_key(ctx, NK_KEY_DOWN, down);
-            else if (kc == ALLEGRO_KEY_BACKSPACE) nk_input_key(ctx, NK_KEY_BACKSPACE, down);
             else if (kc == ALLEGRO_KEY_ESCAPE)    nk_input_key(ctx, NK_KEY_TEXT_RESET_MODE, down);
             else if (kc == ALLEGRO_KEY_PGUP)      nk_input_key(ctx, NK_KEY_SCROLL_UP, down);
             else if (kc == ALLEGRO_KEY_PGDN)      nk_input_key(ctx, NK_KEY_SCROLL_DOWN, down);
@@ -448,30 +441,49 @@ nk_allegro5_handle_event(ALLEGRO_EVENT *ev)
         } break;
         case ALLEGRO_EVENT_KEY_CHAR: {
             int kc = ev->keyboard.keycode;
+            int repeat = ev->keyboard.repeat;
             int control_mask = (ev->keyboard.modifiers & ALLEGRO_KEYMOD_CTRL) ||
                                (ev->keyboard.modifiers & ALLEGRO_KEYMOD_COMMAND);
 
-            if (kc == ALLEGRO_KEY_C && control_mask) {
+            if (kc == ALLEGRO_KEY_C && control_mask && !repeat) {
                 nk_input_key(ctx, NK_KEY_COPY, 1);
             } else if (kc == ALLEGRO_KEY_V && control_mask) {
                 nk_input_key(ctx, NK_KEY_PASTE, 1);
-            } else if (kc == ALLEGRO_KEY_X && control_mask) {
+            } else if (kc == ALLEGRO_KEY_X && control_mask && !repeat) {
                 nk_input_key(ctx, NK_KEY_CUT, 1);
             } else if (kc == ALLEGRO_KEY_Z && control_mask) {
                 nk_input_key(ctx, NK_KEY_TEXT_UNDO, 1);
             } else if (kc == ALLEGRO_KEY_R && control_mask) {
                 nk_input_key(ctx, NK_KEY_TEXT_REDO, 1);
-            } else if (kc == ALLEGRO_KEY_A && control_mask) {
+            } else if (kc == ALLEGRO_KEY_A && control_mask && !repeat) {
                 nk_input_key(ctx, NK_KEY_TEXT_SELECT_ALL, 1);
+            } else if (kc == ALLEGRO_KEY_BACKSPACE) {
+                nk_input_key(ctx, NK_KEY_BACKSPACE, 1);
+            } else if (kc == ALLEGRO_KEY_LEFT) {
+                if (control_mask) {
+                    nk_input_key(ctx, NK_KEY_TEXT_WORD_LEFT, 1);
+                } else {
+                    nk_input_key(ctx, NK_KEY_LEFT, 1);
+                }
+            } else if (kc == ALLEGRO_KEY_RIGHT) {
+                if (control_mask) {
+                    nk_input_key(ctx, NK_KEY_TEXT_WORD_RIGHT, 1);
+                } else {
+                    nk_input_key(ctx, NK_KEY_RIGHT, 1);
+                }
+            } else if (kc == ALLEGRO_KEY_UP) {
+                nk_input_key(ctx, NK_KEY_UP, 1);
+            } else if (kc == ALLEGRO_KEY_DOWN) {
+                nk_input_key(ctx, NK_KEY_DOWN, 1);
+            } else if (kc == ALLEGRO_KEY_DELETE) {
+                nk_input_key(ctx, NK_KEY_DEL, 1);
+            } else if (kc == ALLEGRO_KEY_ENTER || kc == ALLEGRO_KEY_PAD_ENTER) {
+                nk_input_key(ctx, NK_KEY_ENTER, 1);
+            } else if (kc == ALLEGRO_KEY_TAB) {
+                nk_input_key(ctx, NK_KEY_TAB, 1);
             } else {
                 if (kc != ALLEGRO_KEY_BACKSPACE &&
-                    kc != ALLEGRO_KEY_LEFT &&
-                    kc != ALLEGRO_KEY_RIGHT &&
-                    kc != ALLEGRO_KEY_UP &&
-                    kc != ALLEGRO_KEY_DOWN &&
                     kc != ALLEGRO_KEY_HOME &&
-                    kc != ALLEGRO_KEY_DELETE &&
-                    kc != ALLEGRO_KEY_ENTER &&
                     kc != ALLEGRO_KEY_END &&
                     kc != ALLEGRO_KEY_ESCAPE &&
                     kc != ALLEGRO_KEY_INSERT &&

--- a/demo/common/overview.c
+++ b/demo/common/overview.c
@@ -18,7 +18,7 @@ overview(struct nk_context *ctx)
 
 #ifdef INCLUDE_STYLE
     /* styles */
-    static const char* themes[] = {"Black", "White", "Red", "Blue", "Dark", "Dracula", 
+    static const char* themes[] = {"Black", "White", "Red", "Blue", "Dark", "Dracula",
       "Catppucin Latte", "Catppucin Frappe", "Catppucin Macchiato", "Catppucin Mocha"};
     static int current_theme = 0;
 #endif
@@ -592,10 +592,12 @@ overview(struct nk_context *ctx)
             {
                 static const float ratio[] = {120, 150};
                 static char field_buffer[64];
+                static char field_w_overwrite_buf[64];
                 static char text[9][64];
                 static int text_len[9];
                 static char box_buffer[512];
                 static int field_len;
+                static int field_ow_len;
                 static int box_len;
                 nk_flags active;
 
@@ -627,6 +629,9 @@ overview(struct nk_context *ctx)
 
                 nk_label(ctx, "Field:", NK_TEXT_LEFT);
                 nk_edit_string(ctx, NK_EDIT_FIELD, field_buffer, &field_len, 64, nk_filter_default);
+
+                nk_label(ctx, "Field 2:", NK_TEXT_LEFT);
+                nk_edit_string(ctx, NK_EDIT_SELECTABLE|NK_EDIT_CLIPBOARD, field_w_overwrite_buf, &field_ow_len, 64, nk_filter_default);
 
                 nk_label(ctx, "Box:", NK_TEXT_LEFT);
                 nk_layout_row_static(ctx, 180, 278, 1);

--- a/demo/d3d11/nuklear_d3d11.h
+++ b/demo/d3d11/nuklear_d3d11.h
@@ -209,6 +209,7 @@ nk_d3d11_resize(ID3D11DeviceContext *context, int width, int height)
 NK_API int
 nk_d3d11_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
 {
+    static int insert_toggle = 0;
     switch (msg)
     {
     case WM_KEYDOWN:
@@ -283,6 +284,34 @@ nk_d3d11_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
         case VK_PRIOR:
             nk_input_key(&d3d11.ctx, NK_KEY_SCROLL_UP, down);
             return 1;
+
+        case VK_ESCAPE:
+            nk_input_key(&d3d11.ctx, NK_KEY_TEXT_RESET_MODE, down);
+            return 1;
+
+        case VK_INSERT:
+        /* Only switch on release to avoid repeat issues
+         * kind of confusing since we have to negate it but we're already
+         * hacking it since Nuklear treats them as two separate keys rather
+         * than a single toggle state */
+            if (!down) {
+                insert_toggle = !insert_toggle;
+                if (insert_toggle) {
+                    nk_input_key(&d3d11.ctx, NK_KEY_TEXT_INSERT_MODE, !down);
+                    /* nk_input_key(&d3d11.ctx, NK_KEY_TEXT_REPLACE_MODE, down); */
+                } else {
+                    nk_input_key(&d3d11.ctx, NK_KEY_TEXT_REPLACE_MODE, !down);
+                    /* nk_input_key(&d3d11.ctx, NK_KEY_TEXT_INSERT_MODE, down); */
+                }
+            }
+            return 1;
+
+        case 'A':
+            if (ctrl) {
+                nk_input_key(&d3d11.ctx, NK_KEY_TEXT_SELECT_ALL, down);
+                return 1;
+            }
+            break;
 
         case 'B':
             if (ctrl) {

--- a/demo/d3d12/nuklear_d3d12.h
+++ b/demo/d3d12/nuklear_d3d12.h
@@ -341,6 +341,7 @@ nk_d3d12_resize(int width, int height)
 NK_API int
 nk_d3d12_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
 {
+    static int insert_toggle = 0;
     switch (msg)
     {
     case WM_KEYDOWN:
@@ -407,6 +408,48 @@ nk_d3d12_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
         case VK_PRIOR:
             nk_input_key(&d3d12.ctx, NK_KEY_SCROLL_UP, down);
             return 1;
+
+        case VK_ESCAPE:
+            nk_input_key(&d3d12.ctx, NK_KEY_TEXT_RESET_MODE, down);
+            return 1;
+
+        case VK_INSERT:
+        /* Only switch on release to avoid repeat issues
+         * kind of confusing since we have to negate it but we're already
+         * hacking it since Nuklear treats them as two separate keys rather
+         * than a single toggle state */
+            if (!down) {
+                insert_toggle = !insert_toggle;
+                if (insert_toggle) {
+                    nk_input_key(&d3d12.ctx, NK_KEY_TEXT_INSERT_MODE, !down);
+                    /* nk_input_key(&d3d12.ctx, NK_KEY_TEXT_REPLACE_MODE, down); */
+                } else {
+                    nk_input_key(&d3d12.ctx, NK_KEY_TEXT_REPLACE_MODE, !down);
+                    /* nk_input_key(&d3d12.ctx, NK_KEY_TEXT_INSERT_MODE, down); */
+                }
+            }
+            return 1;
+
+        case 'A':
+            if (ctrl) {
+                nk_input_key(&d3d12.ctx, NK_KEY_TEXT_SELECT_ALL, down);
+                return 1;
+            }
+            break;
+
+        case 'B':
+            if (ctrl) {
+                nk_input_key(&d3d12.ctx, NK_KEY_TEXT_LINE_START, down);
+                return 1;
+            }
+            break;
+
+        case 'E':
+            if (ctrl) {
+                nk_input_key(&d3d12.ctx, NK_KEY_TEXT_LINE_END, down);
+                return 1;
+            }
+            break;
 
         case 'C':
             if (ctrl) {

--- a/demo/d3d9/nuklear_d3d9.h
+++ b/demo/d3d9/nuklear_d3d9.h
@@ -269,6 +269,7 @@ nk_d3d9_resize(int width, int height)
 NK_API int
 nk_d3d9_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
 {
+    static int insert_toggle = 0;
     switch (msg)
     {
     case WM_KEYDOWN:
@@ -335,6 +336,48 @@ nk_d3d9_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
         case VK_PRIOR:
             nk_input_key(&d3d9.ctx, NK_KEY_SCROLL_UP, down);
             return 1;
+
+        case VK_ESCAPE:
+            nk_input_key(&d3d9.ctx, NK_KEY_TEXT_RESET_MODE, down);
+            return 1;
+
+        case VK_INSERT:
+        /* Only switch on release to avoid repeat issues
+         * kind of confusing since we have to negate it but we're already
+         * hacking it since Nuklear treats them as two separate keys rather
+         * than a single toggle state */
+            if (!down) {
+                insert_toggle = !insert_toggle;
+                if (insert_toggle) {
+                    nk_input_key(&d3d9.ctx, NK_KEY_TEXT_INSERT_MODE, !down);
+                    /* nk_input_key(&d3d9.ctx, NK_KEY_TEXT_REPLACE_MODE, down); */
+                } else {
+                    nk_input_key(&d3d9.ctx, NK_KEY_TEXT_REPLACE_MODE, !down);
+                    /* nk_input_key(&d3d9.ctx, NK_KEY_TEXT_INSERT_MODE, down); */
+                }
+            }
+            return 1;
+
+        case 'A':
+            if (ctrl) {
+                nk_input_key(&d3d9.ctx, NK_KEY_TEXT_SELECT_ALL, down);
+                return 1;
+            }
+            break;
+
+        case 'B':
+            if (ctrl) {
+                nk_input_key(&d3d9.ctx, NK_KEY_TEXT_LINE_START, down);
+                return 1;
+            }
+            break;
+
+        case 'E':
+            if (ctrl) {
+                nk_input_key(&d3d9.ctx, NK_KEY_TEXT_LINE_END, down);
+                return 1;
+            }
+            break;
 
         case 'C':
             if (ctrl) {

--- a/demo/gdi/nuklear_gdi.h
+++ b/demo/gdi/nuklear_gdi.h
@@ -687,6 +687,7 @@ nk_gdi_set_font(GdiFont *gdifont)
 NK_API int
 nk_gdi_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
 {
+    static int insert_toggle = 0;
     switch (msg)
     {
     case WM_SIZE:
@@ -778,9 +779,44 @@ nk_gdi_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
             nk_input_key(&gdi.ctx, NK_KEY_SCROLL_UP, down);
             return 1;
 
+        case VK_ESCAPE:
+            nk_input_key(&gdi.ctx, NK_KEY_TEXT_RESET_MODE, down);
+            return 1;
+
+        case VK_INSERT:
+        /* Only switch on release to avoid repeat issues
+         * kind of confusing since we have to negate it but we're already
+         * hacking it since Nuklear treats them as two separate keys rather
+         * than a single toggle state */
+            if (!down) {
+                insert_toggle = !insert_toggle;
+                if (insert_toggle) {
+                    nk_input_key(&gdi.ctx, NK_KEY_TEXT_INSERT_MODE, !down);
+                    /* nk_input_key(&gdi.ctx, NK_KEY_TEXT_REPLACE_MODE, down); */
+                } else {
+                    nk_input_key(&gdi.ctx, NK_KEY_TEXT_REPLACE_MODE, !down);
+                    /* nk_input_key(&gdi.ctx, NK_KEY_TEXT_INSERT_MODE, down); */
+                }
+            }
+            return 1;
+
         case 'A':
             if (ctrl) {
                 nk_input_key(&gdi.ctx, NK_KEY_TEXT_SELECT_ALL, down);
+                return 1;
+            }
+            break;
+
+        case 'B':
+            if (ctrl) {
+                nk_input_key(&gdi.ctx, NK_KEY_TEXT_LINE_START, down);
+                return 1;
+            }
+            break;
+
+        case 'E':
+            if (ctrl) {
+                nk_input_key(&gdi.ctx, NK_KEY_TEXT_LINE_END, down);
                 return 1;
             }
             break;

--- a/demo/gdi_native_nuklear/nuklear_gdi.h
+++ b/demo/gdi_native_nuklear/nuklear_gdi.h
@@ -651,6 +651,7 @@ nk_gdi_set_font(nk_gdi_ctx gdi, GdiFont* gdifont)
 NK_API int
 nk_gdi_handle_event(nk_gdi_ctx gdi, HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
 {
+    static int insert_toggle = 0;
     switch (msg)
     {
     case WM_SIZE:
@@ -741,6 +742,48 @@ nk_gdi_handle_event(nk_gdi_ctx gdi, HWND wnd, UINT msg, WPARAM wparam, LPARAM lp
         case VK_PRIOR:
             nk_input_key(&gdi->ctx, NK_KEY_SCROLL_UP, down);
             return 1;
+
+        case VK_ESCAPE:
+            nk_input_key(&gdi->ctx, NK_KEY_TEXT_RESET_MODE, down);
+            return 1;
+
+        case VK_INSERT:
+        /* Only switch on release to avoid repeat issues
+         * kind of confusing since we have to negate it but we're already
+         * hacking it since Nuklear treats them as two separate keys rather
+         * than a single toggle state */
+            if (!down) {
+                insert_toggle = !insert_toggle;
+                if (insert_toggle) {
+                    nk_input_key(&gdi->ctx, NK_KEY_TEXT_INSERT_MODE, !down);
+                    /* nk_input_key(&gdi->ctx, NK_KEY_TEXT_REPLACE_MODE, down); */
+                } else {
+                    nk_input_key(&gdi->ctx, NK_KEY_TEXT_REPLACE_MODE, !down);
+                    /* nk_input_key(&gdi->ctx, NK_KEY_TEXT_INSERT_MODE, down); */
+                }
+            }
+            return 1;
+
+        case 'A':
+            if (ctrl) {
+                nk_input_key(&gdi->ctx, NK_KEY_TEXT_SELECT_ALL, down);
+                return 1;
+            }
+            break;
+
+        case 'B':
+            if (ctrl) {
+                nk_input_key(&gdi->ctx, NK_KEY_TEXT_LINE_START, down);
+                return 1;
+            }
+            break;
+
+        case 'E':
+            if (ctrl) {
+                nk_input_key(&gdi->ctx, NK_KEY_TEXT_LINE_END, down);
+                return 1;
+            }
+            break;
 
         case 'C':
             if (ctrl) {

--- a/demo/gdip/nuklear_gdip.h
+++ b/demo/gdip/nuklear_gdip.h
@@ -875,6 +875,7 @@ nk_gdip_set_font(GdipFont *gdipfont)
 NK_API int
 nk_gdip_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
 {
+    static int insert_toggle = 0;
     switch (msg)
     {
     case WM_SIZE:
@@ -968,12 +969,48 @@ nk_gdip_handle_event(HWND wnd, UINT msg, WPARAM wparam, LPARAM lparam)
             nk_input_key(&gdip.ctx, NK_KEY_SCROLL_UP, down);
             return 1;
 
+        case VK_ESCAPE:
+            nk_input_key(&gdip.ctx, NK_KEY_TEXT_RESET_MODE, down);
+            return 1;
+
+        case VK_INSERT:
+        /* Only switch on release to avoid repeat issues
+         * kind of confusing since we have to negate it but we're already
+         * hacking it since Nuklear treats them as two separate keys rather
+         * than a single toggle state */
+            if (!down) {
+                insert_toggle = !insert_toggle;
+                if (insert_toggle) {
+                    nk_input_key(&gdip.ctx, NK_KEY_TEXT_INSERT_MODE, !down);
+                    /* nk_input_key(&gdip.ctx, NK_KEY_TEXT_REPLACE_MODE, down); */
+                } else {
+                    nk_input_key(&gdip.ctx, NK_KEY_TEXT_REPLACE_MODE, !down);
+                    /* nk_input_key(&gdip.ctx, NK_KEY_TEXT_INSERT_MODE, down); */
+                }
+            }
+            return 1;
+
         case 'A':
             if (ctrl) {
                 nk_input_key(&gdip.ctx, NK_KEY_TEXT_SELECT_ALL, down);
                 return 1;
             }
             break;
+
+        case 'B':
+            if (ctrl) {
+                nk_input_key(&gdip.ctx, NK_KEY_TEXT_LINE_START, down);
+                return 1;
+            }
+            break;
+
+        case 'E':
+            if (ctrl) {
+                nk_input_key(&gdip.ctx, NK_KEY_TEXT_LINE_END, down);
+                return 1;
+            }
+            break;
+
 
         case 'C':
             if (ctrl) {

--- a/demo/glfw_opengl2/nuklear_glfw_gl2.h
+++ b/demo/glfw_opengl2/nuklear_glfw_gl2.h
@@ -215,6 +215,7 @@ nk_glfw3_char_callback(GLFWwindow *win, unsigned int codepoint)
 NK_API void
 nk_glfw3_key_callback(GLFWwindow *win, int key, int scancode, int action, int mods)
 {
+    static int insert_toggle = 0;
     /*
      * convert GLFW_REPEAT to down (technically GLFW_RELEASE, GLFW_PRESS, GLFW_REPEAT are
      * already 0, 1, 2 but just to be clearer)
@@ -233,6 +234,7 @@ nk_glfw3_key_callback(GLFWwindow *win, int key, int scancode, int action, int mo
     case GLFW_KEY_DOWN:      glfw.key_events[NK_KEY_DOWN] = a; break;
     case GLFW_KEY_LEFT:      glfw.key_events[NK_KEY_LEFT] = a; break;
     case GLFW_KEY_RIGHT:     glfw.key_events[NK_KEY_RIGHT] = a; break;
+    case GLFW_KEY_ESCAPE:    glfw.key_events[NK_KEY_TEXT_RESET_MODE] = a; break;
 
     case GLFW_KEY_PAGE_UP:   glfw.key_events[NK_KEY_SCROLL_UP] = a; break;
     case GLFW_KEY_PAGE_DOWN: glfw.key_events[NK_KEY_SCROLL_DOWN] = a; break;
@@ -256,6 +258,22 @@ nk_glfw3_key_callback(GLFWwindow *win, int key, int scancode, int action, int mo
     case GLFW_KEY_ENTER:
     case GLFW_KEY_KP_ENTER:
         glfw.key_events[NK_KEY_ENTER] = a;
+        break;
+    case GLFW_KEY_INSERT:
+        /* Only switch on release to avoid repeat issues
+         * kind of confusing since we have to negate it but we're already
+         * hacking it since Nuklear treats them as two separate keys rather
+         * than a single toggle state */
+        if (!a) {
+            insert_toggle = !insert_toggle;
+            if (insert_toggle) {
+                glfw.key_events[NK_KEY_TEXT_INSERT_MODE] = !a;
+                /* glfw.key_events[NK_KEY_TEXT_REPLACE_MODE] = a; */
+            } else {
+                /* glfw.key_events[NK_KEY_TEXT_INSERT_MODE] = a; */
+                glfw.key_events[NK_KEY_TEXT_REPLACE_MODE] = !a;
+            }
+        }
         break;
     default:
         ;
@@ -383,6 +401,7 @@ nk_glfw3_new_frame(void)
 
     if (k_state[NK_KEY_DEL] >= 0) nk_input_key(ctx, NK_KEY_DEL, k_state[NK_KEY_DEL]);
     if (k_state[NK_KEY_ENTER] >= 0) nk_input_key(ctx, NK_KEY_ENTER, k_state[NK_KEY_ENTER]);
+    if (k_state[NK_KEY_TEXT_RESET_MODE] >= 0) nk_input_key(ctx, NK_KEY_TEXT_RESET_MODE, k_state[NK_KEY_TEXT_RESET_MODE]);
 
     if (k_state[NK_KEY_TAB] >= 0) nk_input_key(ctx, NK_KEY_TAB, k_state[NK_KEY_TAB]);
     if (k_state[NK_KEY_BACKSPACE] >= 0) nk_input_key(ctx, NK_KEY_BACKSPACE, k_state[NK_KEY_BACKSPACE]);
@@ -390,6 +409,9 @@ nk_glfw3_new_frame(void)
     if (k_state[NK_KEY_DOWN] >= 0) nk_input_key(ctx, NK_KEY_DOWN, k_state[NK_KEY_DOWN]);
     if (k_state[NK_KEY_SCROLL_UP] >= 0) nk_input_key(ctx, NK_KEY_SCROLL_UP, k_state[NK_KEY_SCROLL_UP]);
     if (k_state[NK_KEY_SCROLL_DOWN] >= 0) nk_input_key(ctx, NK_KEY_SCROLL_DOWN, k_state[NK_KEY_SCROLL_DOWN]);
+
+    if (k_state[NK_KEY_TEXT_INSERT_MODE] >= 0) nk_input_key(ctx, NK_KEY_TEXT_INSERT_MODE, k_state[NK_KEY_TEXT_INSERT_MODE]);
+    if (k_state[NK_KEY_TEXT_REPLACE_MODE] >= 0) nk_input_key(ctx, NK_KEY_TEXT_REPLACE_MODE, k_state[NK_KEY_TEXT_REPLACE_MODE]);
 
     nk_input_key(ctx, NK_KEY_TEXT_START, glfwGetKey(win, GLFW_KEY_HOME) == GLFW_PRESS);
     nk_input_key(ctx, NK_KEY_TEXT_END, glfwGetKey(win, GLFW_KEY_END) == GLFW_PRESS);

--- a/demo/glfw_opengl3/nuklear_glfw_gl3.h
+++ b/demo/glfw_opengl3/nuklear_glfw_gl3.h
@@ -325,6 +325,7 @@ nk_glfw3_char_callback(GLFWwindow *win, unsigned int codepoint)
 NK_API void
 nk_glfw3_key_callback(GLFWwindow *win, int key, int scancode, int action, int mods)
 {
+    static int insert_toggle = 0;
     struct nk_glfw* glfw = (struct nk_glfw *)glfwGetWindowUserPointer(win);
     /*
      * convert GLFW_REPEAT to down (technically GLFW_RELEASE, GLFW_PRESS, GLFW_REPEAT are
@@ -343,6 +344,7 @@ nk_glfw3_key_callback(GLFWwindow *win, int key, int scancode, int action, int mo
     case GLFW_KEY_DOWN:      glfw->key_events[NK_KEY_DOWN] = a; break;
     case GLFW_KEY_LEFT:      glfw->key_events[NK_KEY_LEFT] = a; break;
     case GLFW_KEY_RIGHT:     glfw->key_events[NK_KEY_RIGHT] = a; break;
+    case GLFW_KEY_ESCAPE:    glfw->key_events[NK_KEY_TEXT_RESET_MODE] = a; break;
 
     case GLFW_KEY_PAGE_UP:   glfw->key_events[NK_KEY_SCROLL_UP] = a; break;
     case GLFW_KEY_PAGE_DOWN: glfw->key_events[NK_KEY_SCROLL_DOWN] = a; break;
@@ -359,6 +361,22 @@ nk_glfw3_key_callback(GLFWwindow *win, int key, int scancode, int action, int mo
     case GLFW_KEY_ENTER:
     case GLFW_KEY_KP_ENTER:
         glfw->key_events[NK_KEY_ENTER] = a;
+        break;
+    case GLFW_KEY_INSERT:
+        /* Only switch on release to avoid repeat issues
+         * kind of confusing since we have to negate it but we're already
+         * hacking it since Nuklear treats them as two separate keys rather
+         * than a single toggle state */
+        if (!a) {
+            insert_toggle = !insert_toggle;
+            if (insert_toggle) {
+                glfw->key_events[NK_KEY_TEXT_INSERT_MODE] = !a;
+                /* glfw->key_events[NK_KEY_TEXT_REPLACE_MODE] = a; */
+            } else {
+                /* glfw->key_events[NK_KEY_TEXT_INSERT_MODE] = a; */
+                glfw->key_events[NK_KEY_TEXT_REPLACE_MODE] = !a;
+            }
+        }
         break;
     default:
         ;
@@ -494,12 +512,17 @@ nk_glfw3_new_frame(struct nk_glfw* glfw)
     if (k_state[NK_KEY_DEL] >= 0) nk_input_key(ctx, NK_KEY_DEL, k_state[NK_KEY_DEL]);
     if (k_state[NK_KEY_ENTER] >= 0) nk_input_key(ctx, NK_KEY_ENTER, k_state[NK_KEY_ENTER]);
 
+    if (k_state[NK_KEY_TEXT_RESET_MODE] >= 0) nk_input_key(ctx, NK_KEY_TEXT_RESET_MODE, k_state[NK_KEY_TEXT_RESET_MODE]);
+
     if (k_state[NK_KEY_TAB] >= 0) nk_input_key(ctx, NK_KEY_TAB, k_state[NK_KEY_TAB]);
     if (k_state[NK_KEY_BACKSPACE] >= 0) nk_input_key(ctx, NK_KEY_BACKSPACE, k_state[NK_KEY_BACKSPACE]);
     if (k_state[NK_KEY_UP] >= 0) nk_input_key(ctx, NK_KEY_UP, k_state[NK_KEY_UP]);
     if (k_state[NK_KEY_DOWN] >= 0) nk_input_key(ctx, NK_KEY_DOWN, k_state[NK_KEY_DOWN]);
     if (k_state[NK_KEY_SCROLL_UP] >= 0) nk_input_key(ctx, NK_KEY_SCROLL_UP, k_state[NK_KEY_SCROLL_UP]);
     if (k_state[NK_KEY_SCROLL_DOWN] >= 0) nk_input_key(ctx, NK_KEY_SCROLL_DOWN, k_state[NK_KEY_SCROLL_DOWN]);
+
+    if (k_state[NK_KEY_TEXT_INSERT_MODE] >= 0) nk_input_key(ctx, NK_KEY_TEXT_INSERT_MODE, k_state[NK_KEY_TEXT_INSERT_MODE]);
+    if (k_state[NK_KEY_TEXT_REPLACE_MODE] >= 0) nk_input_key(ctx, NK_KEY_TEXT_REPLACE_MODE, k_state[NK_KEY_TEXT_REPLACE_MODE]);
 
     nk_input_key(ctx, NK_KEY_TEXT_START, glfwGetKey(win, GLFW_KEY_HOME) == GLFW_PRESS);
     nk_input_key(ctx, NK_KEY_TEXT_END, glfwGetKey(win, GLFW_KEY_END) == GLFW_PRESS);

--- a/demo/glfw_opengl4/nuklear_glfw_gl4.h
+++ b/demo/glfw_opengl4/nuklear_glfw_gl4.h
@@ -415,6 +415,7 @@ nk_glfw3_char_callback(GLFWwindow *win, unsigned int codepoint)
 NK_API void
 nk_glfw3_key_callback(GLFWwindow *win, int key, int scancode, int action, int mods)
 {
+    static int insert_toggle = 0;
     /*
      * convert GLFW_REPEAT to down (technically GLFW_RELEASE, GLFW_PRESS, GLFW_REPEAT are
      * already 0, 1, 2 but just to be clearer)
@@ -433,6 +434,7 @@ nk_glfw3_key_callback(GLFWwindow *win, int key, int scancode, int action, int mo
     case GLFW_KEY_DOWN:      glfw.key_events[NK_KEY_DOWN] = a; break;
     case GLFW_KEY_LEFT:      glfw.key_events[NK_KEY_LEFT] = a; break;
     case GLFW_KEY_RIGHT:     glfw.key_events[NK_KEY_RIGHT] = a; break;
+    case GLFW_KEY_ESCAPE:    glfw.key_events[NK_KEY_TEXT_RESET_MODE] = a; break;
 
     case GLFW_KEY_PAGE_UP:   glfw.key_events[NK_KEY_SCROLL_UP] = a; break;
     case GLFW_KEY_PAGE_DOWN: glfw.key_events[NK_KEY_SCROLL_DOWN] = a; break;
@@ -456,6 +458,22 @@ nk_glfw3_key_callback(GLFWwindow *win, int key, int scancode, int action, int mo
     case GLFW_KEY_ENTER:
     case GLFW_KEY_KP_ENTER:
         glfw.key_events[NK_KEY_ENTER] = a;
+        break;
+    case GLFW_KEY_INSERT:
+        /* Only switch on release to avoid repeat issues
+         * kind of confusing since we have to negate it but we're already
+         * hacking it since Nuklear treats them as two separate keys rather
+         * than a single toggle state */
+        if (!a) {
+            insert_toggle = !insert_toggle;
+            if (insert_toggle) {
+                glfw.key_events[NK_KEY_TEXT_INSERT_MODE] = !a;
+                /* glfw.key_events[NK_KEY_TEXT_REPLACE_MODE] = a; */
+            } else {
+                /* glfw.key_events[NK_KEY_TEXT_INSERT_MODE] = a; */
+                glfw.key_events[NK_KEY_TEXT_REPLACE_MODE] = !a;
+            }
+        }
         break;
     default:
         ;
@@ -592,12 +610,17 @@ nk_glfw3_new_frame(void)
     if (k_state[NK_KEY_DEL] >= 0) nk_input_key(ctx, NK_KEY_DEL, k_state[NK_KEY_DEL]);
     if (k_state[NK_KEY_ENTER] >= 0) nk_input_key(ctx, NK_KEY_ENTER, k_state[NK_KEY_ENTER]);
 
+    if (k_state[NK_KEY_TEXT_RESET_MODE] >= 0) nk_input_key(ctx, NK_KEY_TEXT_RESET_MODE, k_state[NK_KEY_TEXT_RESET_MODE]);
+
     if (k_state[NK_KEY_TAB] >= 0) nk_input_key(ctx, NK_KEY_TAB, k_state[NK_KEY_TAB]);
     if (k_state[NK_KEY_BACKSPACE] >= 0) nk_input_key(ctx, NK_KEY_BACKSPACE, k_state[NK_KEY_BACKSPACE]);
     if (k_state[NK_KEY_UP] >= 0) nk_input_key(ctx, NK_KEY_UP, k_state[NK_KEY_UP]);
     if (k_state[NK_KEY_DOWN] >= 0) nk_input_key(ctx, NK_KEY_DOWN, k_state[NK_KEY_DOWN]);
     if (k_state[NK_KEY_SCROLL_UP] >= 0) nk_input_key(ctx, NK_KEY_SCROLL_UP, k_state[NK_KEY_SCROLL_UP]);
     if (k_state[NK_KEY_SCROLL_DOWN] >= 0) nk_input_key(ctx, NK_KEY_SCROLL_DOWN, k_state[NK_KEY_SCROLL_DOWN]);
+
+    if (k_state[NK_KEY_TEXT_INSERT_MODE] >= 0) nk_input_key(ctx, NK_KEY_TEXT_INSERT_MODE, k_state[NK_KEY_TEXT_INSERT_MODE]);
+    if (k_state[NK_KEY_TEXT_REPLACE_MODE] >= 0) nk_input_key(ctx, NK_KEY_TEXT_REPLACE_MODE, k_state[NK_KEY_TEXT_REPLACE_MODE]);
 
     nk_input_key(ctx, NK_KEY_TEXT_START, glfwGetKey(win, GLFW_KEY_HOME) == GLFW_PRESS);
     nk_input_key(ctx, NK_KEY_TEXT_END, glfwGetKey(win, GLFW_KEY_END) == GLFW_PRESS);

--- a/demo/glfw_vulkan/nuklear_glfw_vulkan.h
+++ b/demo/glfw_vulkan/nuklear_glfw_vulkan.h
@@ -1281,12 +1281,17 @@ NK_API void nk_glfw3_new_frame(void) {
     if (k_state[NK_KEY_DEL] >= 0) nk_input_key(ctx, NK_KEY_DEL, k_state[NK_KEY_DEL]);
     if (k_state[NK_KEY_ENTER] >= 0) nk_input_key(ctx, NK_KEY_ENTER, k_state[NK_KEY_ENTER]);
 
+    if (k_state[NK_KEY_TEXT_RESET_MODE] >= 0) nk_input_key(ctx, NK_KEY_TEXT_RESET_MODE, k_state[NK_KEY_TEXT_RESET_MODE]);
+
     if (k_state[NK_KEY_TAB] >= 0) nk_input_key(ctx, NK_KEY_TAB, k_state[NK_KEY_TAB]);
     if (k_state[NK_KEY_BACKSPACE] >= 0) nk_input_key(ctx, NK_KEY_BACKSPACE, k_state[NK_KEY_BACKSPACE]);
     if (k_state[NK_KEY_UP] >= 0) nk_input_key(ctx, NK_KEY_UP, k_state[NK_KEY_UP]);
     if (k_state[NK_KEY_DOWN] >= 0) nk_input_key(ctx, NK_KEY_DOWN, k_state[NK_KEY_DOWN]);
     if (k_state[NK_KEY_SCROLL_UP] >= 0) nk_input_key(ctx, NK_KEY_SCROLL_UP, k_state[NK_KEY_SCROLL_UP]);
     if (k_state[NK_KEY_SCROLL_DOWN] >= 0) nk_input_key(ctx, NK_KEY_SCROLL_DOWN, k_state[NK_KEY_SCROLL_DOWN]);
+
+    if (k_state[NK_KEY_TEXT_INSERT_MODE] >= 0) nk_input_key(ctx, NK_KEY_TEXT_INSERT_MODE, k_state[NK_KEY_TEXT_INSERT_MODE]);
+    if (k_state[NK_KEY_TEXT_REPLACE_MODE] >= 0) nk_input_key(ctx, NK_KEY_TEXT_REPLACE_MODE, k_state[NK_KEY_TEXT_REPLACE_MODE]);
 
     nk_input_key(ctx, NK_KEY_TEXT_START, glfwGetKey(win, GLFW_KEY_HOME) == GLFW_PRESS);
     nk_input_key(ctx, NK_KEY_TEXT_END, glfwGetKey(win, GLFW_KEY_END) == GLFW_PRESS);
@@ -1560,6 +1565,7 @@ NK_API void nk_glfw3_char_callback(GLFWwindow *win, unsigned int codepoint) {
 NK_API void
 nk_glfw3_key_callback(GLFWwindow *win, int key, int scancode, int action, int mods)
 {
+    static int insert_toggle = 0;
     /*
      * convert GLFW_REPEAT to down (technically GLFW_RELEASE, GLFW_PRESS, GLFW_REPEAT are
      * already 0, 1, 2 but just to be clearer)
@@ -1578,6 +1584,7 @@ nk_glfw3_key_callback(GLFWwindow *win, int key, int scancode, int action, int mo
     case GLFW_KEY_DOWN:      glfw.key_events[NK_KEY_DOWN] = a; break;
     case GLFW_KEY_LEFT:      glfw.key_events[NK_KEY_LEFT] = a; break;
     case GLFW_KEY_RIGHT:     glfw.key_events[NK_KEY_RIGHT] = a; break;
+    case GLFW_KEY_ESCAPE:    glfw.key_events[NK_KEY_TEXT_RESET_MODE] = a; break;
 
     case GLFW_KEY_PAGE_UP:   glfw.key_events[NK_KEY_SCROLL_UP] = a; break;
     case GLFW_KEY_PAGE_DOWN: glfw.key_events[NK_KEY_SCROLL_DOWN] = a; break;
@@ -1601,6 +1608,22 @@ nk_glfw3_key_callback(GLFWwindow *win, int key, int scancode, int action, int mo
     case GLFW_KEY_ENTER:
     case GLFW_KEY_KP_ENTER:
         glfw.key_events[NK_KEY_ENTER] = a;
+        break;
+    case GLFW_KEY_INSERT:
+        /* Only switch on release to avoid repeat issues
+         * kind of confusing since we have to negate it but we're already
+         * hacking it since Nuklear treats them as two separate keys rather
+         * than a single toggle state */
+        if (!a) {
+            insert_toggle = !insert_toggle;
+            if (insert_toggle) {
+                glfw.key_events[NK_KEY_TEXT_INSERT_MODE] = !a;
+                /* glfw.key_events[NK_KEY_TEXT_REPLACE_MODE] = a; */
+            } else {
+                /* glfw.key_events[NK_KEY_TEXT_INSERT_MODE] = a; */
+                glfw.key_events[NK_KEY_TEXT_REPLACE_MODE] = !a;
+            }
+        }
         break;
     default:
         ;

--- a/demo/sdl_opengl2/nuklear_sdl_gl2.h
+++ b/demo/sdl_opengl2/nuklear_sdl_gl2.h
@@ -263,7 +263,8 @@ NK_API int
 nk_sdl_handle_event(SDL_Event *evt)
 {
     struct nk_context *ctx = &sdl.ctx;
-    int ctrl_down = SDL_GetModState() & (KMOD_LCTRL | KMOD_RCTRL);
+    int ctrl_down = SDL_GetModState() & KMOD_CTRL;
+    static int insert_toggle = 0;
 
     switch(evt->type)
     {
@@ -297,6 +298,15 @@ nk_sdl_handle_event(SDL_Event *evt)
                     case SDLK_e:         nk_input_key(ctx, NK_KEY_TEXT_LINE_END, down && ctrl_down); break;
                     case SDLK_UP:        nk_input_key(ctx, NK_KEY_UP, down); break;
                     case SDLK_DOWN:      nk_input_key(ctx, NK_KEY_DOWN, down); break;
+                    case SDLK_ESCAPE:    nk_input_key(ctx, NK_KEY_TEXT_RESET_MODE, down); break;
+                    case SDLK_INSERT:
+                        if (down) insert_toggle = !insert_toggle;
+                        if (insert_toggle) {
+                            nk_input_key(ctx, NK_KEY_TEXT_INSERT_MODE, down);
+                        } else {
+                            nk_input_key(ctx, NK_KEY_TEXT_REPLACE_MODE, down);
+                        }
+                        break;
                     case SDLK_a:
                         if (ctrl_down)
                             nk_input_key(ctx,NK_KEY_TEXT_SELECT_ALL, down);

--- a/demo/sdl_opengl3/Makefile
+++ b/demo/sdl_opengl3/Makefile
@@ -2,7 +2,7 @@
 BIN = demo
 
 # Flags
-CFLAGS += -std=c89 -Wall -Wextra -pedantic -DSDL_DISABLE_IMMINTRIN_H
+CFLAGS += -g -std=c89 -Wall -Wextra -pedantic -DSDL_DISABLE_IMMINTRIN_H
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/demo/sdl_opengl3/nuklear_sdl_gl3.h
+++ b/demo/sdl_opengl3/nuklear_sdl_gl3.h
@@ -373,7 +373,8 @@ NK_API int
 nk_sdl_handle_event(SDL_Event *evt)
 {
     struct nk_context *ctx = &sdl.ctx;
-    int ctrl_down = SDL_GetModState() & (KMOD_LCTRL | KMOD_RCTRL);
+    int ctrl_down = SDL_GetModState() & KMOD_CTRL;
+    static int insert_toggle = 0;
 
     switch(evt->type)
     {
@@ -407,6 +408,17 @@ nk_sdl_handle_event(SDL_Event *evt)
                     case SDLK_e:         nk_input_key(ctx, NK_KEY_TEXT_LINE_END, down && ctrl_down); break;
                     case SDLK_UP:        nk_input_key(ctx, NK_KEY_UP, down); break;
                     case SDLK_DOWN:      nk_input_key(ctx, NK_KEY_DOWN, down); break;
+
+                    case SDLK_ESCAPE:    nk_input_key(ctx, NK_KEY_TEXT_RESET_MODE, down); break;
+                    case SDLK_INSERT:
+                        if (down) insert_toggle = !insert_toggle;
+                        if (insert_toggle) {
+                            nk_input_key(ctx, NK_KEY_TEXT_INSERT_MODE, down);
+                        } else {
+                            nk_input_key(ctx, NK_KEY_TEXT_REPLACE_MODE, down);
+                        }
+                        break;
+
                     case SDLK_a:
                         if (ctrl_down)
                             nk_input_key(ctx,NK_KEY_TEXT_SELECT_ALL, down);

--- a/demo/sdl_opengles2/nuklear_sdl_gles2.h
+++ b/demo/sdl_opengles2/nuklear_sdl_gles2.h
@@ -373,7 +373,8 @@ NK_API int
 nk_sdl_handle_event(SDL_Event *evt)
 {
     struct nk_context *ctx = &sdl.ctx;
-    int ctrl_down = SDL_GetModState() & (KMOD_LCTRL | KMOD_RCTRL);
+    int ctrl_down = SDL_GetModState() & KMOD_CTRL;
+    static int insert_toggle = 0;
 
     switch(evt->type)
     {
@@ -407,6 +408,15 @@ nk_sdl_handle_event(SDL_Event *evt)
                     case SDLK_e:         nk_input_key(ctx, NK_KEY_TEXT_LINE_END, down && ctrl_down); break;
                     case SDLK_UP:        nk_input_key(ctx, NK_KEY_UP, down); break;
                     case SDLK_DOWN:      nk_input_key(ctx, NK_KEY_DOWN, down); break;
+                    case SDLK_ESCAPE:    nk_input_key(ctx, NK_KEY_TEXT_RESET_MODE, down); break;
+                    case SDLK_INSERT:
+                        if (down) insert_toggle = !insert_toggle;
+                        if (insert_toggle) {
+                            nk_input_key(ctx, NK_KEY_TEXT_INSERT_MODE, down);
+                        } else {
+                            nk_input_key(ctx, NK_KEY_TEXT_REPLACE_MODE, down);
+                        }
+                        break;
                     case SDLK_a:
                         if (ctrl_down)
                             nk_input_key(ctx,NK_KEY_TEXT_SELECT_ALL, down);

--- a/demo/sdl_renderer/nuklear_sdl_renderer.h
+++ b/demo/sdl_renderer/nuklear_sdl_renderer.h
@@ -296,7 +296,8 @@ NK_API int
 nk_sdl_handle_event(SDL_Event *evt)
 {
     struct nk_context *ctx = &sdl.ctx;
-    int ctrl_down = SDL_GetModState() & (KMOD_LCTRL | KMOD_RCTRL);
+    int ctrl_down = SDL_GetModState() & KMOD_CTRL;
+    static int insert_toggle = 0;
 
     switch(evt->type)
     {
@@ -330,6 +331,15 @@ nk_sdl_handle_event(SDL_Event *evt)
                     case SDLK_e:         nk_input_key(ctx, NK_KEY_TEXT_LINE_END, down && ctrl_down); break;
                     case SDLK_UP:        nk_input_key(ctx, NK_KEY_UP, down); break;
                     case SDLK_DOWN:      nk_input_key(ctx, NK_KEY_DOWN, down); break;
+                    case SDLK_ESCAPE:    nk_input_key(ctx, NK_KEY_TEXT_RESET_MODE, down); break;
+                    case SDLK_INSERT:
+                        if (down) insert_toggle = !insert_toggle;
+                        if (insert_toggle) {
+                            nk_input_key(ctx, NK_KEY_TEXT_INSERT_MODE, down);
+                        } else {
+                            nk_input_key(ctx, NK_KEY_TEXT_REPLACE_MODE, down);
+                        }
+                        break;
                     case SDLK_a:
                         if (ctrl_down)
                             nk_input_key(ctx,NK_KEY_TEXT_SELECT_ALL, down);

--- a/demo/sdl_vulkan/nuklear_sdl_vulkan.h
+++ b/demo/sdl_vulkan/nuklear_sdl_vulkan.h
@@ -1254,7 +1254,8 @@ NK_API void nk_sdl_handle_grab(void) {
 
 NK_API int nk_sdl_handle_event(SDL_Event *evt) {
     struct nk_context *ctx = &sdl.ctx;
-    int ctrl_down = SDL_GetModState() & (KMOD_LCTRL | KMOD_RCTRL);
+    int ctrl_down = SDL_GetModState() & KMOD_CTRL;
+    static int insert_toggle = 0;
 
     switch (evt->type) {
     case SDL_KEYUP: /* KEYUP & KEYDOWN share same routine */
@@ -1322,6 +1323,17 @@ NK_API int nk_sdl_handle_event(SDL_Event *evt) {
             break;
         case SDLK_DOWN:
             nk_input_key(ctx, NK_KEY_DOWN, down);
+            break;
+        case SDLK_ESCAPE:
+            nk_input_key(ctx, NK_KEY_TEXT_RESET_MODE, down);
+            break;
+        case SDLK_INSERT:
+            if (down) insert_toggle = !insert_toggle;
+            if (insert_toggle) {
+                nk_input_key(ctx, NK_KEY_TEXT_INSERT_MODE, down);
+            } else {
+                nk_input_key(ctx, NK_KEY_TEXT_REPLACE_MODE, down);
+            }
             break;
         case SDLK_a:
             if(ctrl_down)

--- a/demo/x11/Makefile
+++ b/demo/x11/Makefile
@@ -2,7 +2,7 @@
 BIN = demo
 
 # Flags
-CFLAGS += -std=c89 -Wall -Wextra -pedantic -Wno-unused-function
+CFLAGS += -g -std=c89 -Wall -Wextra -pedantic -Wno-unused-function
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)

--- a/demo/x11/nuklear_xlib.h
+++ b/demo/x11/nuklear_xlib.h
@@ -717,6 +717,7 @@ NK_API int
 nk_xlib_handle_event(Display *dpy, int screen, Window win, XEvent *evt)
 {
     struct nk_context *ctx = &xlib.ctx;
+    static int insert_toggle = 0;
 
     NK_UNUSED(screen);
 
@@ -776,11 +777,14 @@ nk_xlib_handle_event(Display *dpy, int screen, Window win, XEvent *evt)
                 nk_input_key(ctx, NK_KEY_TEXT_LINE_END, down);
             else if (*code == 'a' && (evt->xkey.state & ControlMask))
                 nk_input_key(ctx,NK_KEY_TEXT_SELECT_ALL, down);
-            else {
-                if (*code == 'i')
+            else if (*code == XK_Insert) {
+                if (down) insert_toggle = !insert_toggle;
+                if (insert_toggle) {
                     nk_input_key(ctx, NK_KEY_TEXT_INSERT_MODE, down);
-                else if (*code == 'r')
+                } else {
                     nk_input_key(ctx, NK_KEY_TEXT_REPLACE_MODE, down);
+                }
+            } else {
                 if (down) {
                     char buf[32];
                     KeySym keysym = 0;

--- a/demo/x11_opengl2/nuklear_xlib_gl2.h
+++ b/demo/x11_opengl2/nuklear_xlib_gl2.h
@@ -240,6 +240,7 @@ NK_API int
 nk_x11_handle_event(XEvent *evt)
 {
     struct nk_context *ctx = &x11.ctx;
+    static int insert_toggle = 0;
 
     /* optional grabbing behavior */
     if (ctx->input.mouse.grab) {
@@ -267,7 +268,7 @@ nk_x11_handle_event(XEvent *evt)
         else if (*code == XK_Up)      nk_input_key(ctx, NK_KEY_UP, down);
         else if (*code == XK_Down)     nk_input_key(ctx, NK_KEY_DOWN, down);
         else if (*code == XK_BackSpace) nk_input_key(ctx, NK_KEY_BACKSPACE, down);
-        else if (*code == XK_space && !down) nk_input_char(ctx, ' ');
+        else if (*code == XK_Escape)    nk_input_key(ctx, NK_KEY_TEXT_RESET_MODE, down);
         else if (*code == XK_Page_Up)   nk_input_key(ctx, NK_KEY_SCROLL_UP, down);
         else if (*code == XK_Page_Down) nk_input_key(ctx, NK_KEY_SCROLL_DOWN, down);
         else if (*code == XK_Home) {
@@ -295,11 +296,14 @@ nk_x11_handle_event(XEvent *evt)
                 nk_input_key(ctx, NK_KEY_TEXT_LINE_START, down);
             else if (*code == 'e' && (evt->xkey.state & ControlMask))
                 nk_input_key(ctx, NK_KEY_TEXT_LINE_END, down);
-            else {
-                if (*code == 'i')
+            else if (*code == XK_Insert) {
+                if (down) insert_toggle = !insert_toggle;
+                if (insert_toggle) {
                     nk_input_key(ctx, NK_KEY_TEXT_INSERT_MODE, down);
-                else if (*code == 'r')
+                } else {
                     nk_input_key(ctx, NK_KEY_TEXT_REPLACE_MODE, down);
+                }
+            } else {
                 if (down) {
                     char buf[32];
                     KeySym keysym = 0;

--- a/demo/x11_opengl3/nuklear_xlib_gl3.h
+++ b/demo/x11_opengl3/nuklear_xlib_gl3.h
@@ -607,6 +607,7 @@ NK_API int
 nk_x11_handle_event(XEvent *evt)
 {
     struct nk_context *ctx = &x11.ctx;
+    static int insert_toggle = 0;
 
     /* optional grabbing behavior */
     if (ctx->input.mouse.grab) {
@@ -634,7 +635,7 @@ nk_x11_handle_event(XEvent *evt)
         else if (*code == XK_Up)        nk_input_key(ctx, NK_KEY_UP, down);
         else if (*code == XK_Down)      nk_input_key(ctx, NK_KEY_DOWN, down);
         else if (*code == XK_BackSpace) nk_input_key(ctx, NK_KEY_BACKSPACE, down);
-        else if (*code == XK_space && !down) nk_input_char(ctx, ' ');
+        else if (*code == XK_Escape)    nk_input_key(ctx, NK_KEY_TEXT_RESET_MODE, down);
         else if (*code == XK_Page_Up)   nk_input_key(ctx, NK_KEY_SCROLL_UP, down);
         else if (*code == XK_Page_Down) nk_input_key(ctx, NK_KEY_SCROLL_DOWN, down);
         else if (*code == XK_Home) {
@@ -662,11 +663,14 @@ nk_x11_handle_event(XEvent *evt)
                 nk_input_key(ctx, NK_KEY_TEXT_LINE_START, down);
             else if (*code == 'e' && (evt->xkey.state & ControlMask))
                 nk_input_key(ctx, NK_KEY_TEXT_LINE_END, down);
-            else {
-                if (*code == 'i')
+            else if (*code == XK_Insert) {
+                if (down) insert_toggle = !insert_toggle;
+                if (insert_toggle) {
                     nk_input_key(ctx, NK_KEY_TEXT_INSERT_MODE, down);
-                else if (*code == 'r')
+                } else {
                     nk_input_key(ctx, NK_KEY_TEXT_REPLACE_MODE, down);
+                }
+            } else {
                 if (down) {
                     char buf[32];
                     KeySym keysym = 0;

--- a/demo/x11_xft/nuklear_xlib.h
+++ b/demo/x11_xft/nuklear_xlib.h
@@ -802,6 +802,7 @@ NK_API int
 nk_xlib_handle_event(Display *dpy, int screen, Window win, XEvent *evt)
 {
     struct nk_context *ctx = &xlib.ctx;
+    static int insert_toggle = 0;
 
     NK_UNUSED(screen);
 
@@ -861,11 +862,14 @@ nk_xlib_handle_event(Display *dpy, int screen, Window win, XEvent *evt)
                 nk_input_key(ctx, NK_KEY_TEXT_LINE_END, down);
             else if (*code == 'a' && (evt->xkey.state & ControlMask))
                 nk_input_key(ctx,NK_KEY_TEXT_SELECT_ALL, down);
-            else {
-                if (*code == 'i')
+            else if (*code == XK_Insert) {
+                if (down) insert_toggle = !insert_toggle;
+                if (insert_toggle) {
                     nk_input_key(ctx, NK_KEY_TEXT_INSERT_MODE, down);
-                else if (*code == 'r')
+                } else {
                     nk_input_key(ctx, NK_KEY_TEXT_REPLACE_MODE, down);
+                }
+            } else {
                 if (down) {
                     char buf[32];
                     KeySym keysym = 0;

--- a/demo/xcb_cairo/nuklear_xcb.h
+++ b/demo/xcb_cairo/nuklear_xcb.h
@@ -240,6 +240,7 @@ NK_API int nk_xcb_handle_event(struct nk_xcb_context *xcb_ctx, struct nk_context
 {
     int events = 0;
     xcb_generic_event_t *event;
+    static int insert_toggle = 0;
 
 #ifdef NK_XCB_MIN_FRAME_TIME
     struct timespec tp;
@@ -298,8 +299,14 @@ NK_API int nk_xcb_handle_event(struct nk_xcb_context *xcb_ctx, struct nk_context
                 case XK_Right:
                     nk_input_key(nk_ctx, NK_KEY_RIGHT, press);
                     break;
-                /* NK_KEY_TEXT_INSERT_MODE, */
-                /* NK_KEY_TEXT_REPLACE_MODE, */
+                case XK_Insert:
+                    if (press) insert_toggle = !insert_toggle;
+                    if (insert_toggle) {
+                        nk_input_key(nk_ctx, NK_KEY_TEXT_INSERT_MODE, press);
+                    } else {
+                        nk_input_key(nk_ctx, NK_KEY_TEXT_REPLACE_MODE, press);
+                    }
+                    break;
                 case XK_Escape:
                     nk_input_key(nk_ctx, NK_KEY_TEXT_RESET_MODE, press);
                     break;

--- a/nuklear.h
+++ b/nuklear.h
@@ -27169,8 +27169,6 @@ nk_textedit_text(struct nk_text_edit *state, const char *text, int total_len)
             if (state->mode == NK_TEXT_EDIT_MODE_REPLACE) {
                 nk_textedit_makeundo_replace(state, state->cursor, 1, 1);
                 nk_str_delete_runes(&state->string, state->cursor, 1);
-            } else {
-                puts("still insert mode");
             }
             if (nk_str_insert_text_utf8(&state->string, state->cursor,
                                         text+text_len, 1))
@@ -27226,17 +27224,13 @@ retry:
         break;
 
     case NK_KEY_TEXT_INSERT_MODE:
-        /* if (state->mode == NK_TEXT_EDIT_MODE_VIEW) */
-            state->mode = NK_TEXT_EDIT_MODE_INSERT;
+        state->mode = NK_TEXT_EDIT_MODE_INSERT;
         break;
     case NK_KEY_TEXT_REPLACE_MODE:
-        /* if (state->mode == NK_TEXT_EDIT_MODE_VIEW) */
-            state->mode = NK_TEXT_EDIT_MODE_REPLACE;
+        state->mode = NK_TEXT_EDIT_MODE_REPLACE;
         break;
     case NK_KEY_TEXT_RESET_MODE:
-        if (state->mode == NK_TEXT_EDIT_MODE_INSERT ||
-            state->mode == NK_TEXT_EDIT_MODE_REPLACE)
-            state->mode = NK_TEXT_EDIT_MODE_VIEW;
+        state->mode = NK_TEXT_EDIT_MODE_VIEW;
         break;
 
     case NK_KEY_LEFT:
@@ -30718,6 +30712,7 @@ nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)
 ///   - [y]: Minor version with non-breaking API and library changes
 ///   - [z]: Patch version with no direct changes to the API
 ///
+/// - 2025/04/28 (4.12.8) - Allow switching between TEXT_INSERT and TEXT_REPLACE modes directly
 /// - 2025/04/06 (4.12.7) - Fix text input navigation and mouse scrolling
 /// - 2025/03/29 (4.12.6) - Fix unitialized data in nk_input_char
 /// - 2025/03/05 (4.12.5) - Fix scrolling knob also scrolling parent window, remove dead code

--- a/nuklear.h
+++ b/nuklear.h
@@ -27169,6 +27169,8 @@ nk_textedit_text(struct nk_text_edit *state, const char *text, int total_len)
             if (state->mode == NK_TEXT_EDIT_MODE_REPLACE) {
                 nk_textedit_makeundo_replace(state, state->cursor, 1, 1);
                 nk_str_delete_runes(&state->string, state->cursor, 1);
+            } else {
+                puts("still insert mode");
             }
             if (nk_str_insert_text_utf8(&state->string, state->cursor,
                                         text+text_len, 1))
@@ -27224,11 +27226,11 @@ retry:
         break;
 
     case NK_KEY_TEXT_INSERT_MODE:
-        if (state->mode == NK_TEXT_EDIT_MODE_VIEW)
+        /* if (state->mode == NK_TEXT_EDIT_MODE_VIEW) */
             state->mode = NK_TEXT_EDIT_MODE_INSERT;
         break;
     case NK_KEY_TEXT_REPLACE_MODE:
-        if (state->mode == NK_TEXT_EDIT_MODE_VIEW)
+        /* if (state->mode == NK_TEXT_EDIT_MODE_VIEW) */
             state->mode = NK_TEXT_EDIT_MODE_REPLACE;
         break;
     case NK_KEY_TEXT_RESET_MODE:

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -7,6 +7,7 @@
 ///   - [y]: Minor version with non-breaking API and library changes
 ///   - [z]: Patch version with no direct changes to the API
 ///
+/// - 2025/04/28 (4.12.8) - Allow switching between TEXT_INSERT and TEXT_REPLACE modes directly
 /// - 2025/04/06 (4.12.7) - Fix text input navigation and mouse scrolling
 /// - 2025/03/29 (4.12.6) - Fix unitialized data in nk_input_char
 /// - 2025/03/05 (4.12.5) - Fix scrolling knob also scrolling parent window, remove dead code

--- a/src/nuklear_text_editor.c
+++ b/src/nuklear_text_editor.c
@@ -446,17 +446,13 @@ retry:
         break;
 
     case NK_KEY_TEXT_INSERT_MODE:
-        if (state->mode == NK_TEXT_EDIT_MODE_VIEW)
-            state->mode = NK_TEXT_EDIT_MODE_INSERT;
+        state->mode = NK_TEXT_EDIT_MODE_INSERT;
         break;
     case NK_KEY_TEXT_REPLACE_MODE:
-        if (state->mode == NK_TEXT_EDIT_MODE_VIEW)
-            state->mode = NK_TEXT_EDIT_MODE_REPLACE;
+        state->mode = NK_TEXT_EDIT_MODE_REPLACE;
         break;
     case NK_KEY_TEXT_RESET_MODE:
-        if (state->mode == NK_TEXT_EDIT_MODE_INSERT ||
-            state->mode == NK_TEXT_EDIT_MODE_REPLACE)
-            state->mode = NK_TEXT_EDIT_MODE_VIEW;
+        state->mode = NK_TEXT_EDIT_MODE_VIEW;
         break;
 
     case NK_KEY_LEFT:


### PR DESCRIPTION
This pull request does a few things:

1. Adds support for INSERT/REPLACE/RESET key inputs to all backends (except rawfb).  Despite INSERT and REPLACE being treated as separate keys by Nuklear, I made them use the Insert key as a toggle similar to other word processors.  This involved changing the behavior in the 1 or 2 backends that already had it.  ESC is RESET for everything.  I did not build/test the windows backends.
2. In the process I found several issues in a couple backends.  I added some other keys when I noticed and completely fixed Allegro's broken behavior (It now correctly does key repeat behavior for special keys/combos like BACKSPACE, DELETE, the arrows, etc.
3. Minor modification to Nuklear itself, allowing you to switch between directly between insert and replace/overwrite modes directly rather than having to reset back to VIEW mode first.  This again matches other editor behavior and is far more intuitive.

In the process of making these changes I needed an input field where I could actually test it since the default types EDIT_SIMPLE, EDIT_FIELD, EDIT_BOX all include ALWAYS_INSERT_MODE.  So I added a field to the overview demo.

This brings me to some other changes I want to make to Nuklear.  Let's see if
I can decide on the best way to describe/design this.

I think ALWAYS_INSERT_MODE should really be ALWAYS_EDIT_MODE and allow
switching between INSERT and REPLACE modes but not allow VIEW_MODE.  I think
that makes much more sense for the default behavior for EDIT_SIMPLE,
EDIT_FIELD, and EDIT_BOX.  Realistically I think that should be the default
behavior period, even if you pass no flags and supporting VIEW_MODE should be
an opt-in not an opt-out decision since it's rare that users would want that
behavior.

On a slightly related note, I noticed a while ago that if you want a text
field that is read only you can't actually use EDIT_READ_ONLY.  READ_ONLY
should actually be called NON_INTERACTIVE which seems pointless to me.  If
you want that, why not just use a label?  Just for the box around it?  If
you want the user to actually be able to copy the text displayed
but not be able to change the text you have to do this:

NK_EDIT_SELECTABLE | NK_EDIT_AUTO_SELECT | NK_EDIT_CLIPBOARD;

Granted the AUTO_SELECT is optional.  You also need to use a null filter
function (which doesn't exist in Nuklear though I think it should):
```
nk_bool
nk_filter_nothing(const struct nk_text_edit *box, nk_rune unicode)
{
    NK_UNUSED(unicode);
    NK_UNUSED(box);
    return nk_false;
}
```
I think we should have READ_ONLY have the behavior above, and a new flag
NON_INTERACTIVE behave like READ_ONLY currently does.

Lastly, there is another thing I discovered that AUTO_SELECT does not imply
SELECTABLE which is ridiculous and counterintuitive.


So, I could do/add all of these things to this pull request or create a
separate pull request (or several though I think that's overkill).  While all
of these technically change Nuklear behavior (even the pull request as it is
now), I don't think it will really affect almost anyone.  Most of the changes
are in ways people hardly ever use it (or even couldn't use it considering
none of the backends even supported insert/replace/reset till now).

So whether I continue in this pull request or make a new one, since none of
these change the actual function calls/prototypes I would say they would be
minor changes at most, ie 4.13.0

EDIT: typos