### PR TITLE
Fix windows gdiplus demo runtime panic

### DIFF
--- a/demo/gdip/nuklear_gdip.h
+++ b/demo/gdip/nuklear_gdip.h
@@ -419,7 +419,7 @@ static struct {
 
 static ARGB convert_color(struct nk_color c)
 {
-    return (c.a << 24) | (c.r << 16) | (c.g << 8) | c.b;
+    return ((ARGB)c.a << 24) | (c.r << 16) | (c.g << 8) | c.b;
 }
 
 static void


### PR DESCRIPTION
On windows 11, run demo/gdip, will have a runtime panic like below:

<img width="1099" height="506" alt="屏幕截图 2025-12-11 160939" src="https://github.com/user-attachments/assets/bbf06387-02b8-4501-87cb-4a0161e06a46" />

    thread 11332 panic: left shift of 255 by 24 places cannot be represented in type 'int' in `nuklear_gdip.h:422:0`:
    return (c.a <<  24) | (c.r << 16) | (c.g << 8) | c.b;

As `ARGB` is `DWORD`(aka `u32`), `c.a` is `nk_byte`(aka `u8`), `c.a << 24` will result in `int` type(Integer Promotion), then the runntime checker will panic.

So, cast `c.a` to `ARGB` will fix this.