### PR TITLE
Introduce minimal API for text keyboard request with text area and cursor support

### DIFF
--- a/clib.json
+++ b/clib.json
@@ -1,6 +1,6 @@
 {
   "name": "nuklear",
-  "version": "4.12.8",
+  "version": "4.13.0",
   "repo": "Immediate-Mode-UI/Nuklear",
   "description": "A small ANSI C gui toolkit",
   "keywords": ["gl", "ui", "toolkit"],

--- a/src/CHANGELOG
+++ b/src/CHANGELOG
@@ -7,6 +7,9 @@
 ///   - [y]: Minor version with non-breaking API and library changes
 ///   - [z]: Patch version with no direct changes to the API
 ///
+/// - 2025/11/13 (4.13.0) - Introduced minimal text keyboard request API (nk_input_want_text_keyboard)
+///                         with support for text input area and cursor position.
+///                         This functionality is required for SDL_SetTextInputRect
 /// - 2025/10/08 (4.12.8) - Fix nk_widget_text to use NK_TEXT_ALIGN_LEFT by default,
 ///                         instead of silently failing when no x-axis alignment is provided,
 ///                         and refactor this function to keep the code style consistent

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -4694,6 +4694,11 @@ struct nk_keyboard {
     struct nk_key keys[NK_KEY_MAX];
     char text[NK_INPUT_MAX];
     int text_len;
+
+    /*Text keyboard request system*/
+    nk_bool text_want; /*When true, text input is actively requested*/
+    struct nk_rect text_area; /*Input area (valid only when text_want == true)*/
+    struct nk_rect text_cursor; /*Cursor position (valid only when text_want == true)*/
 };
 
 struct nk_input {
@@ -4718,6 +4723,10 @@ NK_API nk_bool nk_input_is_mouse_released(const struct nk_input*, enum nk_button
 NK_API nk_bool nk_input_is_key_pressed(const struct nk_input*, enum nk_keys);
 NK_API nk_bool nk_input_is_key_released(const struct nk_input*, enum nk_keys);
 NK_API nk_bool nk_input_is_key_down(const struct nk_input*, enum nk_keys);
+/* This is a utility function that should be called inside a widget
+ * to mark text keyboard for opening.
+ * Returns true only on the first request each frame */
+NK_API nk_bool nk_input_want_text_keyboard(struct nk_input*);
 
 /* ===============================================================
  *

--- a/src/nuklear_edit.c
+++ b/src/nuklear_edit.c
@@ -583,12 +583,23 @@ nk_do_edit(nk_flags *state, struct nk_command_buffer *out,
                     row_height, font, background_color, text_color, nk_false);
             }
             if (edit->select_start != edit->select_end) {
+                int glyph_len;
+                nk_rune unicode;
+
                 /* draw selected text */
                 NK_ASSERT(select_begin_ptr);
                 if (!select_end_ptr) {
                     const char *begin = nk_str_get_const(&edit->string);
                     select_end_ptr = begin + nk_str_len_char(&edit->string);
                 }
+
+                glyph_len = nk_utf_decode(select_begin_ptr, &unicode, (int)(select_end_ptr - select_begin_ptr));
+                /* In this case, we set the cursor to the first selected character */
+                kb_text_cursor = nk_rect(
+                    area.x + selection_offset_start.x - edit->scrollbar.x,
+                    area.y + selection_offset_start.y - edit->scrollbar.y,
+                    font->width(font->userdata, font->height, select_begin_ptr, glyph_len), row_height);
+
                 nk_edit_draw_text(out, style,
                     area.x - edit->scrollbar.x,
                     area.y + selection_offset_start.y - edit->scrollbar.y,

--- a/src/nuklear_input.c
+++ b/src/nuklear_input.c
@@ -17,6 +17,10 @@ nk_input_begin(struct nk_context *ctx)
     for (i = 0; i < NK_BUTTON_MAX; ++i)
         in->mouse.buttons[i].clicked = 0;
 
+    in->keyboard.text_want = nk_false;
+    in->keyboard.text_area = nk_rect(0.0f, 0.0f, 0.0f, 0.0f);
+    in->keyboard.text_cursor = nk_rect(0.0f, 0.0f, 0.0f, 0.0f);
+
     in->keyboard.text_len = 0;
     in->mouse.scroll_delta = nk_vec2(0,0);
     in->mouse.prev.x = in->mouse.pos.x;
@@ -287,4 +291,12 @@ nk_input_is_key_down(const struct nk_input *i, enum nk_keys key)
     if (k->down) return nk_true;
     return nk_false;
 }
-
+NK_API nk_bool
+nk_input_want_text_keyboard(struct nk_input* i)
+{
+    nk_bool ret;
+    NK_ASSERT(i);
+    ret = !i->keyboard.text_want;
+    i->keyboard.text_want = nk_true;
+    return ret;
+}


### PR DESCRIPTION
🎉🥳 I’m happy to propose a very small but useful API addition that allows Nuklear to provide complete information about the _active text input area_ and _cursor position_. This data can be consumed by backends to enable functions such as `SDL_SetTextInputArea`

Mini FAQ
Q: **Why SDL_SetTextInputArea is important?**
<details>
<summary>Answer</summary>

`SDL_SetTextInputArea` informs the operating system where text is currently being entered.
This is crucial for IME (Input Method Editor) systems.

**For example**, on [Windows with the Japanese](https://support.microsoft.com/en-us/windows/microsoft-japanese-ime-da40471d-6b91-4042-ae8b-713a96476916) IME enabled, the OS shows a small candidate list window near the cursor when typing. Without accurate text area information, this window appears in the wrong place. With this API, the IME candidate window is correctly positioned on top of the actual editing location. 

This greatly improves the usability of Nuklear for logographic languages such as Japanese, Chinese, and Korean. And that's just one example we haven't even touched mobile devices yet! 

</details>

Q: **Why this architecture?**
<details>
<summary>Answer</summary>

The chosen design is [inspired by Dear ImGui](https://github.com/ocornut/imgui/blob/c254db763709e12eeabea54c52631c2b972b7d58/backends/imgui_impl_sdl3.cpp#L178-L207).
ImGui demonstrates that callback-based control can be unnecessarily heavy, and that a much simpler pattern works better in immediate-mode GUI systems: the backend polls the desired text input state every frame.

**The key idea:**

- Widgets don’t hold multi-frame state.
- The GUI "proves" each frame that it needs the text keyboard
- The backend simply reads this state(`text_want`) and useful data(`text_area` and `text_cursor`).

No persistent widget ownership logic is required, and the changes to Nuklear’s core remain extremely small.

</details>

Q: **Why we believe this approach is robust**
<details>
<summary>Answer</summary>

This design follows what I call a _proof system_:

- On every `nk_input_begin`, text input is considered disabled.
- If any editable widget reaches the stage where it needs text input, it explicitly sets a `text_want` flag.
- The backend checks this flag during rendering and activates text input accordingly.

This approach guarantees that no stale state carries over between frames, and avoids the need for any complex widget-activation logic. The text area and cursor rectangles remain simple auxiliary metadata.
</details>

This also includes a patch (written quickly, so not yet C89 compatible) for the existing [SDL3 PR](https://github.com/Immediate-Mode-UI/Nuklear/pull/852). I highly recommend trying this patch, as it visualizes debug rectangles for the active text field and cursor. Japanese keyboard layout is recommended for testing on Windows.

<details>
<summary>CLICK ME</summary>

```diff
diff --git a/nuklear_sdl3_renderer_latest.h b/nuklear_sdl3_renderer.h
index 73b800b..74d2c8e 100644
--- a/nuklear_sdl3_renderer_latest.h
+++ b/nuklear_sdl3_renderer.h
@@ -164,6 +164,22 @@ nk_sdl_device_upload_atlas(struct nk_context* ctx, const void *image, int width,
     SDL_SetTextureBlendMode(sdl->ogl.font_tex, SDL_BLENDMODE_BLEND);
 }
 
+NK_INTERN SDL_FRect
+nk_sdl_render__rect_to_win(SDL_Renderer* renderer, float x, float y, float w, float h)
+{
+    SDL_FRect result;
+    float x1, y1, x2, y2;
+
+    SDL_RenderCoordinatesToWindow(renderer, x, y, &x1, &y1);
+    SDL_RenderCoordinatesToWindow(renderer, x + w, y + h, &x2, &y2);
+    result.x = x1;
+    result.y = y1;
+    result.w = x2 - x1;
+    result.h = y2 - y1;
+
+    return result;
+}
+
 NK_API void
 nk_sdl_render(struct nk_context* ctx, enum nk_anti_aliasing AA)
 {
@@ -180,8 +196,37 @@ nk_sdl_render(struct nk_context* ctx, enum nk_anti_aliasing AA)
         sdl->last_render = ticks;
     }
 
+    SDL_FRect dbg_arect = { 0,0,0,0 };
+    SDL_FRect dbg_crect = { 0,0,0,0 };
+    if (ctx->input.keyboard.text_want) {
+        struct nk_rect ta = ctx->input.keyboard.text_area;
+        struct nk_rect tc = ctx->input.keyboard.text_cursor;
+
+        dbg_arect = (SDL_FRect){ ta.x, ta.y, ta.w, ta.h };
+        dbg_crect = (SDL_FRect){ tc.x, tc.y, tc.w, tc.h };
+
+        if (ta.w > 0.0f && ta.h > 0.0f && tc.w > 0.0f && tc.h > 0.0f)
+        {
+            struct SDL_FRect wta = nk_sdl_render__rect_to_win(sdl->renderer, ta.x, ta.y, ta.w, ta.h);
+            struct SDL_FRect wtc = nk_sdl_render__rect_to_win(sdl->renderer, tc.x, tc.y, tc.w, tc.h);
+            struct nk_rect row = nk_rect(wta.x, wtc.y, wta.w, SDL_max(wtc.h, 16));
+            //SDL_Rect irow = { (int)SDL_floorf(row.x), (int)SDL_floorf(row.y), (int)SDL_ceilf(row.w), (int)SDL_ceilf(row.h) };
+            SDL_Rect irow = { (int)row.x, (int)row.y, (int)row.w, (int)row.h };
+            SDL_SetTextInputArea(sdl->win, &irow, (int)(wtc.x - row.x));
+        }
+        else {
+            SDL_Rect default_rect = { 0, 0, 0, 0 };
+            SDL_SetTextInputArea(sdl->win, &default_rect, 0);
+        }
+        if (!SDL_TextInputActive(sdl->win)) {
+            SDL_StartTextInput(sdl->win);
+        }
+    }
+    else {
+        SDL_StopTextInput(sdl->win);
+    }
     /* start/stop SDL text input events upon (de)activating any Edit */
-    active = nk_edit_is_any_active(ctx);
+    /*active = nk_edit_is_any_active(ctx);
     if (active != sdl->edit_was_active)
     {
         const bool sdl_active = SDL_TextInputActive(sdl->win);
@@ -190,7 +235,8 @@ nk_sdl_render(struct nk_context* ctx, enum nk_anti_aliasing AA)
         else if (sdl_active && sdl->edit_was_active && !active)
             SDL_StopTextInput(sdl->win);
         sdl->edit_was_active = active;
-    }
+    }*/
+
 
     {
         SDL_Rect saved_clip;
@@ -275,6 +321,14 @@ nk_sdl_render(struct nk_context* ctx, enum nk_anti_aliasing AA)
         nk_buffer_free(&vbuf);
         nk_buffer_free(&ebuf);
     }
+    if (ctx->input.keyboard.text_want) {
+
+        SDL_SetRenderDrawBlendMode(sdl->renderer, SDL_BLENDMODE_BLEND);
+        SDL_SetRenderDrawColor(sdl->renderer, 255, 0, 0, 100); 
+        SDL_RenderFillRect(sdl->renderer, &dbg_arect);
+        SDL_SetRenderDrawColor(sdl->renderer, 0, 0, 255, 100);
+        SDL_RenderFillRect(sdl->renderer, &dbg_crect);
+    }
 }
 
 NK_INTERN void

```

</details>

<img width="562" height="428" alt="изображение" src="https://github.com/user-attachments/assets/3cd353ea-87f6-4900-ba73-fd5fcc1aea2f" />
