### PR TITLE
demo/sdl3_renderer/main.c: call nk_input_begin at the end of SDL_AppInit

### DIFF
--- a/demo/sdl3_renderer/main.c
+++ b/demo/sdl3_renderer/main.c
@@ -409,6 +409,7 @@ SDL_AppQuit(void* appstate, SDL_AppResult result)
     NK_UNUSED(result);
 
     if (app) {
+        nk_input_end(app->ctx);
         nk_sdl_shutdown(app->ctx);
         SDL_DestroyRenderer(app->renderer);
         SDL_DestroyWindow(app->window);


### PR DESCRIPTION
The very first `nk_input_end` call in `SDL_AppIterate` occurs without a preceding `nk_input_begin` call. While not critical, this violates the expected pairing of these functions.