### PR TITLE
Add CMake scripts to D3D11/D3D12 demos

### DIFF
--- a/demo/d3d11/CMakeLists.txt
+++ b/demo/d3d11/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 4.0)
+set(CMAKE_C_STANDARD 17)
+project(NuklearDemo LANGUAGES C)
+
+file(GLOB SOURCES CONFIGURE_DEPENDS
+   RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+   "${CMAKE_CURRENT_SOURCE_DIR}/*.h"
+   "${CMAKE_CURRENT_SOURCE_DIR}/*.c"
+)
+
+add_executable(D3D11Demo ${SOURCES})
+
+target_link_libraries(D3D11Demo PRIVATE dxgi.lib D3D11.lib dxguid.lib d3dcompiler.lib)
+
+set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT D3D11Demo)

--- a/demo/d3d12/CMakeLists.txt
+++ b/demo/d3d12/CMakeLists.txt
@@ -1,0 +1,15 @@
+cmake_minimum_required(VERSION 4.0)
+set(CMAKE_C_STANDARD 17)
+project(NuklearDemo LANGUAGES C)
+
+file(GLOB SOURCES CONFIGURE_DEPENDS
+   RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
+   "${CMAKE_CURRENT_SOURCE_DIR}/*.h"
+   "${CMAKE_CURRENT_SOURCE_DIR}/*.c"
+)
+
+add_executable(D3D12Demo ${SOURCES})
+
+target_link_libraries(D3D12Demo PRIVATE dxgi.lib D3D12.lib dxguid.lib d3dcompiler.lib)
+
+set_property(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY VS_STARTUP_PROJECT D3D12Demo)


### PR DESCRIPTION
This change helps other users, one command can generate a VS solution regardless of which Visual Studio IDE users have.

e.g.
cd ./demo/d3d12
cmake -S ./ -B ./cmake