### PR TITLE
Fixing the demo to not provoque ctrl actions with modded keyboards or mobile virtual keyboards

### DIFF
--- a/demo/sdl3_renderer/nuklear_sdl3_renderer.h
+++ b/demo/sdl3_renderer/nuklear_sdl3_renderer.h
@@ -337,6 +337,7 @@ nk_sdl_clipboard_paste(nk_handle usr, struct nk_text_edit *edit)
     }
     SDL_free(text);
 }
+
 NK_INTERN void
 nk_sdl_clipboard_copy(nk_handle usr, const char *text, int len)
 {

--- a/demo/sdl3_renderer/nuklear_sdl3_renderer.h
+++ b/demo/sdl3_renderer/nuklear_sdl3_renderer.h
@@ -471,42 +471,42 @@ nk_sdl_handle_event(struct nk_context* ctx, SDL_Event *evt)
                     case SDL_SCANCODE_PAGEDOWN:  nk_input_key(ctx, NK_KEY_SCROLL_DOWN, down); break;
                     case SDL_SCANCODE_PAGEUP:    nk_input_key(ctx, NK_KEY_SCROLL_UP, down); break;
                     case SDL_SCANCODE_A:
-                        if (ctrl_down){
+                        if ((down && ctrl_down) ^ nk_input_is_key_down(&ctx->input, NK_KEY_TEXT_SELECT_ALL)){
                             nk_input_key(ctx, NK_KEY_TEXT_SELECT_ALL, down);
                         }
                         break;
                     case SDL_SCANCODE_Z:
-                        if (ctrl_down){
+                        if ((down && ctrl_down) ^ nk_input_is_key_down(&ctx->input, NK_KEY_TEXT_UNDO)){
                             nk_input_key(ctx, NK_KEY_TEXT_UNDO, down);
                         }
                         break;
                     case SDL_SCANCODE_R:
-                        if (ctrl_down){
+                        if ((down && ctrl_down) ^ nk_input_is_key_down(&ctx->input, NK_KEY_TEXT_REDO)){
                             nk_input_key(ctx, NK_KEY_TEXT_REDO, down);
                         }
                         break;
                     case SDL_SCANCODE_C:
-                        if (ctrl_down){
+                        if ((down && ctrl_down) ^ nk_input_is_key_down(&ctx->input, NK_KEY_COPY)){
                             nk_input_key(ctx, NK_KEY_COPY, down);
                         }
                         break;
                     case SDL_SCANCODE_V:
-                        if (ctrl_down){
+                        if ((down && ctrl_down) ^ nk_input_is_key_down(&ctx->input, NK_KEY_PASTE)){
                             nk_input_key(ctx, NK_KEY_PASTE, down);
                         }
                         break;
                     case SDL_SCANCODE_X:
-                        if (ctrl_down){
+                        if ((down && ctrl_down) ^ nk_input_is_key_down(&ctx->input, NK_KEY_CUT)){
                             nk_input_key(ctx, NK_KEY_CUT, down);
                         }
                         break;
                     case SDL_SCANCODE_B:
-                        if (ctrl_down){
+                        if ((down && ctrl_down) ^ nk_input_is_key_down(&ctx->input, NK_KEY_TEXT_LINE_START)){
                             nk_input_key(ctx, NK_KEY_TEXT_LINE_START, down);
                         }
                         break;
                     case SDL_SCANCODE_E:
-                        if (ctrl_down){
+                        if ((down && ctrl_down) ^ nk_input_is_key_down(&ctx->input, NK_KEY_TEXT_LINE_END)){
                             nk_input_key(ctx, NK_KEY_TEXT_LINE_END, down);
                         }
                         break;

--- a/demo/sdl3_renderer/nuklear_sdl3_renderer.h
+++ b/demo/sdl3_renderer/nuklear_sdl3_renderer.h
@@ -337,7 +337,6 @@ nk_sdl_clipboard_paste(nk_handle usr, struct nk_text_edit *edit)
     }
     SDL_free(text);
 }
-
 NK_INTERN void
 nk_sdl_clipboard_copy(nk_handle usr, const char *text, int len)
 {
@@ -470,14 +469,46 @@ nk_sdl_handle_event(struct nk_context* ctx, SDL_Event *evt)
                                                  nk_input_key(ctx, NK_KEY_SCROLL_END, down); break;
                     case SDL_SCANCODE_PAGEDOWN:  nk_input_key(ctx, NK_KEY_SCROLL_DOWN, down); break;
                     case SDL_SCANCODE_PAGEUP:    nk_input_key(ctx, NK_KEY_SCROLL_UP, down); break;
-                    case SDL_SCANCODE_A:         nk_input_key(ctx, NK_KEY_TEXT_SELECT_ALL, down && ctrl_down); break;
-                    case SDL_SCANCODE_Z:         nk_input_key(ctx, NK_KEY_TEXT_UNDO, down && ctrl_down); break;
-                    case SDL_SCANCODE_R:         nk_input_key(ctx, NK_KEY_TEXT_REDO, down && ctrl_down); break;
-                    case SDL_SCANCODE_C:         nk_input_key(ctx, NK_KEY_COPY, down && ctrl_down); break;
-                    case SDL_SCANCODE_V:         nk_input_key(ctx, NK_KEY_PASTE, down && ctrl_down); break;
-                    case SDL_SCANCODE_X:         nk_input_key(ctx, NK_KEY_CUT, down && ctrl_down); break;
-                    case SDL_SCANCODE_B:         nk_input_key(ctx, NK_KEY_TEXT_LINE_START, down && ctrl_down); break;
-                    case SDL_SCANCODE_E:         nk_input_key(ctx, NK_KEY_TEXT_LINE_END, down && ctrl_down); break;
+                    case SDL_SCANCODE_A:
+                        if (ctrl_down){
+                            nk_input_key(ctx, NK_KEY_TEXT_SELECT_ALL, down);
+                        }
+                        break;
+                    case SDL_SCANCODE_Z:
+                        if (ctrl_down){
+                            nk_input_key(ctx, NK_KEY_TEXT_UNDO, down);
+                        }
+                        break;
+                    case SDL_SCANCODE_R:
+                        if (ctrl_down){
+                            nk_input_key(ctx, NK_KEY_TEXT_REDO, down);
+                        }
+                        break;
+                    case SDL_SCANCODE_C:
+                        if (ctrl_down){
+                            nk_input_key(ctx, NK_KEY_COPY, down);
+                        }
+                        break;
+                    case SDL_SCANCODE_V:
+                        if (ctrl_down){
+                            nk_input_key(ctx, NK_KEY_PASTE, down);
+                        }
+                        break;
+                    case SDL_SCANCODE_X:
+                        if (ctrl_down){
+                            nk_input_key(ctx, NK_KEY_CUT, down);
+                        }
+                        break;
+                    case SDL_SCANCODE_B:
+                        if (ctrl_down){
+                            nk_input_key(ctx, NK_KEY_TEXT_LINE_START, down);
+                        }
+                        break;
+                    case SDL_SCANCODE_E:
+                        if (ctrl_down){
+                            nk_input_key(ctx, NK_KEY_TEXT_LINE_END, down);
+                        }
+                        break;
                     case SDL_SCANCODE_UP:        nk_input_key(ctx, NK_KEY_UP, down); break;
                     case SDL_SCANCODE_DOWN:      nk_input_key(ctx, NK_KEY_DOWN, down); break;
                     case SDL_SCANCODE_ESCAPE:    nk_input_key(ctx, NK_KEY_TEXT_RESET_MODE, down); break;


### PR DESCRIPTION
While using a modded keyboard with macros on the characters pressing the keys affected by the ctrl modifier without ctrl down, would still trigger it, it was the same issue using the Android virtual keyboard.

Here's an example of what was happening, pressing `a` would erase all text and write the letter `a` instead, pressing `b` would write the letter `b` at the start of the text area and set the cursor in between the first and second character, pressing `e` would add the letter `e` at the end of the text area.

After some code investigation, I found out that calling `nk_input_key` would always increase `ctx->input.keyboard.keys[key].clicked` even if `ctrl` wasn't push, then if it was released while the clicked counter was still equals to 1, it would increase it to 2 triggering the `nk_input_key_pressed` due to the validation of `if ((k->down && k->clicked) || (!k->down && k->clicked >= 2))`.

Only calling `nk_input_key` when `ctrl` is down fixes the problem.