### PR TITLE
Add tooltip positioning

### DIFF
--- a/demo/common/overview.c
+++ b/demo/common/overview.c
@@ -844,7 +844,7 @@ overview(struct nk_context *ctx)
             bounds = nk_widget_bounds(ctx);
             nk_label(ctx, "Hover me for tooltip", NK_TEXT_LEFT);
             if (nk_input_is_mouse_hovering_rect(in, bounds))
-                nk_tooltip(ctx, "This is a tooltip");
+                nk_tooltip_positioned(ctx, "This is a tooltip", NK_BOTTOM_LEFT);
 
             nk_tree_pop(ctx);
         }

--- a/demo/common/overview.c
+++ b/demo/common/overview.c
@@ -842,9 +842,28 @@ overview(struct nk_context *ctx)
             /* tooltip */
             nk_layout_row_static(ctx, 30, 150, 1);
             bounds = nk_widget_bounds(ctx);
-            nk_label(ctx, "Hover me for tooltip", NK_TEXT_LEFT);
-            if (nk_input_is_mouse_hovering_rect(in, bounds))
-                nk_tooltip_positioned(ctx, "This is a tooltip", NK_BOTTOM_LEFT);
+            nk_label(ctx, "Hover for tooltip", NK_TEXT_LEFT);
+            if (nk_input_is_mouse_hovering_rect(in, bounds)) {
+                nk_tooltip(ctx, "This is a default tooltip");
+            }
+            bounds = nk_widget_bounds(ctx);
+            nk_label(ctx, "Chrome-like tooltip", NK_TEXT_LEFT);
+            if (nk_input_is_mouse_hovering_rect(in, bounds)) {
+                struct nk_vec2 offset = { 8, 8 };
+                nk_tooltip_pos_offset(ctx, "Chrome offsets just a bit", NK_TOP_LEFT, offset);
+            }
+            bounds = nk_widget_bounds(ctx);
+            nk_label(ctx, "Gnome-like tooltip", NK_TEXT_LEFT);
+            if (nk_input_is_mouse_hovering_rect(in, bounds)) {
+                struct nk_vec2 offset = { 0, -15 };
+                nk_tooltip_pos_offset(ctx, "Gnome centers with greater y offset", NK_BOTTOM_MIDDLE, offset);
+            }
+            bounds = nk_widget_bounds(ctx);
+            nk_label(ctx, "Bottom left tooltip", NK_TEXT_LEFT);
+            if (nk_input_is_mouse_hovering_rect(in, bounds)) {
+                struct nk_vec2 offset = { 0, 0 };
+                nk_tooltip_pos_offset(ctx, "Bottom left positioning", NK_BOTTOM_LEFT, offset);
+            }
 
             nk_tree_pop(ctx);
         }

--- a/demo/common/overview.c
+++ b/demo/common/overview.c
@@ -850,13 +850,13 @@ overview(struct nk_context *ctx)
             nk_label(ctx, "Hover for Gnome-like tooltip", NK_TEXT_LEFT);
             if (nk_input_is_mouse_hovering_rect(in, bounds)) {
                 struct nk_vec2 offset = { 0, -15 };
-                nk_tooltip_pos_offset(ctx, "Gnome bottom centers plus a -y offset", NK_BOTTOM_CENTER, offset);
+                nk_tooltip_offset(ctx, "Gnome bottom centers plus a -y offset", NK_BOTTOM_CENTER, offset);
             }
             bounds = nk_widget_bounds(ctx);
             nk_label(ctx, "Hover for a bottom left tooltip", NK_TEXT_LEFT);
             if (nk_input_is_mouse_hovering_rect(in, bounds)) {
                 struct nk_vec2 offset = { 0, 0 };
-                nk_tooltip_pos_offset(ctx, "Bottom left positioning", NK_BOTTOM_LEFT, offset);
+                nk_tooltip_offset(ctx, "Bottom left positioning", NK_BOTTOM_LEFT, offset);
             }
             bounds = nk_widget_bounds(ctx);
             nk_label(ctx, "Hover for MAGIC!", NK_TEXT_LEFT);
@@ -866,7 +866,7 @@ overview(struct nk_context *ctx)
                 struct nk_vec2 offset;
                 offset.x = radius * cos(accum_time_seconds * speed);
                 offset.y = radius * sin(accum_time_seconds * speed);
-                nk_tooltip_pos_offset(ctx, "WOW!", NK_MIDDLE_CENTER, offset);
+                nk_tooltip_offset(ctx, "WOW!", NK_MIDDLE_CENTER, offset);
                 accum_time_seconds += (double)(ctx->delta_time_seconds);
             }
 
@@ -902,7 +902,7 @@ overview(struct nk_context *ctx)
                 bounds = nk_widget_bounds(ctx);
                 nk_label(ctx, "Hover for custom tooltip (you can customize it below)", NK_TEXT_LEFT);
                 if (nk_input_is_mouse_hovering_rect(in, bounds)) {
-                    nk_tooltip_pos_offset(ctx, text_buf, cur_pos, offset);
+                    nk_tooltip_offset(ctx, text_buf, cur_pos, offset);
                 }
                 nk_layout_row_dynamic(ctx, 1, 1);
                 nk_rule_horizontal(ctx, nk_white, nk_true);

--- a/demo/common/overview.c
+++ b/demo/common/overview.c
@@ -839,30 +839,86 @@ overview(struct nk_context *ctx)
                 } else popup_active = nk_false;
             }
 
-            /* tooltip */
-            nk_layout_row_static(ctx, 30, 150, 1);
+            /* tooltips */
+            nk_layout_row_static(ctx, 30, 400, 1);
             bounds = nk_widget_bounds(ctx);
-            nk_label(ctx, "Hover for tooltip", NK_TEXT_LEFT);
+            nk_label(ctx, "Hover for default tooltip", NK_TEXT_LEFT);
             if (nk_input_is_mouse_hovering_rect(in, bounds)) {
                 nk_tooltip(ctx, "This is a default tooltip");
             }
             bounds = nk_widget_bounds(ctx);
-            nk_label(ctx, "Chrome-like tooltip", NK_TEXT_LEFT);
-            if (nk_input_is_mouse_hovering_rect(in, bounds)) {
-                struct nk_vec2 offset = { 8, 8 };
-                nk_tooltip_pos_offset(ctx, "Chrome offsets just a bit", NK_TOP_LEFT, offset);
-            }
-            bounds = nk_widget_bounds(ctx);
-            nk_label(ctx, "Gnome-like tooltip", NK_TEXT_LEFT);
+            nk_label(ctx, "Hover for Gnome-like tooltip", NK_TEXT_LEFT);
             if (nk_input_is_mouse_hovering_rect(in, bounds)) {
                 struct nk_vec2 offset = { 0, -15 };
-                nk_tooltip_pos_offset(ctx, "Gnome centers with greater y offset", NK_BOTTOM_MIDDLE, offset);
+                nk_tooltip_pos_offset(ctx, "Gnome bottom centers plus a -y offset", NK_BOTTOM_CENTER, offset);
             }
             bounds = nk_widget_bounds(ctx);
