### PR TITLE
Handle forcible cursor moving in allegro demo

### DIFF
--- a/demo/allegro5/nuklear_allegro5.h
+++ b/demo/allegro5/nuklear_allegro5.h
@@ -354,7 +354,8 @@ nk_allegro5_handle_event(ALLEGRO_EVENT *ev)
             al_acknowledge_resize(ev->display.source);
             return 1;
         } break;
-        case ALLEGRO_EVENT_MOUSE_AXES: {
+        case ALLEGRO_EVENT_MOUSE_AXES:
+        case ALLEGRO_EVENT_MOUSE_WARPED: {
             nk_input_motion(ctx, ev->mouse.x, ev->mouse.y);
             if (ev->mouse.dz != 0) {
                 nk_input_scroll(ctx, nk_vec2(0,(float)ev->mouse.dz / al_get_mouse_wheel_precision()));


### PR DESCRIPTION
Hello! This tiny PR adds handling of [ALLEGRO_EVENT_MOUSE_WARPED](https://liballeg.org/a5docs/trunk/events.html#allegro_event_mouse_warped) event to liballegro demo, which is caused by forcibly setting cursor coordinates with e.g. [al_set_mouse_xy](https://liballeg.org/a5docs/trunk/mouse.html#al_set_mouse_xy). It is not used in demo, but it'll come in handy for complex UIs with multiple input event sources (e.g. joystick).