### PR TITLE
Fix Vulkan Reusing Signaled Semaphore  

### DIFF
--- a/demo/glfw_vulkan/main.c
+++ b/demo/glfw_vulkan/main.c
@@ -26,7 +26,7 @@
 
 #define MAX_VERTEX_BUFFER 512 * 1024
 #define MAX_ELEMENT_BUFFER 128 * 1024
-
+#define MAX_IN_FLIGHT_FRAMES 2
 /* ===============================================================
  *
  *                          EXAMPLE
@@ -135,14 +135,15 @@ struct vulkan_demo {
     VkPipeline pipeline;
     VkCommandPool command_pool;
     VkCommandBuffer *command_buffers;
-    VkSemaphore image_available;
-    VkSemaphore render_finished;
+    VkSemaphore *image_available;
+    VkSemaphore *render_finished;
 
     VkImage demo_texture_image;
     VkImageView demo_texture_image_view;
     VkDeviceMemory demo_texture_memory;
 
-    VkFence render_fence;
+    VkFence *render_fence;
+    uint32_t current_in_flight_frame;
 
     bool framebuffer_resized;
 };
@@ -1471,13 +1472,13 @@ bool create_command_buffers(struct vulkan_demo *demo) {
     VkResult result;
 
     demo->command_buffers =
-        malloc(demo->swap_chain_images_len * sizeof(VkCommandBuffer));
+        malloc(MAX_IN_FLIGHT_FRAMES * sizeof(VkCommandBuffer));
 
     memset(&alloc_info, 0, sizeof(VkCommandBufferAllocateInfo));
     alloc_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_ALLOCATE_INFO;
     alloc_info.commandPool = demo->command_pool;
     alloc_info.level = VK_COMMAND_BUFFER_LEVEL_PRIMARY;
-    alloc_info.commandBufferCount = demo->swap_chain_images_len;
+    alloc_info.commandBufferCount = MAX_IN_FLIGHT_FRAMES;
 
     result = vkAllocateCommandBuffers(demo->device, &alloc_info,
                                       demo->command_buffers);
@@ -1492,20 +1493,28 @@ bool create_command_buffers(struct vulkan_demo *demo) {
 bool create_semaphores(struct vulkan_demo *demo) {
     VkSemaphoreCreateInfo semaphore_info;
     VkResult result;
-
+    uint32_t i;
+    
+    demo->image_available = (VkSemaphore*)malloc(MAX_IN_FLIGHT_FRAMES * sizeof(VkSemaphore));
+    demo->render_finished = (VkSemaphore*)malloc(demo->swap_chain_images_len * sizeof(VkSemaphore));
     memset(&semaphore_info, 0, sizeof(VkSemaphoreCreateInfo));
     semaphore_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-    result = vkCreateSemaphore(demo->device, &semaphore_info, NULL,
-                               &demo->image_available);
-    if (result != VK_SUCCESS) {
-        fprintf(stderr, "vkCreateSemaphore failed: %d\n", result);
-        return false;
+    
+    for(i = 0; i < MAX_IN_FLIGHT_FRAMES; i++) {
+        result = vkCreateSemaphore(demo->device, &semaphore_info, NULL,
+                               &demo->image_available[i]);
+        if (result != VK_SUCCESS) {
+            fprintf(stderr, "vkCreateSemaphore failed: %d\n", result);
+            return false;
+        }
     }
-    result = vkCreateSemaphore(demo->device, &semaphore_info, NULL,
-                               &demo->render_finished);
-    if (result != VK_SUCCESS) {
-        fprintf(stderr, "vkCreateSemaphore failed: %d\n", result);
-        return false;
+    for(i = 0; i < demo->swap_chain_images_len; i++) {
+        result = vkCreateSemaphore(demo->device, &semaphore_info, NULL,
+                               &demo->render_finished[i]);
+        if (result != VK_SUCCESS) {
+            fprintf(stderr, "vkCreateSemaphore failed: %d\n", result);
+            return false;
+        }
     }
     return true;
 }
@@ -1513,17 +1522,21 @@ bool create_semaphores(struct vulkan_demo *demo) {
 bool create_fence(struct vulkan_demo *demo) {
     VkResult result;
     VkFenceCreateInfo fence_create_info;
+    uint32_t i;
+    
+    demo->render_fence = (VkFence*)malloc(MAX_IN_FLIGHT_FRAMES * sizeof(VkFence));
 
     memset(&fence_create_info, 0, sizeof(VkFenceCreateInfo));
     fence_create_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
     fence_create_info.flags = VK_FENCE_CREATE_SIGNALED_BIT;
-
-    result = vkCreateFence(demo->device, &fence_create_info, NULL,
-                           &demo->render_fence);
-
-    if (result != VK_SUCCESS) {
-        fprintf(stderr, "vkCreateFence failed: %d\n", result);
-        return false;
+    
+    for(i = 0; i < MAX_IN_FLIGHT_FRAMES; i++) {
+        result = vkCreateFence(demo->device, &fence_create_info, NULL,
+                           &demo->render_fence[i]);
+        if (result != VK_SUCCESS) {
+            fprintf(stderr, "vkCreateFence failed: %d\n", result);
+            return false;
+        }
     }
     return true;
 }
@@ -1926,7 +1939,7 @@ bool render(struct vulkan_demo *demo, struct nk_colorf *bg,
     command_buffer_begin_info.sType =
         VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
 
-    command_buffer = demo->command_buffers[image_index];
+    command_buffer = demo->command_buffers[demo->current_in_flight_frame];
     result = vkBeginCommandBuffer(command_buffer, &command_buffer_begin_info);
 
     if (result != VK_SUCCESS) {
@@ -1968,12 +1981,12 @@ bool render(struct vulkan_demo *demo, struct nk_colorf *bg,
     submit_info.pWaitSemaphores = &wait_semaphore;
     submit_info.pWaitDstStageMask = &wait_stage;
     submit_info.commandBufferCount = 1;
-    submit_info.pCommandBuffers = &demo->command_buffers[image_index];
+    submit_info.pCommandBuffers = &command_buffer;
     submit_info.signalSemaphoreCount = 1;
-    submit_info.pSignalSemaphores = &demo->render_finished;
+    submit_info.pSignalSemaphores = &demo->render_finished[image_index];
 
     result = vkQueueSubmit(demo->graphics_queue, 1, &submit_info,
-                           demo->render_fence);
+                           demo->render_fence[demo->current_in_flight_frame]);
 
     if (result != VK_SUCCESS) {
         fprintf(stderr, "vkQueueSubmit failed: %d\n", result);
@@ -1983,7 +1996,7 @@ bool render(struct vulkan_demo *demo, struct nk_colorf *bg,
     memset(&present_info, 0, sizeof(VkPresentInfoKHR));
     present_info.sType = VK_STRUCTURE_TYPE_PRESENT_INFO_KHR;
     present_info.waitSemaphoreCount = 1;
-    present_info.pWaitSemaphores = &demo->render_finished;
+    present_info.pWaitSemaphores = &demo->render_finished[image_index];
     present_info.swapchainCount = 1;
     present_info.pSwapchains = &demo->swap_chain;
     present_info.pImageIndices = &image_index;
@@ -1991,8 +2004,10 @@ bool render(struct vulkan_demo *demo, struct nk_colorf *bg,
     result = vkQueuePresentKHR(demo->present_queue, &present_info);
 
     if (result == VK_ERROR_OUT_OF_DATE_KHR || result == VK_SUBOPTIMAL_KHR || demo->framebuffer_resized) {
-        recreate_swap_chain(demo);
-    } else if (result != VK_SUCCESS) {
+        if (!recreate_swap_chain(demo)) {
+            fprintf(stderr, "failed to recreate swap chain!\n");
+        }
+    } else if (result != VK_SUCCESS && result != VK_SUBOPTIMAL_KHR) {
         fprintf(stderr, "vkQueuePresentKHR failed: %d\n", result);
         return false;
     }
@@ -2016,6 +2031,7 @@ destroy_debug_utils_messenger_ext(VkInstance instance,
 
 bool cleanup(struct vulkan_demo *demo) {
     VkResult result;
+    uint32_t i;
 
     printf("cleaning up\n");
     result = vkDeviceWaitIdle(demo->device);
@@ -2027,13 +2043,25 @@ bool cleanup(struct vulkan_demo *demo) {
     destroy_swap_chain_related_resources(demo);
 
     vkFreeCommandBuffers(demo->device, demo->command_pool,
-                         demo->swap_chain_images_len, demo->command_buffers);
+                         MAX_IN_FLIGHT_FRAMES, demo->command_buffers);
     vkDestroyCommandPool(demo->device, demo->command_pool, NULL);
     vkDestroySampler(demo->device, demo->sampler, NULL);
-    vkDestroySemaphore(demo->device, demo->render_finished, NULL);
-    vkDestroySemaphore(demo->device, demo->image_available, NULL);
-    vkDestroyFence(demo->device, demo->render_fence, NULL);
-
+    
+    for(i = 0; i < demo->swap_chain_images_len; i++)
+     vkDestroySemaphore(demo->device, demo->render_finished[i], NULL);
+    if(demo->render_finished)
+     free(demo->render_finished);
+     
+    for(i = 0; i < MAX_IN_FLIGHT_FRAMES; i++)
+     vkDestroySemaphore(demo->device, demo->image_available[i], NULL);
+    if(demo->image_available)
+     free(demo->image_available);
+     
+    for(i = 0; i < MAX_IN_FLIGHT_FRAMES; i++)
+    vkDestroyFence(demo->device, demo->render_fence[i], NULL);
+    if(demo->render_fence)
+     free(demo->render_fence);
+    
     vkDestroyImage(demo->device, demo->demo_texture_image, NULL);
     vkDestroyImageView(demo->device, demo->demo_texture_image_view, NULL);
     vkFreeMemory(demo->device, demo->demo_texture_memory, NULL);
@@ -2212,15 +2240,15 @@ int main(void) {
 #endif
         /* ----------------------------------------- */
 