-            nk_label(ctx, "Bottom left tooltip", NK_TEXT_LEFT);
+            nk_label(ctx, "Hover for a bottom left tooltip", NK_TEXT_LEFT);
             if (nk_input_is_mouse_hovering_rect(in, bounds)) {
                 struct nk_vec2 offset = { 0, 0 };
                 nk_tooltip_pos_offset(ctx, "Bottom left positioning", NK_BOTTOM_LEFT, offset);
+            }
+            bounds = nk_widget_bounds(ctx);
+            nk_label(ctx, "Hover for MAGIC!", NK_TEXT_LEFT);
+            if (nk_input_is_mouse_hovering_rect(in, bounds)) {
+                static double accum_time_seconds = 0.0;
+                const double speed = 3.0, radius = 50.0;
+                struct nk_vec2 offset;
+                offset.x = radius * cos(accum_time_seconds * speed);
+                offset.y = radius * sin(accum_time_seconds * speed);
+                nk_tooltip_pos_offset(ctx, "WOW!", NK_MIDDLE_CENTER, offset);
+                accum_time_seconds += (double)(ctx->delta_time_seconds);
+            }
+
+            /* editor for custom tooltip */
+            {
+                static char text_buf[64] = {0};
+                static int text_len = 0;
+                static int text_initialized = 0;
+                static struct nk_vec2 offset = {0};
+                static const char* tooltip_positions[] =
+                {
+                    "TOP_LEFT",
+                    "TOP_CENTER",
+                    "TOP_RIGHT",
+
+                    "MIDDLE_LEFT",
+                    "MIDDLE_CENTER",
+                    "MIDDLE_RIGHT",
+
+                    "BOTTOM_LEFT",
+                    "BOTTOM_CENTER",
+                    "BOTTOM_RIGHT"
+                };
+                static int cur_pos = NK_TOP_LEFT;
+
+                if (!text_initialized) {
+                    const char text_default[] = "you can customize this!";
+                    NK_ASSERT(sizeof(text_default) < sizeof(text_buf));
+                    memcpy(text_buf, text_default, sizeof(text_default));
+                    text_len = sizeof(text_default) - 1;
+                    text_initialized = 1;
+                }
+                bounds = nk_widget_bounds(ctx);
+                nk_label(ctx, "Hover for custom tooltip (you can customize it below)", NK_TEXT_LEFT);
+                if (nk_input_is_mouse_hovering_rect(in, bounds)) {
+                    nk_tooltip_pos_offset(ctx, text_buf, cur_pos, offset);
+                }
+                nk_layout_row_dynamic(ctx, 1, 1);
+                nk_rule_horizontal(ctx, nk_white, nk_true);
+                nk_layout_row_dynamic(ctx, 30, 2);
+                nk_label(ctx, "custom tooltip text:", NK_TEXT_LEFT);
+                nk_edit_string(ctx, NK_EDIT_FIELD, text_buf, &text_len, sizeof(text_buf), nk_filter_default);
+                text_buf[text_len] = '\0';  /* TODO: why nk_edit_string is NOT setting this on its own? */
+                nk_layout_row_dynamic(ctx, 30, 1);
+                cur_pos = nk_combo(ctx, tooltip_positions, NK_LEN(tooltip_positions), cur_pos, 25, nk_vec2(200, 200));
+
+
+                nk_layout_row_dynamic(ctx, 30, 2);
+                nk_label(ctx, "custom tooltip offset", NK_TEXT_LEFT);
+                nk_property_float(ctx, "x", -100.0f, &offset.x, 100.0f, 5.0f, 0.5f);
+                nk_label(ctx, "custom tooltip offset", NK_TEXT_LEFT);
+                nk_property_float(ctx, "y", -100.0f, &offset.y, 100.0f, 5.0f, 0.5f);
             }
 
             nk_tree_pop(ctx);

