### PR TITLE
demo/sdl3_renderer: rewrite Makefile in order to support Emscripten

### DIFF
--- a/demo/sdl3_renderer/Makefile
+++ b/demo/sdl3_renderer/Makefile
@@ -23,28 +23,32 @@ BINEXT := ${binext_${OSNAME}}
 TEMPDIR := ./bin
 BIN := ${TEMPDIR}/demo${BINEXT}
 
-CFLAGS += -std=c89 -Wall -Wextra -Wpedantic
-CFLAGS += -O2
-#CFLAGS += -O0 -g
-#CFLAGS += -fsanitize=address
-#CFLAGS += -fsanitize=undefined
+cflags += -std=c89 -Wall -Wextra -Wpedantic
+cflags += -O2
+#cflags += -O0 -g
+#cflags += -fsanitize=address
+#cflags += -fsanitize=undefined
+cflags += ${CFLAGS}
 
-CPPFLAGS += $(shell ${PKG_CONFIG} ${PKG_SDL3} --cflags --keep-system-cflags)
+cppflags += $(shell ${PKG_CONFIG} ${PKG_SDL3} --cflags --keep-system-cflags)
+cppflags += ${CPPFLAGS}
 
-LDFLAGS += $(shell ${PKG_CONFIG} ${PKG_SDL3} --libs-only-L --libs-only-other --keep-system-libs)
+ldflags += $(shell ${PKG_CONFIG} ${PKG_SDL3} --libs-only-L --libs-only-other --keep-system-libs)
+ldflags += ${LDFLAGS}
 
-LDLIBS += $(shell ${PKG_CONFIG} ${PKG_SDL3} --libs-only-l --keep-system-libs)
-LDLIBS += -lm
+ldlibs += $(shell ${PKG_CONFIG} ${PKG_SDL3} --libs-only-l --keep-system-libs)
+ldlibs += -lm
+ldlibs += ${LDLIBS}
 # HACK: this one is for compatibility with other demos
-LDLIBS += ${LIBS}
+ldlibs += ${LIBS}
 
-DEP := ${BIN}.d
+DEP := ${TEMPDIR}/$(notdir ${BIN}).d
 
 SRC := main.c
 
 ${BIN}:
 	mkdir -p $(dir $@)
-	${CC} ${SRC} -o $@ -MD -MF ${DEP} ${CPPFLAGS} ${LDFLAGS} ${LDLIBS} ${CFLAGS}
+	${CC} ${SRC} -o $@ -MD -MF ${DEP} ${cppflags} ${ldflags} ${ldlibs} ${cflags}
 
 ${BIN}: ${SRC}
 


### PR DESCRIPTION
I wanted to fix this Makefile ~~and add a CI for it~~ for quite some time, and since there is some interest in Emscripten support (https://github.com/Immediate-Mode-UI/Nuklear/issues/888), I also added a support for this use-case. Read the corresponding commit message for more details.

This PR is split into 3 commits in order to be easier to review, but feel free to Squash it.