### PR TITLE
Fix crash in nk_buffer_realloc and forbid the use of realloc

### DIFF
--- a/demo/sdl3_renderer/nuklear_sdl3_renderer.h
+++ b/demo/sdl3_renderer/nuklear_sdl3_renderer.h
@@ -112,16 +112,7 @@ NK_INTERN void *
 nk_sdl_alloc(nk_handle user, void *old, nk_size size)
 {
     NK_UNUSED(user);
-    /* FIXME: nk_sdl_alloc should use SDL_realloc here, not SDL_malloc
-     * but this could cause a double-free due to bug within Nuklear, see:
-     * https://github.com/Immediate-Mode-UI/Nuklear/issues/768
-     * */
-#if 0
     return SDL_realloc(old, size);
-#else
-    NK_UNUSED(old);
-    return SDL_malloc(size);
-#endif
 }
 
 NK_INTERN void

--- a/nuklear.h
+++ b/nuklear.h
@@ -8524,7 +8524,16 @@ NK_LIB void*
 nk_malloc(nk_handle unused, void *old,nk_size size)
 {
     NK_UNUSED(unused);
-    NK_UNUSED(old);
+    /*
+     * Due to historical reasons, Nuklear always calls alloc(user,old,size)
+     * with the "old" pointer always being NULL. For full explanation, see:
+     * https://github.com/Immediate-Mode-UI/Nuklear/issues/768
+     *
+     * FIXME: The best would be to replace this function with "nk_realloc",
+     * but some custom allocators could still depend on "malloc" assumption
+     * so changing this now (without major bump) would break existing code.
+     */
+    NK_ASSERT(!old && "Nuklear's internal code must never call realloc !");
     return malloc(size);
 }
 NK_LIB void
@@ -8617,15 +8626,16 @@ nk_buffer_realloc(struct nk_buffer *b, nk_size capacity, nk_size *size)
         return 0;
 
     buffer_size = b->memory.size;
-    temp = b->pool.alloc(b->pool.userdata, b->memory.ptr, capacity);
+    NK_ASSERT(capacity >= buffer_size && "shrinking was never supported here");
+
+    /* HACK: this simulates realloc with malloc+memcpy+free
+     * for backwards compatibility reasons, see the note in nk_malloc */
+    temp = b->pool.alloc(b->pool.userdata, 0, capacity);
     NK_ASSERT(temp);
     if (!temp) return 0;
-
     *size = capacity;
-    if (temp != b->memory.ptr) {
-        NK_MEMCPY(temp, b->memory.ptr, buffer_size);
-        b->pool.free(b->pool.userdata, b->memory.ptr);
-    }
+    NK_MEMCPY(temp, b->memory.ptr, buffer_size);
+    b->pool.free(b->pool.userdata, b->memory.ptr);
 
     if (b->size == buffer_size) {
         /* no back buffer so just set correct size */

--- a/src/nuklear_buffer.c
+++ b/src/nuklear_buffer.c
@@ -11,7 +11,16 @@ NK_LIB void*
 nk_malloc(nk_handle unused, void *old,nk_size size)
 {
     NK_UNUSED(unused);
-    NK_UNUSED(old);
+    /*
+     * Due to historical reasons, Nuklear always calls alloc(user,old,size)
+     * with the "old" pointer always being NULL. For full explanation, see:
+     * https://github.com/Immediate-Mode-UI/Nuklear/issues/768
+     *
+     * FIXME: The best would be to replace this function with "nk_realloc",
+     * but some custom allocators could still depend on "malloc" assumption
+     * so changing this now (without major bump) would break existing code.
+     */
+    NK_ASSERT(!old && "Nuklear's internal code must never call realloc !");
     return malloc(size);
 }
 NK_LIB void
@@ -104,15 +113,16 @@ nk_buffer_realloc(struct nk_buffer *b, nk_size capacity, nk_size *size)
         return 0;
 
     buffer_size = b->memory.size;
-    temp = b->pool.alloc(b->pool.userdata, b->memory.ptr, capacity);
+    NK_ASSERT(capacity >= buffer_size && "shrinking was never supported here");
+
+    /* HACK: this simulates realloc with malloc+memcpy+free
+     * for backwards compatibility reasons, see the note in nk_malloc */
+    temp = b->pool.alloc(b->pool.userdata, 0, capacity);
     NK_ASSERT(temp);
     if (!temp) return 0;
-
     *size = capacity;
-    if (temp != b->memory.ptr) {
-        NK_MEMCPY(temp, b->memory.ptr, buffer_size);
-        b->pool.free(b->pool.userdata, b->memory.ptr);
-    }
+    NK_MEMCPY(temp, b->memory.ptr, buffer_size);
+    b->pool.free(b->pool.userdata, b->memory.ptr);
 
     if (b->size == buffer_size) {
         /* no back buffer so just set correct size */


### PR DESCRIPTION
Fixes: https://github.com/Immediate-Mode-UI/Nuklear/issues/768

Please read the linked issue for explanation.

The default implementation of nk_allocator callback (aka nk_malloc) is fundamentally broken, and should have used realloc instead of malloc in the first place. This must have led to the workaround in nk_buffer_realloc that would crash whenever you use an allocator with correct realloc assumption.

We cannot change nk_malloc at this point as people could have implemented their own allocators based on same assumptions, nor we can change the nk_allocator interface because it would be a breaking change (and because we may actually want to use realloc in a future) but we can ensure that Nuklear itself never tries to reallocate memory in its internal code (which is already happening anyway, this only enforces it)

This is kinda ugly, but it still leaves a room for making a breaking change later.