--- a/nuklear.h
+++ b/nuklear.h
@@ -3832,6 +3832,8 @@ NK_API void nk_tooltip_pos_offset(struct nk_context *ctx, const char *text, enum
 #ifdef NK_INCLUDE_STANDARD_VARARGS
 NK_API void nk_tooltipf(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, ...) NK_PRINTF_VARARG_FUNC(2);
 NK_API void nk_tooltipfv(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(2);
+NK_API void nk_tooltipf_pos_offset(struct nk_context*, enum nk_tooltip_pos, struct nk_vec2, NK_PRINTF_FORMAT_STRING const char*, ...) NK_PRINTF_VARARG_FUNC(4);
+NK_API void nk_tooltipfv_pos_offset(struct nk_context*, enum nk_tooltip_pos, struct nk_vec2, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(4);
 #endif
 NK_API nk_bool nk_tooltip_begin(struct nk_context*, float width);
 NK_API nk_bool nk_tooltip_begin_pos_offset(struct nk_context*, float, enum nk_tooltip_pos, struct nk_vec2);
@@ -30791,12 +30793,27 @@ nk_tooltip(struct nk_context *ctx, const char *text)
 }
 #ifdef NK_INCLUDE_STANDARD_VARARGS
 NK_API void
+nk_tooltipf_pos_offset(struct nk_context *ctx, enum nk_tooltip_pos position, struct nk_vec2 offset, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    nk_tooltipfv_pos_offset(ctx, position, offset, fmt, args);
+    va_end(args);
+}
+NK_API void
 nk_tooltipf(struct nk_context *ctx, const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
     nk_tooltipfv(ctx, fmt, args);
     va_end(args);
+}
+NK_API void
+nk_tooltipfv_pos_offset(struct nk_context *ctx, enum nk_tooltip_pos position, struct nk_vec2 offset, const char *fmt, va_list args)
+{
+    char buf[256];
+    nk_strfmt(buf, NK_LEN(buf), fmt, args);
+    nk_tooltip_pos_offset(ctx, buf, position, offset);
 }
 NK_API void
 nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)

--- a/nuklear.h
+++ b/nuklear.h
@@ -3828,14 +3828,13 @@ NK_API void nk_contextual_end(struct nk_context*);
  *
  * ============================================================================= */
 NK_API void nk_tooltip(struct nk_context*, const char*);
-NK_API void nk_tooltip_positioned(struct nk_context*, const char*, enum nk_tooltip_pos);
-NK_API void nk_tooltip_offset(struct nk_context*, const char*, struct nk_vec2);
+NK_API void nk_tooltip_pos_offset(struct nk_context *ctx, const char *text, enum nk_tooltip_pos position, struct nk_vec2 offset);
 #ifdef NK_INCLUDE_STANDARD_VARARGS
 NK_API void nk_tooltipf(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, ...) NK_PRINTF_VARARG_FUNC(2);
 NK_API void nk_tooltipfv(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(2);
 #endif
 NK_API nk_bool nk_tooltip_begin(struct nk_context*, float width);
-NK_API nk_bool nk_tooltip_begin_offset(struct nk_context*, float, struct nk_vec2);
+NK_API nk_bool nk_tooltip_begin_pos_offset(struct nk_context*, float, enum nk_tooltip_pos, struct nk_vec2);
 NK_API void nk_tooltip_end(struct nk_context*);
 /* =============================================================================
  *
@@ -30637,11 +30636,11 @@ NK_API nk_bool
 nk_tooltip_begin(struct nk_context *ctx, float width)
 {
     struct nk_vec2 offset = {0};
-    return nk_tooltip_begin_offset(ctx, width, offset);
+    return nk_tooltip_begin_pos_offset(ctx, width, NK_TOP_LEFT, offset);
 }
 
 NK_API nk_bool
-nk_tooltip_begin_offset(struct nk_context *ctx, float width, struct nk_vec2 offset)
+nk_tooltip_begin_pos_offset(struct nk_context *ctx, float width, enum nk_tooltip_pos position, struct nk_vec2 offset)
 {
     int x,y,w,h;
     struct nk_window *win;
@@ -30662,14 +30661,43 @@ nk_tooltip_begin_offset(struct nk_context *ctx, float width, struct nk_vec2 offs
         return 0;
 
     w = nk_iceilf(width);
-    h = nk_iceilf(nk_null_rect.h);
+    /* Should I use text_height? Any difference? */
+    h = ctx->current->layout->row.min_height;
+
+    /* Default origin is top left, plus user offset */
     x = nk_ifloorf(in->mouse.pos.x + 1) - (int)win->layout->clip.x + offset.x;
     y = nk_ifloorf(in->mouse.pos.y + 1) - (int)win->layout->clip.y + offset.y;
+
+    /* Adjust origin based on enum */
+    switch (position) {
+    case NK_TOP_LEFT:
+        /* no change */
+        break;
+    case NK_BOTTOM_LEFT:
+        y -= h;
+        break;
+    case NK_TOP_RIGHT:
+        x -= w;
+        break;
+    case NK_BOTTOM_RIGHT:
+        x -= w;
+        y -= h;
+        break;
+    case NK_TOP_MIDDLE:
+        x -= w/2;
+        break;
+    case NK_BOTTOM_MIDDLE:
+        x -= w/2;
+        y -= h;
+        break;
+    default:
+        NK_ASSERT(0 && "Invalid tooltip position");
+    }
 
     bounds.x = (float)x;
     bounds.y = (float)y;
     bounds.w = (float)w;
-    bounds.h = (float)h;
+    bounds.h = (float)nk_iceilf(nk_null_rect.h);
 
     ret = nk_popup_begin(ctx, NK_POPUP_DYNAMIC,
         "__##Tooltip##__", NK_WINDOW_NO_SCROLLBAR|NK_WINDOW_BORDER, bounds);
@@ -30691,7 +30719,7 @@ nk_tooltip_end(struct nk_context *ctx)
 }
 
 NK_API void
-nk_tooltip_offset(struct nk_context *ctx, const char *text, struct nk_vec2 offset)
+nk_tooltip_pos_offset(struct nk_context *ctx, const char *text, enum nk_tooltip_pos position, struct nk_vec2 offset)
 {
     const struct nk_style *style;
     struct nk_vec2 padding;
@@ -30719,80 +30747,7 @@ nk_tooltip_offset(struct nk_context *ctx, const char *text, struct nk_vec2 offse
     text_height = (style->font->height + 2 * padding.y);
 
     /* execute tooltip and fill with text */
-    if (nk_tooltip_begin_offset(ctx, (float)text_width, offset)) {
-        nk_layout_row_dynamic(ctx, (float)text_height, 1);
-        nk_text(ctx, text, text_len, NK_TEXT_LEFT);
-        nk_tooltip_end(ctx);
-    }
-}
-
-NK_API void
-nk_tooltip_positioned(struct nk_context *ctx, const char *text, enum nk_tooltip_pos position)
-{
-    const struct nk_style *style;
-    struct nk_vec2 padding;
-
-    int text_len;
-    float text_width;
-    float text_height;
-
-    struct nk_vec2 offset = { 0 };
-    int w,h;
-
-    NK_ASSERT(ctx);
-    NK_ASSERT(ctx->current);
-    NK_ASSERT(ctx->current->layout);
-    NK_ASSERT(text);
-    if (!ctx || !ctx->current || !ctx->current->layout || !text)
-        return;
-
-    /* fetch configuration data */
-    style = &ctx->style;
-    padding = style->window.padding;
-
-    /* calculate size of the text and tooltip */
-    text_len = nk_strlen(text);
-    text_width = style->font->width(style->font->userdata,
-                    style->font->height, text, text_len);
-    text_width += (4 * padding.x);
-    text_height = (style->font->height + 2 * padding.y);
-
-    /* Should I use text_height? Any difference? */
-    h = ctx->current->layout->row.min_height;
-    w = nk_iceilf(text_width);
-
-    switch (position) {
-    case NK_TOP_LEFT:
-        offset.x = 0;
-        offset.y = 0;
-        break;
-    case NK_BOTTOM_LEFT:
-        offset.x = 0;
-        offset.y = -h;
-        break;
-    case NK_TOP_RIGHT:
-        offset.x = -w;
-        offset.y = 0;
-        break;
-    case NK_BOTTOM_RIGHT:
-        offset.x = -w;
-        offset.y = -h;
-        break;
-    case NK_TOP_MIDDLE:
-        offset.x = -w/2;
-        offset.y = 0;
-        break;
-    case NK_BOTTOM_MIDDLE:
-        offset.x = -w/2;
-        offset.y = -h;
-        break;
-    default:
-        offset.x = 0;
-        offset.y = 0;
-    }
-
-    /* execute tooltip and fill with text */
-    if (nk_tooltip_begin_offset(ctx, (float)text_width, offset)) {
+    if (nk_tooltip_begin_pos_offset(ctx, (float)text_width, position, offset)) {
         nk_layout_row_dynamic(ctx, (float)text_height, 1);
         nk_text(ctx, text, text_len, NK_TEXT_LEFT);
         nk_tooltip_end(ctx);

--- a/nuklear.h
+++ b/nuklear.h
@@ -515,7 +515,20 @@ enum nk_color_format    {NK_RGB, NK_RGBA};
 enum nk_popup_type      {NK_POPUP_STATIC, NK_POPUP_DYNAMIC};
 enum nk_layout_format   {NK_DYNAMIC, NK_STATIC};
 enum nk_tree_type       {NK_TREE_NODE, NK_TREE_TAB};
-enum nk_tooltip_pos     {NK_TOP_LEFT, NK_BOTTOM_LEFT, NK_TOP_RIGHT, NK_BOTTOM_RIGHT, NK_TOP_MIDDLE, NK_BOTTOM_MIDDLE};
+
+enum nk_tooltip_pos {
+    NK_TOP_LEFT,
+    NK_TOP_CENTER,
+    NK_TOP_RIGHT,
+
+    NK_MIDDLE_LEFT,
+    NK_MIDDLE_CENTER,
+    NK_MIDDLE_RIGHT,
+
+    NK_BOTTOM_LEFT,
+    NK_BOTTOM_CENTER,
+    NK_BOTTOM_RIGHT
+};
 
 typedef void*(*nk_plugin_alloc)(nk_handle, void *old, nk_size);
 typedef void (*nk_plugin_free)(nk_handle, void *old);
@@ -30675,21 +30688,34 @@ nk_tooltip_begin_pos_offset(struct nk_context *ctx, float width, enum nk_tooltip
     case NK_TOP_LEFT:
         /* no change */
         break;
-    case NK_BOTTOM_LEFT:
-        y -= h;
+    case NK_TOP_CENTER:
+        x -= w/2;
         break;
     case NK_TOP_RIGHT:
         x -= w;
         break;
-    case NK_BOTTOM_RIGHT:
+
+    case NK_MIDDLE_LEFT:
+        y -= h/2;
+        break;
+    case NK_MIDDLE_CENTER:
+        x -= w/2;
+        y -= h/2;
+        break;
+    case NK_MIDDLE_RIGHT:
         x -= w;
+        y -= h/2;
+        break;
+
+    case NK_BOTTOM_LEFT:
         y -= h;
         break;
-    case NK_TOP_MIDDLE:
+    case NK_BOTTOM_CENTER:
         x -= w/2;
+        y -= h;
         break;
-    case NK_BOTTOM_MIDDLE:
-        x -= w/2;
+    case NK_BOTTOM_RIGHT:
+        x -= w;
         y -= h;
         break;
     default:
@@ -30759,37 +30785,8 @@ nk_tooltip_pos_offset(struct nk_context *ctx, const char *text, enum nk_tooltip_
 NK_API void
 nk_tooltip(struct nk_context *ctx, const char *text)
 {
-    const struct nk_style *style;
-    struct nk_vec2 padding;
-
-    int text_len;
-    float text_width;
-    float text_height;
-
-    NK_ASSERT(ctx);
-    NK_ASSERT(ctx->current);
-    NK_ASSERT(ctx->current->layout);
-    NK_ASSERT(text);
-    if (!ctx || !ctx->current || !ctx->current->layout || !text)
-        return;
-
-    /* fetch configuration data */
-    style = &ctx->style;
-    padding = style->window.padding;
-
-    /* calculate size of the text and tooltip */
-    text_len = nk_strlen(text);
-    text_width = style->font->width(style->font->userdata,
-                    style->font->height, text, text_len);
-    text_width += (4 * padding.x);
-    text_height = (style->font->height + 2 * padding.y);
-
-    /* execute tooltip and fill with text */
-    if (nk_tooltip_begin(ctx, (float)text_width)) {
-        nk_layout_row_dynamic(ctx, (float)text_height, 1);
-        nk_text(ctx, text, text_len, NK_TEXT_LEFT);
-        nk_tooltip_end(ctx);
-    }
+    struct nk_vec2 offset = { 12, 12 };
+    nk_tooltip_pos_offset(ctx, text, NK_TOP_LEFT, offset);
 }
 #ifdef NK_INCLUDE_STANDARD_VARARGS
 NK_API void

--- a/nuklear.h
+++ b/nuklear.h
@@ -515,6 +515,7 @@ enum nk_color_format    {NK_RGB, NK_RGBA};
 enum nk_popup_type      {NK_POPUP_STATIC, NK_POPUP_DYNAMIC};
 enum nk_layout_format   {NK_DYNAMIC, NK_STATIC};
 enum nk_tree_type       {NK_TREE_NODE, NK_TREE_TAB};
+enum nk_tooltip_pos     {NK_TOP_LEFT, NK_BOTTOM_LEFT, NK_TOP_RIGHT, NK_BOTTOM_RIGHT};
 
 typedef void*(*nk_plugin_alloc)(nk_handle, void *old, nk_size);
 typedef void (*nk_plugin_free)(nk_handle, void *old);
@@ -3827,11 +3828,12 @@ NK_API void nk_contextual_end(struct nk_context*);
  *
  * ============================================================================= */
 NK_API void nk_tooltip(struct nk_context*, const char*);
+NK_API void nk_tooltip_positioned(struct nk_context*, const char*, enum nk_tooltip_pos);
 #ifdef NK_INCLUDE_STANDARD_VARARGS
 NK_API void nk_tooltipf(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, ...) NK_PRINTF_VARARG_FUNC(2);
 NK_API void nk_tooltipfv(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(2);
 #endif
-NK_API nk_bool nk_tooltip_begin(struct nk_context*, float width);
+NK_API nk_bool nk_tooltip_begin(struct nk_context*, float width, enum nk_tooltip_pos);
 NK_API void nk_tooltip_end(struct nk_context*);
 /* =============================================================================
  *
@@ -30630,7 +30632,7 @@ nk_combobox_callback(struct nk_context *ctx,
  *
  * ===============================================================*/
 NK_API nk_bool
-nk_tooltip_begin(struct nk_context *ctx, float width)
+nk_tooltip_begin(struct nk_context *ctx, float width, enum nk_tooltip_pos position)
 {
     int x,y,w,h;
     struct nk_window *win;
@@ -30652,8 +30654,28 @@ nk_tooltip_begin(struct nk_context *ctx, float width)
 
     w = nk_iceilf(width);
     h = nk_iceilf(nk_null_rect.h);
-    x = nk_ifloorf(in->mouse.pos.x + 1) - (int)win->layout->clip.x;
-    y = nk_ifloorf(in->mouse.pos.y + 1) - (int)win->layout->clip.y;
+    switch (position) {
+    case NK_TOP_LEFT:
+        x = nk_ifloorf(in->mouse.pos.x + 1) - (int)win->layout->clip.x;
+        y = nk_ifloorf(in->mouse.pos.y + 1) - (int)win->layout->clip.y;
+        break;
+    case NK_BOTTOM_LEFT:
+        x = nk_ifloorf(in->mouse.pos.x + 1) - (int)win->layout->clip.x;
+        y = nk_ifloorf(in->mouse.pos.y + 1) - (int)win->layout->clip.y - win->layout->row.min_height;
+        break;
+    case NK_TOP_RIGHT:
+        x = nk_ifloorf(in->mouse.pos.x + 1) - (int)win->layout->clip.x - w;
+        y = nk_ifloorf(in->mouse.pos.y + 1) - (int)win->layout->clip.y;
+        break;
+    case NK_BOTTOM_RIGHT:
+        x = nk_ifloorf(in->mouse.pos.x + 1) - (int)win->layout->clip.x - w;
+        y = nk_ifloorf(in->mouse.pos.y + 1) - (int)win->layout->clip.y - win->layout->row.min_height;
+        break;
+    default:
+        /* NK_ASSERT(0 && "unknown tooltip position enum"); */
+        x = nk_ifloorf(in->mouse.pos.x + 1) - (int)win->layout->clip.x;
+        y = nk_ifloorf(in->mouse.pos.y + 1) - (int)win->layout->clip.y;
+    }
 
     bounds.x = (float)x;
     bounds.y = (float)y;
@@ -30678,6 +30700,43 @@ nk_tooltip_end(struct nk_context *ctx)
     nk_popup_close(ctx);
     nk_popup_end(ctx);
 }
+
+NK_API void
+nk_tooltip_positioned(struct nk_context *ctx, const char *text, enum nk_tooltip_pos position)
+{
+    const struct nk_style *style;
+    struct nk_vec2 padding;
+
+    int text_len;
+    float text_width;
+    float text_height;
+
+    NK_ASSERT(ctx);
+    NK_ASSERT(ctx->current);
+    NK_ASSERT(ctx->current->layout);
+    NK_ASSERT(text);
+    if (!ctx || !ctx->current || !ctx->current->layout || !text)
+        return;
+
+    /* fetch configuration data */
+    style = &ctx->style;
+    padding = style->window.padding;
+
+    /* calculate size of the text and tooltip */
+    text_len = nk_strlen(text);
+    text_width = style->font->width(style->font->userdata,
+                    style->font->height, text, text_len);
+    text_width += (4 * padding.x);
+    text_height = (style->font->height + 2 * padding.y);
+
+    /* execute tooltip and fill with text */
+    if (nk_tooltip_begin(ctx, (float)text_width, position)) {
+        nk_layout_row_dynamic(ctx, (float)text_height, 1);
+        nk_text(ctx, text, text_len, NK_TEXT_LEFT);
+        nk_tooltip_end(ctx);
+    }
+}
+
 NK_API void
 nk_tooltip(struct nk_context *ctx, const char *text)
 {
@@ -30707,7 +30766,7 @@ nk_tooltip(struct nk_context *ctx, const char *text)
     text_height = (style->font->height + 2 * padding.y);
 
     /* execute tooltip and fill with text */
-    if (nk_tooltip_begin(ctx, (float)text_width)) {
+    if (nk_tooltip_begin(ctx, (float)text_width, NK_TOP_LEFT)) {
         nk_layout_row_dynamic(ctx, (float)text_height, 1);
         nk_text(ctx, text, text_len, NK_TEXT_LEFT);
         nk_tooltip_end(ctx);

--- a/nuklear.h
+++ b/nuklear.h
@@ -515,7 +515,7 @@ enum nk_color_format    {NK_RGB, NK_RGBA};
 enum nk_popup_type      {NK_POPUP_STATIC, NK_POPUP_DYNAMIC};
 enum nk_layout_format   {NK_DYNAMIC, NK_STATIC};
 enum nk_tree_type       {NK_TREE_NODE, NK_TREE_TAB};
-enum nk_tooltip_pos     {NK_TOP_LEFT, NK_BOTTOM_LEFT, NK_TOP_RIGHT, NK_BOTTOM_RIGHT};
+enum nk_tooltip_pos     {NK_TOP_LEFT, NK_BOTTOM_LEFT, NK_TOP_RIGHT, NK_BOTTOM_RIGHT, NK_TOP_MIDDLE, NK_BOTTOM_MIDDLE};
 
 typedef void*(*nk_plugin_alloc)(nk_handle, void *old, nk_size);
 typedef void (*nk_plugin_free)(nk_handle, void *old);
@@ -3829,11 +3829,13 @@ NK_API void nk_contextual_end(struct nk_context*);
  * ============================================================================= */
 NK_API void nk_tooltip(struct nk_context*, const char*);
 NK_API void nk_tooltip_positioned(struct nk_context*, const char*, enum nk_tooltip_pos);
+NK_API void nk_tooltip_offset(struct nk_context*, const char*, struct nk_vec2);
 #ifdef NK_INCLUDE_STANDARD_VARARGS
 NK_API void nk_tooltipf(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, ...) NK_PRINTF_VARARG_FUNC(2);
 NK_API void nk_tooltipfv(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(2);
 #endif
-NK_API nk_bool nk_tooltip_begin(struct nk_context*, float width, enum nk_tooltip_pos);
+NK_API nk_bool nk_tooltip_begin(struct nk_context*, float width);
+NK_API nk_bool nk_tooltip_begin_offset(struct nk_context*, float, struct nk_vec2);
 NK_API void nk_tooltip_end(struct nk_context*);
 /* =============================================================================
  *
@@ -30632,7 +30634,14 @@ nk_combobox_callback(struct nk_context *ctx,
  *
  * ===============================================================*/
 NK_API nk_bool
-nk_tooltip_begin(struct nk_context *ctx, float width, enum nk_tooltip_pos position)
+nk_tooltip_begin(struct nk_context *ctx, float width)
+{
+    struct nk_vec2 offset = {0};
+    return nk_tooltip_begin_offset(ctx, width, offset);
+}
+
+NK_API nk_bool
+nk_tooltip_begin_offset(struct nk_context *ctx, float width, struct nk_vec2 offset)
 {
     int x,y,w,h;
     struct nk_window *win;
@@ -30654,28 +30663,8 @@ nk_tooltip_begin(struct nk_context *ctx, float width, enum nk_tooltip_pos positi
 
     w = nk_iceilf(width);
     h = nk_iceilf(nk_null_rect.h);
-    switch (position) {
-    case NK_TOP_LEFT:
-        x = nk_ifloorf(in->mouse.pos.x + 1) - (int)win->layout->clip.x;
-        y = nk_ifloorf(in->mouse.pos.y + 1) - (int)win->layout->clip.y;
-        break;
-    case NK_BOTTOM_LEFT:
-        x = nk_ifloorf(in->mouse.pos.x + 1) - (int)win->layout->clip.x;
-        y = nk_ifloorf(in->mouse.pos.y + 1) - (int)win->layout->clip.y - win->layout->row.min_height;
-        break;
-    case NK_TOP_RIGHT:
-        x = nk_ifloorf(in->mouse.pos.x + 1) - (int)win->layout->clip.x - w;
-        y = nk_ifloorf(in->mouse.pos.y + 1) - (int)win->layout->clip.y;
-        break;
-    case NK_BOTTOM_RIGHT:
-        x = nk_ifloorf(in->mouse.pos.x + 1) - (int)win->layout->clip.x - w;
-        y = nk_ifloorf(in->mouse.pos.y + 1) - (int)win->layout->clip.y - win->layout->row.min_height;
-        break;
-    default:
-        /* NK_ASSERT(0 && "unknown tooltip position enum"); */
-        x = nk_ifloorf(in->mouse.pos.x + 1) - (int)win->layout->clip.x;
-        y = nk_ifloorf(in->mouse.pos.y + 1) - (int)win->layout->clip.y;
-    }
+    x = nk_ifloorf(in->mouse.pos.x + 1) - (int)win->layout->clip.x + offset.x;
+    y = nk_ifloorf(in->mouse.pos.y + 1) - (int)win->layout->clip.y + offset.y;
 
     bounds.x = (float)x;
     bounds.y = (float)y;
@@ -30702,7 +30691,7 @@ nk_tooltip_end(struct nk_context *ctx)
 }
 
 NK_API void
-nk_tooltip_positioned(struct nk_context *ctx, const char *text, enum nk_tooltip_pos position)
+nk_tooltip_offset(struct nk_context *ctx, const char *text, struct nk_vec2 offset)
 {
     const struct nk_style *style;
     struct nk_vec2 padding;
@@ -30730,7 +30719,80 @@ nk_tooltip_positioned(struct nk_context *ctx, const char *text, enum nk_tooltip_
     text_height = (style->font->height + 2 * padding.y);
 
     /* execute tooltip and fill with text */
-    if (nk_tooltip_begin(ctx, (float)text_width, position)) {
+    if (nk_tooltip_begin_offset(ctx, (float)text_width, offset)) {
+        nk_layout_row_dynamic(ctx, (float)text_height, 1);
+        nk_text(ctx, text, text_len, NK_TEXT_LEFT);
+        nk_tooltip_end(ctx);
+    }
+}
+
+NK_API void
+nk_tooltip_positioned(struct nk_context *ctx, const char *text, enum nk_tooltip_pos position)
+{
+    const struct nk_style *style;
+    struct nk_vec2 padding;
+
+    int text_len;
+    float text_width;
+    float text_height;
+
+    struct nk_vec2 offset = { 0 };
+    int w,h;
+
+    NK_ASSERT(ctx);
+    NK_ASSERT(ctx->current);
+    NK_ASSERT(ctx->current->layout);
+    NK_ASSERT(text);
+    if (!ctx || !ctx->current || !ctx->current->layout || !text)
+        return;
+
+    /* fetch configuration data */
+    style = &ctx->style;
+    padding = style->window.padding;
+
+    /* calculate size of the text and tooltip */
+    text_len = nk_strlen(text);
+    text_width = style->font->width(style->font->userdata,
+                    style->font->height, text, text_len);
+    text_width += (4 * padding.x);
+    text_height = (style->font->height + 2 * padding.y);
+
+    /* Should I use text_height? Any difference? */
+    h = ctx->current->layout->row.min_height;
+    w = nk_iceilf(text_width);
+
+    switch (position) {
+    case NK_TOP_LEFT:
+        offset.x = 0;
+        offset.y = 0;
+        break;
+    case NK_BOTTOM_LEFT:
+        offset.x = 0;
+        offset.y = -h;
+        break;
+    case NK_TOP_RIGHT:
+        offset.x = -w;
+        offset.y = 0;
+        break;
+    case NK_BOTTOM_RIGHT:
+        offset.x = -w;
+        offset.y = -h;
+        break;
+    case NK_TOP_MIDDLE:
+        offset.x = -w/2;
+        offset.y = 0;
+        break;
+    case NK_BOTTOM_MIDDLE:
+        offset.x = -w/2;
+        offset.y = -h;
+        break;
+    default:
+        offset.x = 0;
+        offset.y = 0;
+    }
+
+    /* execute tooltip and fill with text */
+    if (nk_tooltip_begin_offset(ctx, (float)text_width, offset)) {
         nk_layout_row_dynamic(ctx, (float)text_height, 1);
         nk_text(ctx, text, text_len, NK_TEXT_LEFT);
         nk_tooltip_end(ctx);
@@ -30766,7 +30828,7 @@ nk_tooltip(struct nk_context *ctx, const char *text)
     text_height = (style->font->height + 2 * padding.y);
 
     /* execute tooltip and fill with text */
-    if (nk_tooltip_begin(ctx, (float)text_width, NK_TOP_LEFT)) {
+    if (nk_tooltip_begin(ctx, (float)text_width)) {
         nk_layout_row_dynamic(ctx, (float)text_height, 1);
         nk_text(ctx, text, text_len, NK_TEXT_LEFT);
         nk_tooltip_end(ctx);

--- a/nuklear.h
+++ b/nuklear.h
@@ -3841,15 +3841,15 @@ NK_API void nk_contextual_end(struct nk_context*);
  *
  * ============================================================================= */
 NK_API void nk_tooltip(struct nk_context*, const char*);
-NK_API void nk_tooltip_pos_offset(struct nk_context *ctx, const char *text, enum nk_tooltip_pos position, struct nk_vec2 offset);
+NK_API void nk_tooltip_offset(struct nk_context *ctx, const char *text, enum nk_tooltip_pos position, struct nk_vec2 offset);
 #ifdef NK_INCLUDE_STANDARD_VARARGS
 NK_API void nk_tooltipf(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, ...) NK_PRINTF_VARARG_FUNC(2);
 NK_API void nk_tooltipfv(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(2);
-NK_API void nk_tooltipf_pos_offset(struct nk_context*, enum nk_tooltip_pos, struct nk_vec2, NK_PRINTF_FORMAT_STRING const char*, ...) NK_PRINTF_VARARG_FUNC(4);
-NK_API void nk_tooltipfv_pos_offset(struct nk_context*, enum nk_tooltip_pos, struct nk_vec2, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(4);
+NK_API void nk_tooltipf_offset(struct nk_context*, enum nk_tooltip_pos, struct nk_vec2, NK_PRINTF_FORMAT_STRING const char*, ...) NK_PRINTF_VARARG_FUNC(4);
+NK_API void nk_tooltipfv_offset(struct nk_context*, enum nk_tooltip_pos, struct nk_vec2, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(4);
 #endif
 NK_API nk_bool nk_tooltip_begin(struct nk_context*, float width);
-NK_API nk_bool nk_tooltip_begin_pos_offset(struct nk_context*, float, enum nk_tooltip_pos, struct nk_vec2);
+NK_API nk_bool nk_tooltip_begin_offset(struct nk_context*, float, enum nk_tooltip_pos, struct nk_vec2);
 NK_API void nk_tooltip_end(struct nk_context*);
 /* =============================================================================
  *
@@ -30651,11 +30651,11 @@ NK_API nk_bool
 nk_tooltip_begin(struct nk_context *ctx, float width)
 {
     struct nk_vec2 offset = {0};
-    return nk_tooltip_begin_pos_offset(ctx, width, NK_TOP_LEFT, offset);
+    return nk_tooltip_begin_offset(ctx, width, NK_TOP_LEFT, offset);
 }
 
 NK_API nk_bool
-nk_tooltip_begin_pos_offset(struct nk_context *ctx, float width, enum nk_tooltip_pos position, struct nk_vec2 offset)
+nk_tooltip_begin_offset(struct nk_context *ctx, float width, enum nk_tooltip_pos position, struct nk_vec2 offset)
 {
     int x,y,w,h;
     struct nk_window *win;
@@ -30747,7 +30747,7 @@ nk_tooltip_end(struct nk_context *ctx)
 }
 
 NK_API void
-nk_tooltip_pos_offset(struct nk_context *ctx, const char *text, enum nk_tooltip_pos position, struct nk_vec2 offset)
+nk_tooltip_offset(struct nk_context *ctx, const char *text, enum nk_tooltip_pos position, struct nk_vec2 offset)
 {
     const struct nk_style *style;
     struct nk_vec2 padding;
@@ -30775,7 +30775,7 @@ nk_tooltip_pos_offset(struct nk_context *ctx, const char *text, enum nk_tooltip_
     text_height = (style->font->height + 2 * padding.y);
 
     /* execute tooltip and fill with text */
-    if (nk_tooltip_begin_pos_offset(ctx, (float)text_width, position, offset)) {
+    if (nk_tooltip_begin_offset(ctx, (float)text_width, position, offset)) {
         nk_layout_row_dynamic(ctx, (float)text_height, 1);
         nk_text(ctx, text, text_len, NK_TEXT_LEFT);
         nk_tooltip_end(ctx);
@@ -30786,15 +30786,15 @@ NK_API void
 nk_tooltip(struct nk_context *ctx, const char *text)
 {
     struct nk_vec2 offset = { 12, 12 };
-    nk_tooltip_pos_offset(ctx, text, NK_TOP_LEFT, offset);
+    nk_tooltip_offset(ctx, text, NK_TOP_LEFT, offset);
 }
 #ifdef NK_INCLUDE_STANDARD_VARARGS
 NK_API void
-nk_tooltipf_pos_offset(struct nk_context *ctx, enum nk_tooltip_pos position, struct nk_vec2 offset, const char *fmt, ...)
+nk_tooltipf_offset(struct nk_context *ctx, enum nk_tooltip_pos position, struct nk_vec2 offset, const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    nk_tooltipfv_pos_offset(ctx, position, offset, fmt, args);
+    nk_tooltipfv_offset(ctx, position, offset, fmt, args);
     va_end(args);
 }
 NK_API void
@@ -30806,11 +30806,11 @@ nk_tooltipf(struct nk_context *ctx, const char *fmt, ...)
     va_end(args);
 }
 NK_API void
-nk_tooltipfv_pos_offset(struct nk_context *ctx, enum nk_tooltip_pos position, struct nk_vec2 offset, const char *fmt, va_list args)
+nk_tooltipfv_offset(struct nk_context *ctx, enum nk_tooltip_pos position, struct nk_vec2 offset, const char *fmt, va_list args)
 {
     char buf[256];
     nk_strfmt(buf, NK_LEN(buf), fmt, args);
-    nk_tooltip_pos_offset(ctx, buf, position, offset);
+    nk_tooltip_offset(ctx, buf, position, offset);
 }
 NK_API void
 nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -292,6 +292,7 @@ enum nk_color_format    {NK_RGB, NK_RGBA};
 enum nk_popup_type      {NK_POPUP_STATIC, NK_POPUP_DYNAMIC};
 enum nk_layout_format   {NK_DYNAMIC, NK_STATIC};
 enum nk_tree_type       {NK_TREE_NODE, NK_TREE_TAB};
+enum nk_tooltip_pos     {NK_TOP_LEFT, NK_BOTTOM_LEFT, NK_TOP_RIGHT, NK_BOTTOM_RIGHT};
 
 typedef void*(*nk_plugin_alloc)(nk_handle, void *old, nk_size);
 typedef void (*nk_plugin_free)(nk_handle, void *old);
@@ -3604,11 +3605,12 @@ NK_API void nk_contextual_end(struct nk_context*);
  *
  * ============================================================================= */
 NK_API void nk_tooltip(struct nk_context*, const char*);
+NK_API void nk_tooltip_positioned(struct nk_context*, const char*, enum nk_tooltip_pos);
 #ifdef NK_INCLUDE_STANDARD_VARARGS
 NK_API void nk_tooltipf(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, ...) NK_PRINTF_VARARG_FUNC(2);
 NK_API void nk_tooltipfv(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(2);
 #endif
-NK_API nk_bool nk_tooltip_begin(struct nk_context*, float width);
+NK_API nk_bool nk_tooltip_begin(struct nk_context*, float width, enum nk_tooltip_pos);
 NK_API void nk_tooltip_end(struct nk_context*);
 /* =============================================================================
  *

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -292,7 +292,7 @@ enum nk_color_format    {NK_RGB, NK_RGBA};
 enum nk_popup_type      {NK_POPUP_STATIC, NK_POPUP_DYNAMIC};
 enum nk_layout_format   {NK_DYNAMIC, NK_STATIC};
 enum nk_tree_type       {NK_TREE_NODE, NK_TREE_TAB};
-enum nk_tooltip_pos     {NK_TOP_LEFT, NK_BOTTOM_LEFT, NK_TOP_RIGHT, NK_BOTTOM_RIGHT};
+enum nk_tooltip_pos     {NK_TOP_LEFT, NK_BOTTOM_LEFT, NK_TOP_RIGHT, NK_BOTTOM_RIGHT, NK_TOP_MIDDLE, NK_BOTTOM_MIDDLE};
 
 typedef void*(*nk_plugin_alloc)(nk_handle, void *old, nk_size);
 typedef void (*nk_plugin_free)(nk_handle, void *old);
@@ -3606,11 +3606,13 @@ NK_API void nk_contextual_end(struct nk_context*);
  * ============================================================================= */
 NK_API void nk_tooltip(struct nk_context*, const char*);
 NK_API void nk_tooltip_positioned(struct nk_context*, const char*, enum nk_tooltip_pos);
+NK_API void nk_tooltip_offset(struct nk_context*, const char*, struct nk_vec2);
 #ifdef NK_INCLUDE_STANDARD_VARARGS
 NK_API void nk_tooltipf(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, ...) NK_PRINTF_VARARG_FUNC(2);
 NK_API void nk_tooltipfv(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(2);
 #endif
-NK_API nk_bool nk_tooltip_begin(struct nk_context*, float width, enum nk_tooltip_pos);
+NK_API nk_bool nk_tooltip_begin(struct nk_context*, float width);
+NK_API nk_bool nk_tooltip_begin_offset(struct nk_context*, float, struct nk_vec2);
 NK_API void nk_tooltip_end(struct nk_context*);
 /* =============================================================================
  *

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -3605,14 +3605,13 @@ NK_API void nk_contextual_end(struct nk_context*);
  *
  * ============================================================================= */
 NK_API void nk_tooltip(struct nk_context*, const char*);
-NK_API void nk_tooltip_positioned(struct nk_context*, const char*, enum nk_tooltip_pos);
-NK_API void nk_tooltip_offset(struct nk_context*, const char*, struct nk_vec2);
+NK_API void nk_tooltip_pos_offset(struct nk_context *ctx, const char *text, enum nk_tooltip_pos position, struct nk_vec2 offset);
 #ifdef NK_INCLUDE_STANDARD_VARARGS
 NK_API void nk_tooltipf(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, ...) NK_PRINTF_VARARG_FUNC(2);
 NK_API void nk_tooltipfv(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(2);
 #endif
 NK_API nk_bool nk_tooltip_begin(struct nk_context*, float width);
-NK_API nk_bool nk_tooltip_begin_offset(struct nk_context*, float, struct nk_vec2);
+NK_API nk_bool nk_tooltip_begin_pos_offset(struct nk_context*, float, enum nk_tooltip_pos, struct nk_vec2);
 NK_API void nk_tooltip_end(struct nk_context*);
 /* =============================================================================
  *

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -3609,6 +3609,8 @@ NK_API void nk_tooltip_pos_offset(struct nk_context *ctx, const char *text, enum
 #ifdef NK_INCLUDE_STANDARD_VARARGS
 NK_API void nk_tooltipf(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, ...) NK_PRINTF_VARARG_FUNC(2);
 NK_API void nk_tooltipfv(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(2);
+NK_API void nk_tooltipf_pos_offset(struct nk_context*, enum nk_tooltip_pos, struct nk_vec2, NK_PRINTF_FORMAT_STRING const char*, ...) NK_PRINTF_VARARG_FUNC(4);
+NK_API void nk_tooltipfv_pos_offset(struct nk_context*, enum nk_tooltip_pos, struct nk_vec2, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(4);
 #endif
 NK_API nk_bool nk_tooltip_begin(struct nk_context*, float width);
 NK_API nk_bool nk_tooltip_begin_pos_offset(struct nk_context*, float, enum nk_tooltip_pos, struct nk_vec2);

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -3618,15 +3618,15 @@ NK_API void nk_contextual_end(struct nk_context*);
  *
  * ============================================================================= */
 NK_API void nk_tooltip(struct nk_context*, const char*);
-NK_API void nk_tooltip_pos_offset(struct nk_context *ctx, const char *text, enum nk_tooltip_pos position, struct nk_vec2 offset);
+NK_API void nk_tooltip_offset(struct nk_context *ctx, const char *text, enum nk_tooltip_pos position, struct nk_vec2 offset);
 #ifdef NK_INCLUDE_STANDARD_VARARGS
 NK_API void nk_tooltipf(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, ...) NK_PRINTF_VARARG_FUNC(2);
 NK_API void nk_tooltipfv(struct nk_context*, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(2);
-NK_API void nk_tooltipf_pos_offset(struct nk_context*, enum nk_tooltip_pos, struct nk_vec2, NK_PRINTF_FORMAT_STRING const char*, ...) NK_PRINTF_VARARG_FUNC(4);
-NK_API void nk_tooltipfv_pos_offset(struct nk_context*, enum nk_tooltip_pos, struct nk_vec2, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(4);
+NK_API void nk_tooltipf_offset(struct nk_context*, enum nk_tooltip_pos, struct nk_vec2, NK_PRINTF_FORMAT_STRING const char*, ...) NK_PRINTF_VARARG_FUNC(4);
+NK_API void nk_tooltipfv_offset(struct nk_context*, enum nk_tooltip_pos, struct nk_vec2, NK_PRINTF_FORMAT_STRING const char*, va_list) NK_PRINTF_VALIST_FUNC(4);
 #endif
 NK_API nk_bool nk_tooltip_begin(struct nk_context*, float width);
-NK_API nk_bool nk_tooltip_begin_pos_offset(struct nk_context*, float, enum nk_tooltip_pos, struct nk_vec2);
+NK_API nk_bool nk_tooltip_begin_offset(struct nk_context*, float, enum nk_tooltip_pos, struct nk_vec2);
 NK_API void nk_tooltip_end(struct nk_context*);
 /* =============================================================================
  *

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -292,7 +292,20 @@ enum nk_color_format    {NK_RGB, NK_RGBA};
 enum nk_popup_type      {NK_POPUP_STATIC, NK_POPUP_DYNAMIC};
 enum nk_layout_format   {NK_DYNAMIC, NK_STATIC};
 enum nk_tree_type       {NK_TREE_NODE, NK_TREE_TAB};
-enum nk_tooltip_pos     {NK_TOP_LEFT, NK_BOTTOM_LEFT, NK_TOP_RIGHT, NK_BOTTOM_RIGHT, NK_TOP_MIDDLE, NK_BOTTOM_MIDDLE};
+
+enum nk_tooltip_pos {
+    NK_TOP_LEFT,
+    NK_TOP_CENTER,
+    NK_TOP_RIGHT,
+
+    NK_MIDDLE_LEFT,
+    NK_MIDDLE_CENTER,
+    NK_MIDDLE_RIGHT,
+
+    NK_BOTTOM_LEFT,
+    NK_BOTTOM_CENTER,
+    NK_BOTTOM_RIGHT
+};
 
 typedef void*(*nk_plugin_alloc)(nk_handle, void *old, nk_size);
 typedef void (*nk_plugin_free)(nk_handle, void *old);

--- a/src/nuklear_tooltip.c
+++ b/src/nuklear_tooltip.c
@@ -165,12 +165,27 @@ nk_tooltip(struct nk_context *ctx, const char *text)
 }
 #ifdef NK_INCLUDE_STANDARD_VARARGS
 NK_API void
+nk_tooltipf_pos_offset(struct nk_context *ctx, enum nk_tooltip_pos position, struct nk_vec2 offset, const char *fmt, ...)
+{
+    va_list args;
+    va_start(args, fmt);
+    nk_tooltipfv_pos_offset(ctx, position, offset, fmt, args);
+    va_end(args);
+}
+NK_API void
 nk_tooltipf(struct nk_context *ctx, const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
     nk_tooltipfv(ctx, fmt, args);
     va_end(args);
+}
+NK_API void
+nk_tooltipfv_pos_offset(struct nk_context *ctx, enum nk_tooltip_pos position, struct nk_vec2 offset, const char *fmt, va_list args)
+{
+    char buf[256];
+    nk_strfmt(buf, NK_LEN(buf), fmt, args);
+    nk_tooltip_pos_offset(ctx, buf, position, offset);
 }
 NK_API void
 nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)

--- a/src/nuklear_tooltip.c
+++ b/src/nuklear_tooltip.c
@@ -7,7 +7,14 @@
  *
  * ===============================================================*/
 NK_API nk_bool
-nk_tooltip_begin(struct nk_context *ctx, float width, enum nk_tooltip_pos position)
+nk_tooltip_begin(struct nk_context *ctx, float width)
+{
+    struct nk_vec2 offset = {0};
+    return nk_tooltip_begin_offset(ctx, width, offset);
+}
+
+NK_API nk_bool
+nk_tooltip_begin_offset(struct nk_context *ctx, float width, struct nk_vec2 offset)
 {
     int x,y,w,h;
     struct nk_window *win;
@@ -29,28 +36,8 @@ nk_tooltip_begin(struct nk_context *ctx, float width, enum nk_tooltip_pos positi
 
     w = nk_iceilf(width);
     h = nk_iceilf(nk_null_rect.h);
-    switch (position) {
-    case NK_TOP_LEFT:
-        x = nk_ifloorf(in->mouse.pos.x + 1) - (int)win->layout->clip.x;
-        y = nk_ifloorf(in->mouse.pos.y + 1) - (int)win->layout->clip.y;
-        break;
-    case NK_BOTTOM_LEFT:
-        x = nk_ifloorf(in->mouse.pos.x + 1) - (int)win->layout->clip.x;
-        y = nk_ifloorf(in->mouse.pos.y + 1) - (int)win->layout->clip.y - win->layout->row.min_height;
-        break;
-    case NK_TOP_RIGHT:
-        x = nk_ifloorf(in->mouse.pos.x + 1) - (int)win->layout->clip.x - w;
-        y = nk_ifloorf(in->mouse.pos.y + 1) - (int)win->layout->clip.y;
-        break;
-    case NK_BOTTOM_RIGHT:
-        x = nk_ifloorf(in->mouse.pos.x + 1) - (int)win->layout->clip.x - w;
-        y = nk_ifloorf(in->mouse.pos.y + 1) - (int)win->layout->clip.y - win->layout->row.min_height;
-        break;
-    default:
-        /* NK_ASSERT(0 && "unknown tooltip position enum"); */
-        x = nk_ifloorf(in->mouse.pos.x + 1) - (int)win->layout->clip.x;
-        y = nk_ifloorf(in->mouse.pos.y + 1) - (int)win->layout->clip.y;
-    }
+    x = nk_ifloorf(in->mouse.pos.x + 1) - (int)win->layout->clip.x + offset.x;
+    y = nk_ifloorf(in->mouse.pos.y + 1) - (int)win->layout->clip.y + offset.y;
 
     bounds.x = (float)x;
     bounds.y = (float)y;
@@ -77,7 +64,7 @@ nk_tooltip_end(struct nk_context *ctx)
 }
 
 NK_API void
-nk_tooltip_positioned(struct nk_context *ctx, const char *text, enum nk_tooltip_pos position)
+nk_tooltip_offset(struct nk_context *ctx, const char *text, struct nk_vec2 offset)
 {
     const struct nk_style *style;
     struct nk_vec2 padding;
@@ -105,7 +92,80 @@ nk_tooltip_positioned(struct nk_context *ctx, const char *text, enum nk_tooltip_
     text_height = (style->font->height + 2 * padding.y);
 
     /* execute tooltip and fill with text */
-    if (nk_tooltip_begin(ctx, (float)text_width, position)) {
+    if (nk_tooltip_begin_offset(ctx, (float)text_width, offset)) {
+        nk_layout_row_dynamic(ctx, (float)text_height, 1);
+        nk_text(ctx, text, text_len, NK_TEXT_LEFT);
+        nk_tooltip_end(ctx);
+    }
+}
+
+NK_API void
+nk_tooltip_positioned(struct nk_context *ctx, const char *text, enum nk_tooltip_pos position)
+{
+    const struct nk_style *style;
+    struct nk_vec2 padding;
+
+    int text_len;
+    float text_width;
+    float text_height;
+
+    struct nk_vec2 offset = { 0 };
+    int w,h;
+
+    NK_ASSERT(ctx);
+    NK_ASSERT(ctx->current);
+    NK_ASSERT(ctx->current->layout);
+    NK_ASSERT(text);
+    if (!ctx || !ctx->current || !ctx->current->layout || !text)
+        return;
+
+    /* fetch configuration data */
+    style = &ctx->style;
+    padding = style->window.padding;
+
+    /* calculate size of the text and tooltip */
+    text_len = nk_strlen(text);
+    text_width = style->font->width(style->font->userdata,
+                    style->font->height, text, text_len);
+    text_width += (4 * padding.x);
+    text_height = (style->font->height + 2 * padding.y);
+
+    /* Should I use text_height? Any difference? */
+    h = ctx->current->layout->row.min_height;
+    w = nk_iceilf(text_width);
+
+    switch (position) {
+    case NK_TOP_LEFT:
+        offset.x = 0;
+        offset.y = 0;
+        break;
+    case NK_BOTTOM_LEFT:
+        offset.x = 0;
+        offset.y = -h;
+        break;
+    case NK_TOP_RIGHT:
+        offset.x = -w;
+        offset.y = 0;
+        break;
+    case NK_BOTTOM_RIGHT:
+        offset.x = -w;
+        offset.y = -h;
+        break;
+    case NK_TOP_MIDDLE:
+        offset.x = -w/2;
+        offset.y = 0;
+        break;
+    case NK_BOTTOM_MIDDLE:
+        offset.x = -w/2;
+        offset.y = -h;
+        break;
+    default:
+        offset.x = 0;
+        offset.y = 0;
+    }
+
+    /* execute tooltip and fill with text */
+    if (nk_tooltip_begin_offset(ctx, (float)text_width, offset)) {
         nk_layout_row_dynamic(ctx, (float)text_height, 1);
         nk_text(ctx, text, text_len, NK_TEXT_LEFT);
         nk_tooltip_end(ctx);
@@ -141,7 +201,7 @@ nk_tooltip(struct nk_context *ctx, const char *text)
     text_height = (style->font->height + 2 * padding.y);
 
     /* execute tooltip and fill with text */
-    if (nk_tooltip_begin(ctx, (float)text_width, NK_TOP_LEFT)) {
+    if (nk_tooltip_begin(ctx, (float)text_width)) {
         nk_layout_row_dynamic(ctx, (float)text_height, 1);
         nk_text(ctx, text, text_len, NK_TEXT_LEFT);
         nk_tooltip_end(ctx);

--- a/src/nuklear_tooltip.c
+++ b/src/nuklear_tooltip.c
@@ -47,21 +47,34 @@ nk_tooltip_begin_pos_offset(struct nk_context *ctx, float width, enum nk_tooltip
     case NK_TOP_LEFT:
         /* no change */
         break;
-    case NK_BOTTOM_LEFT:
-        y -= h;
+    case NK_TOP_CENTER:
+        x -= w/2;
         break;
     case NK_TOP_RIGHT:
         x -= w;
         break;
-    case NK_BOTTOM_RIGHT:
+
+    case NK_MIDDLE_LEFT:
+        y -= h/2;
+        break;
+    case NK_MIDDLE_CENTER:
+        x -= w/2;
+        y -= h/2;
+        break;
+    case NK_MIDDLE_RIGHT:
         x -= w;
+        y -= h/2;
+        break;
+
+    case NK_BOTTOM_LEFT:
         y -= h;
         break;
-    case NK_TOP_MIDDLE:
+    case NK_BOTTOM_CENTER:
         x -= w/2;
+        y -= h;
         break;
-    case NK_BOTTOM_MIDDLE:
-        x -= w/2;
+    case NK_BOTTOM_RIGHT:
+        x -= w;
         y -= h;
         break;
     default:
@@ -131,37 +144,8 @@ nk_tooltip_pos_offset(struct nk_context *ctx, const char *text, enum nk_tooltip_
 NK_API void
 nk_tooltip(struct nk_context *ctx, const char *text)
 {
-    const struct nk_style *style;
-    struct nk_vec2 padding;
-
-    int text_len;
-    float text_width;
-    float text_height;
-
-    NK_ASSERT(ctx);
-    NK_ASSERT(ctx->current);
-    NK_ASSERT(ctx->current->layout);
-    NK_ASSERT(text);
-    if (!ctx || !ctx->current || !ctx->current->layout || !text)
-        return;
-
-    /* fetch configuration data */
-    style = &ctx->style;
-    padding = style->window.padding;
-
-    /* calculate size of the text and tooltip */
-    text_len = nk_strlen(text);
-    text_width = style->font->width(style->font->userdata,
-                    style->font->height, text, text_len);
-    text_width += (4 * padding.x);
-    text_height = (style->font->height + 2 * padding.y);
-
-    /* execute tooltip and fill with text */
-    if (nk_tooltip_begin(ctx, (float)text_width)) {
-        nk_layout_row_dynamic(ctx, (float)text_height, 1);
-        nk_text(ctx, text, text_len, NK_TEXT_LEFT);
-        nk_tooltip_end(ctx);
-    }
+    struct nk_vec2 offset = { 12, 12 };
+    nk_tooltip_pos_offset(ctx, text, NK_TOP_LEFT, offset);
 }
 #ifdef NK_INCLUDE_STANDARD_VARARGS
 NK_API void

--- a/src/nuklear_tooltip.c
+++ b/src/nuklear_tooltip.c
@@ -10,11 +10,11 @@ NK_API nk_bool
 nk_tooltip_begin(struct nk_context *ctx, float width)
 {
     struct nk_vec2 offset = {0};
-    return nk_tooltip_begin_pos_offset(ctx, width, NK_TOP_LEFT, offset);
+    return nk_tooltip_begin_offset(ctx, width, NK_TOP_LEFT, offset);
 }
 
 NK_API nk_bool
-nk_tooltip_begin_pos_offset(struct nk_context *ctx, float width, enum nk_tooltip_pos position, struct nk_vec2 offset)
+nk_tooltip_begin_offset(struct nk_context *ctx, float width, enum nk_tooltip_pos position, struct nk_vec2 offset)
 {
     int x,y,w,h;
     struct nk_window *win;
@@ -106,7 +106,7 @@ nk_tooltip_end(struct nk_context *ctx)
 }
 
 NK_API void
-nk_tooltip_pos_offset(struct nk_context *ctx, const char *text, enum nk_tooltip_pos position, struct nk_vec2 offset)
+nk_tooltip_offset(struct nk_context *ctx, const char *text, enum nk_tooltip_pos position, struct nk_vec2 offset)
 {
     const struct nk_style *style;
     struct nk_vec2 padding;
@@ -134,7 +134,7 @@ nk_tooltip_pos_offset(struct nk_context *ctx, const char *text, enum nk_tooltip_
     text_height = (style->font->height + 2 * padding.y);
 
     /* execute tooltip and fill with text */
-    if (nk_tooltip_begin_pos_offset(ctx, (float)text_width, position, offset)) {
+    if (nk_tooltip_begin_offset(ctx, (float)text_width, position, offset)) {
         nk_layout_row_dynamic(ctx, (float)text_height, 1);
         nk_text(ctx, text, text_len, NK_TEXT_LEFT);
         nk_tooltip_end(ctx);
@@ -145,15 +145,15 @@ NK_API void
 nk_tooltip(struct nk_context *ctx, const char *text)
 {
     struct nk_vec2 offset = { 12, 12 };
-    nk_tooltip_pos_offset(ctx, text, NK_TOP_LEFT, offset);
+    nk_tooltip_offset(ctx, text, NK_TOP_LEFT, offset);
 }
 #ifdef NK_INCLUDE_STANDARD_VARARGS
 NK_API void
-nk_tooltipf_pos_offset(struct nk_context *ctx, enum nk_tooltip_pos position, struct nk_vec2 offset, const char *fmt, ...)
+nk_tooltipf_offset(struct nk_context *ctx, enum nk_tooltip_pos position, struct nk_vec2 offset, const char *fmt, ...)
 {
     va_list args;
     va_start(args, fmt);
-    nk_tooltipfv_pos_offset(ctx, position, offset, fmt, args);
+    nk_tooltipfv_offset(ctx, position, offset, fmt, args);
     va_end(args);
 }
 NK_API void
@@ -165,11 +165,11 @@ nk_tooltipf(struct nk_context *ctx, const char *fmt, ...)
     va_end(args);
 }
 NK_API void
-nk_tooltipfv_pos_offset(struct nk_context *ctx, enum nk_tooltip_pos position, struct nk_vec2 offset, const char *fmt, va_list args)
+nk_tooltipfv_offset(struct nk_context *ctx, enum nk_tooltip_pos position, struct nk_vec2 offset, const char *fmt, va_list args)
 {
     char buf[256];
     nk_strfmt(buf, NK_LEN(buf), fmt, args);
-    nk_tooltip_pos_offset(ctx, buf, position, offset);
+    nk_tooltip_offset(ctx, buf, position, offset);
 }
 NK_API void
 nk_tooltipfv(struct nk_context *ctx, const char *fmt, va_list args)


### PR DESCRIPTION
It's been bothering me for a while that the tooltip text is always partially covered by the cursor because we position the top left of the tooltip at the cursor position.  This is my first look at fixing that.

This is not how I would really want to do it. Ideally I would break even more existing code by changing nk_tooltip() take the enum and then have nk_tooltip_begin take a nk_vec2 offset.  The position calculation would then be in nk_tooltip() and the user could always call nk_tooltip_begin() directly if they wanted it somewhere arbitrary not covered by the enum options.

Thoughts?