### PR TITLE
demo/xcb_cairo/nuklear_xcb.h: do not discard xcb_client_message_event_t

### DIFF
--- a/demo/xcb_cairo/nuklear_xcb.h
+++ b/demo/xcb_cairo/nuklear_xcb.h
@@ -238,13 +238,12 @@ NK_API void nk_xcb_free(struct nk_xcb_context *xcb_ctx)
     free(xcb_ctx);
 }
 
-static const xcb_client_message_event_t EMPTY_CLIENT_MESSAGE;
-
 NK_API int nk_xcb_handle_event(struct nk_xcb_context *xcb_ctx, struct nk_context *nk_ctx)
 {
     int events = 0;
     xcb_generic_event_t *event;
     static int insert_toggle = 0;
+    static const xcb_client_message_event_t EMPTY_CLIENT_MESSAGE;
 
 #ifdef NK_XCB_MIN_FRAME_TIME
     struct timespec tp;


### PR DESCRIPTION
Currently nk_xcb_handle_event discard everything that was sent from other clients through xcb_send_event.

To enable a minimal IPC over such channel, this patch adds a new option NK_XCB_CLIENT_MESSAGE to the nk_xcb_event_type enum and stores the message recieved in xcb_ctx->last_client_message.

This can be useful in particular when a background process or thread completes a data retrieval or processing and want to wake up the GUI.