-        result = vkWaitForFences(demo.device, 1, &demo.render_fence, VK_TRUE,
+        result = vkWaitForFences(demo.device, 1, &demo.render_fence[demo.current_in_flight_frame], VK_TRUE,
                                  UINT64_MAX);
-
+                                 
         if (result != VK_SUCCESS) {
             fprintf(stderr, "vkWaitForFences failed: %d\n", result);
             return false;
         }
 
-        result = vkResetFences(demo.device, 1, &demo.render_fence);
+        result = vkResetFences(demo.device, 1, &demo.render_fence[demo.current_in_flight_frame]);
         if (result != VK_SUCCESS) {
             fprintf(stderr, "vkResetFences failed: %d\n", result);
             return false;
@@ -2228,7 +2256,7 @@ int main(void) {
 
         result =
             vkAcquireNextImageKHR(demo.device, demo.swap_chain, UINT64_MAX,
-                                  demo.image_available, NULL, &image_index);
+                                  demo.image_available[demo.current_in_flight_frame], NULL, &image_index);
 
         if (result == VK_ERROR_OUT_OF_DATE_KHR) {
             recreate_swap_chain(&demo);
@@ -2245,11 +2273,12 @@ int main(void) {
         /* Draw */
         nk_semaphore =
             nk_glfw3_render(demo.graphics_queue, image_index,
-                            demo.image_available, NK_ANTI_ALIASING_ON);
+                           demo.image_available[demo.current_in_flight_frame], NK_ANTI_ALIASING_ON);
         if (!render(&demo, &bg, nk_semaphore, image_index)) {
             fprintf(stderr, "render failed\n");
             return false;
         }
+        demo.current_in_flight_frame = (demo.current_in_flight_frame + 1) % MAX_IN_FLIGHT_FRAMES;
     }
     nk_glfw3_shutdown();
     cleanup(&demo);

--- a/demo/sdl_vulkan/main.c
+++ b/demo/sdl_vulkan/main.c
@@ -1485,47 +1485,50 @@ bool create_command_buffers(struct vulkan_demo *demo) {
 
 bool create_semaphores(struct vulkan_demo *demo) {
     VkSemaphoreCreateInfo semaphore_info;
-    VkResult result = VK_SUCCESS;
+    VkResult result;
+    uint32_t i;
     
     demo->image_available = (VkSemaphore*)malloc(MAX_IN_FLIGHT_FRAMES * sizeof(VkSemaphore));
     demo->render_finished = (VkSemaphore*)malloc(demo->swap_chain_images_len * sizeof(VkSemaphore));
     memset(&semaphore_info, 0, sizeof(VkSemaphoreCreateInfo));
     semaphore_info.sType = VK_STRUCTURE_TYPE_SEMAPHORE_CREATE_INFO;
-    uint32_t i;
-    for(i = 0; i < MAX_IN_FLIGHT_FRAMES; i++)
-    result |= vkCreateSemaphore(demo->device, &semaphore_info, NULL,
+    for(i = 0; i < MAX_IN_FLIGHT_FRAMES; i++) {
+        result = vkCreateSemaphore(demo->device, &semaphore_info, NULL,
                                &demo->image_available[i]);
-    if (result != VK_SUCCESS) {
-        fprintf(stderr, "vkCreateSemaphore failed: %d\n", result);
-        return false;
+        if (result != VK_SUCCESS) {
+            fprintf(stderr, "vkCreateSemaphore failed: %d\n", result);
+            return false;
+        }
     }
-    for(i = 0; i < demo->swap_chain_images_len; i++) 
-    result |= vkCreateSemaphore(demo->device, &semaphore_info, NULL,
+    for(i = 0; i < demo->swap_chain_images_len; i++) {
+        result = vkCreateSemaphore(demo->device, &semaphore_info, NULL,
                                &demo->render_finished[i]);
-    if (result != VK_SUCCESS) {
-        fprintf(stderr, "vkCreateSemaphore failed: %d\n", result);
-        return false;
+        if (result != VK_SUCCESS) {
+            fprintf(stderr, "vkCreateSemaphore failed: %d\n", result);
+            return false;
+        }
     }
     return true;
 }
 
 bool create_fence(struct vulkan_demo *demo) {
-    VkResult result = VK_SUCCESS;
+    VkResult result;
     VkFenceCreateInfo fence_create_info;
+    uint32_t i;
     
     demo->render_fence = (VkFence*)malloc(MAX_IN_FLIGHT_FRAMES * sizeof(VkFence));
 
     memset(&fence_create_info, 0, sizeof(VkFenceCreateInfo));
     fence_create_info.sType = VK_STRUCTURE_TYPE_FENCE_CREATE_INFO;
     fence_create_info.flags = VK_FENCE_CREATE_SIGNALED_BIT;
-    uint32_t i;
-    for(i = 0; i < MAX_IN_FLIGHT_FRAMES; i++)
-    result |= vkCreateFence(demo->device, &fence_create_info, NULL,
+    
+    for(i = 0; i < MAX_IN_FLIGHT_FRAMES; i++) {
+        result = vkCreateFence(demo->device, &fence_create_info, NULL,
                            &demo->render_fence[i]);
-
-    if (result != VK_SUCCESS) {
-        fprintf(stderr, "vkCreateFence failed: %d\n", result);
-        return false;
+        if (result != VK_SUCCESS) {
+            fprintf(stderr, "vkCreateFence failed: %d\n", result);
+            return false;
+        }
     }
     return true;
 }
@@ -2018,7 +2021,8 @@ destroy_debug_utils_messenger_ext(VkInstance instance,
 
 bool cleanup(struct vulkan_demo *demo) {
     VkResult result;
-
+    uint32_t i;
+    
     printf("cleaning up\n");
     result = vkDeviceWaitIdle(demo->device);
     if (result != VK_SUCCESS) {
@@ -2032,7 +2036,7 @@ bool cleanup(struct vulkan_demo *demo) {
                          MAX_IN_FLIGHT_FRAMES, demo->command_buffers);
     vkDestroyCommandPool(demo->device, demo->command_pool, NULL);
     vkDestroySampler(demo->device, demo->sampler, NULL);
-    uint32_t i;
+    
     for(i = 0; i < demo->swap_chain_images_len; i++)
      vkDestroySemaphore(demo->device, demo->render_finished[i], NULL);
     if(demo->render_finished)


### PR DESCRIPTION
error msg
``` 
validation layer: vkQueueSubmit(): pSubmits[0].pSignalSemaphores[0] (VkSemaphore 0x380000000038) is being signaled by VkQueue 0x7117f965b0, but it may still be in use by VkSwapchainKHR 0x40000000004.
Most recently acquired image indices: [0], 1.
(Brackets mark the last use of VkSemaphore 0x380000000038 in a presentation operation.)
Swapchain image 0 was presented but was not re-acquired, so VkSemaphore 0x380000000038 may still be in use and cannot be safely reused with image index 1.
Vulkan insight: See [https://docs.vulkan.org/guide/latest/swapchain_semaphore_reuse.html](https://docs.vulkan.org/guide/latest/swapchain_semaphore_reuse.html?fbclid=IwZXh0bgNhZW0CMTAAYnJpZBExRlBKN2ZOZUU2dGk3YVBaenNydGMGYXBwX2lkEDIyMjAzOTE3ODgyMDA4OTIAAR6ehXO-kqgw9DRNx0pWel9AkPNN4GOHvnh6gsZnB04zVOI0FHT0A9J9ul_Brw_aem_f_WJBbC0-nA52QVSfFOGeA) for details on swapchain semaphore reuse. Examples of possible approaches:
   a) Use a separate semaphore per swapchain image. Index these semaphores using the index of the acquired image.
   b) Consider the VK_KHR_swapchain_maintenance1 extension. It allows using a VkFence with the presentation operation.
The Vulkan spec states: Each binary semaphore element of the pSignalSemaphores member of any element of pSubmits must be unsignaled when the semaphore signal operation it defines is executed on the device ([https://docs.vulkan.org/spec/latest/chapters/cmdbuffers.html#VUID-vkQueueSubmit-pSignalSemaphores-00067](https://docs.vulkan.org/spec/latest/chapters/cmdbuffers.html?fbclid=IwZXh0bgNhZW0CMTAAYnJpZBExRlBKN2ZOZUU2dGk3YVBaenNydGMGYXBwX2lkEDIyMjAzOTE3ODgyMDA4OTIAAR68tfXod7jwsd5K7fpRfFTLAXB_2sz3_LstkvM-JvCjgw1fh1iOgJnlNZhV-g_aem_kXHeG07d4grINTK3_qglUA#VUID-vkQueueSubmit-pSignalSemaphores-00067))
``` 
i just used [this](https://docs.vulkan.org/guide/latest/swapchain_semaphore_reuse.html) example to fix it.
