### PR TITLE
fix(style_configurator): fix unsafe int to nk_bool pointer casts

### DIFF
--- a/demo/common/style_configurator.c
+++ b/demo/common/style_configurator.c
@@ -275,6 +275,7 @@ style_slider(struct nk_context* ctx, struct nk_style_slider* out_style)
 {
 	struct nk_style_slider slider = *out_style;
 	struct nk_style_button* dups[1];
+	nk_bool show_buttons_b;
 
 	nk_layout_row_dynamic(ctx, 30, 2);
 
@@ -299,7 +300,9 @@ style_slider(struct nk_context* ctx, struct nk_style_slider* out_style)
 	nk_property_float(ctx, "#Rounding:", -100.0f, &slider.rounding, 100.0f, 1,0.5f);
 
 	nk_layout_row_dynamic(ctx, 30, 1);
-	nk_checkbox_label(ctx, "Show Buttons", &slider.show_buttons);
+	show_buttons_b = (nk_bool)slider.show_buttons;
+	nk_checkbox_label(ctx, "Show Buttons", &show_buttons_b);
+	slider.show_buttons = (int)show_buttons_b;
 
 	if (slider.show_buttons) {
 		nk_layout_row_dynamic(ctx, 30, 2);
@@ -355,6 +358,7 @@ style_scrollbars(struct nk_context* ctx, struct nk_style_scrollbar* out_style, s
 {
 	struct nk_style_scrollbar scroll = *out_style;
 	struct nk_style_button* dups[3];
+	nk_bool show_buttons_b;
 
 	nk_layout_row_dynamic(ctx, 30, 2);
 
@@ -380,7 +384,9 @@ style_scrollbars(struct nk_context* ctx, struct nk_style_scrollbar* out_style, s
 
 	/* TODO what is wrong with scrollbar buttons?  Also look into controlling the total width (and height) of scrollbars */
 	nk_layout_row_dynamic(ctx, 30, 1);
-	nk_checkbox_label(ctx, "Show Buttons", &scroll.show_buttons);
+	show_buttons_b = (nk_bool)scroll.show_buttons;
+	nk_checkbox_label(ctx, "Show Buttons", &show_buttons_b);
+	scroll.show_buttons = (int)show_buttons_b;
 
 	if (scroll.show_buttons) {
 		nk_layout_row_dynamic(ctx, 30, 2);


### PR DESCRIPTION
Fixes: https://github.com/Immediate-Mode-UI/Nuklear/issues/812

For more detailed explanation see the commit message or the linked issue. Also, if you're wondering if those are the only places affected by this issue, [I really think there is nothing else left :)](https://github.com/Immediate-Mode-UI/Nuklear/issues/812#issuecomment-3829232745)