### PR TITLE
MSYS2 mingw64 in Win10 Error : Add UTF-8 encoding to file read operation

### DIFF
--- a/src/build.py
+++ b/src/build.py
@@ -164,6 +164,6 @@ print("#endif /* " + macro + "_IMPLEMENTATION */");
 
 print("\n/*")
 for f in outro_files:
-    sys.stdout.write(open(f, 'r').read())
+    sys.stdout.write(open(f, 'r',encoding='utf-8').read())
 print("*/\n")
 


### PR DESCRIPTION
An Error in Win10 for MSYS2 mingw64,GBK:
src/build.py", line 167, in <module>
    sys.stdout.write(open(f, 'r').read())
                     ^^^^^^^^^^^^^^^^^^^
UnicodeDecodeError: 'gbk' codec can't decode byte 0x99 in position 751: illegal multibyte sequence make: *** [Makefile:56: nuke] Error 1