### PR TITLE
Check y for NULL too, remove duplicate zero'ing

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -23340,7 +23340,13 @@ nk_group_begin_titled(struct nk_context *ctx, const char *id,
         NK_ASSERT(y_offset);
         if (!x_offset || !y_offset) return 0;
         *x_offset = *y_offset = 0;
-    } else y_offset = nk_find_value(win, id_hash+1);
+    } else if (!(y_offset = nk_find_value(win, id_hash+1))) {
+        y_offset = nk_add_value(ctx, win, id_hash+1, 0);
+        NK_ASSERT(y_offset);
+        if (!y_offset) return 0;
+        *x_offset = *y_offset = 0; /* I think this covers the degenerate case */
+    }
+
     return nk_group_scrolled_offset_begin(ctx, x_offset, y_offset, title, flags);
 }
 NK_API nk_bool
@@ -23382,7 +23388,12 @@ nk_group_get_scroll(struct nk_context *ctx, const char *id, nk_uint *x_offset, n
         NK_ASSERT(y_offset_ptr);
         if (!x_offset_ptr || !y_offset_ptr) return;
         *x_offset_ptr = *y_offset_ptr = 0;
-    } else y_offset_ptr = nk_find_value(win, id_hash+1);
+    } else if (!(y_offset_ptr = nk_find_value(win, id_hash+1))) {
+        y_offset_ptr = nk_add_value(ctx, win, id_hash+1, 0);
+        NK_ASSERT(y_offset_ptr);
+        if (!y_offset_ptr) return;
+        *x_offset_ptr = *y_offset_ptr = 0;
+    }
     if (x_offset)
       *x_offset = *x_offset_ptr;
     if (y_offset)
@@ -23417,7 +23428,11 @@ nk_group_set_scroll(struct nk_context *ctx, const char *id, nk_uint x_offset, nk
         NK_ASSERT(y_offset_ptr);
         if (!x_offset_ptr || !y_offset_ptr) return;
         *x_offset_ptr = *y_offset_ptr = 0;
-    } else y_offset_ptr = nk_find_value(win, id_hash+1);
+    } else if (!(y_offset_ptr = nk_find_value(win, id_hash+1))) {
+        NK_ASSERT(y_offset_ptr);
+        if (!y_offset_ptr) return;
+        *x_offset_ptr = *y_offset_ptr = 0;
+    }
     *x_offset_ptr = x_offset;
     *y_offset_ptr = y_offset;
 }
@@ -23467,7 +23482,11 @@ nk_list_view_begin(struct nk_context *ctx, struct nk_list_view *view,
         NK_ASSERT(y_offset);
         if (!x_offset || !y_offset) return 0;
         *x_offset = *y_offset = 0;
-    } else y_offset = nk_find_value(win, title_hash+1);
+    } else if (!(y_offset = nk_find_value(win, title_hash+1))) {
+        NK_ASSERT(y_offset);
+        if (!y_offset) return 0;
+        *x_offset = *y_offset = 0;
+    }
     view->scroll_value = *y_offset;
     view->scroll_pointer = y_offset;
 

--- a/nuklear.h
+++ b/nuklear.h
@@ -19896,7 +19896,6 @@ nk_create_table(struct nk_context *ctx)
     struct nk_page_element *elem;
     elem = nk_create_page_element(ctx);
     if (!elem) return 0;
-    nk_zero_struct(*elem);
     return &elem->data.tbl;
 }
 NK_LIB void
@@ -19986,7 +19985,6 @@ nk_create_panel(struct nk_context *ctx)
     struct nk_page_element *elem;
     elem = nk_create_page_element(ctx);
     if (!elem) return 0;
-    nk_zero_struct(*elem);
     return &elem->data.pan;
 }
 NK_LIB void

--- a/src/nuklear_group.c
+++ b/src/nuklear_group.c
@@ -153,7 +153,13 @@ nk_group_begin_titled(struct nk_context *ctx, const char *id,
         NK_ASSERT(y_offset);
         if (!x_offset || !y_offset) return 0;
         *x_offset = *y_offset = 0;
-    } else y_offset = nk_find_value(win, id_hash+1);
+    } else if (!(y_offset = nk_find_value(win, id_hash+1))) {
+        y_offset = nk_add_value(ctx, win, id_hash+1, 0);
+        NK_ASSERT(y_offset);
+        if (!y_offset) return 0;
+        *x_offset = *y_offset = 0; /* I think this covers the degenerate case */
+    }
+
     return nk_group_scrolled_offset_begin(ctx, x_offset, y_offset, title, flags);
 }
 NK_API nk_bool
@@ -195,7 +201,12 @@ nk_group_get_scroll(struct nk_context *ctx, const char *id, nk_uint *x_offset, n
         NK_ASSERT(y_offset_ptr);
         if (!x_offset_ptr || !y_offset_ptr) return;
         *x_offset_ptr = *y_offset_ptr = 0;
-    } else y_offset_ptr = nk_find_value(win, id_hash+1);
+    } else if (!(y_offset_ptr = nk_find_value(win, id_hash+1))) {
+        y_offset_ptr = nk_add_value(ctx, win, id_hash+1, 0);
+        NK_ASSERT(y_offset_ptr);
+        if (!y_offset_ptr) return;
+        *x_offset_ptr = *y_offset_ptr = 0;
+    }
     if (x_offset)
       *x_offset = *x_offset_ptr;
     if (y_offset)
@@ -230,7 +241,11 @@ nk_group_set_scroll(struct nk_context *ctx, const char *id, nk_uint x_offset, nk
         NK_ASSERT(y_offset_ptr);
         if (!x_offset_ptr || !y_offset_ptr) return;
         *x_offset_ptr = *y_offset_ptr = 0;
-    } else y_offset_ptr = nk_find_value(win, id_hash+1);
+    } else if (!(y_offset_ptr = nk_find_value(win, id_hash+1))) {
+        NK_ASSERT(y_offset_ptr);
+        if (!y_offset_ptr) return;
+        *x_offset_ptr = *y_offset_ptr = 0;
+    }
     *x_offset_ptr = x_offset;
     *y_offset_ptr = y_offset;
 }

--- a/src/nuklear_list_view.c
+++ b/src/nuklear_list_view.c
@@ -43,7 +43,11 @@ nk_list_view_begin(struct nk_context *ctx, struct nk_list_view *view,
         NK_ASSERT(y_offset);
         if (!x_offset || !y_offset) return 0;
         *x_offset = *y_offset = 0;
-    } else y_offset = nk_find_value(win, title_hash+1);
+    } else if (!(y_offset = nk_find_value(win, title_hash+1))) {
+        NK_ASSERT(y_offset);
+        if (!y_offset) return 0;
+        *x_offset = *y_offset = 0;
+    }
     view->scroll_value = *y_offset;
     view->scroll_pointer = y_offset;
 

--- a/src/nuklear_panel.c
+++ b/src/nuklear_panel.c
@@ -12,7 +12,6 @@ nk_create_panel(struct nk_context *ctx)
     struct nk_page_element *elem;
     elem = nk_create_page_element(ctx);
     if (!elem) return 0;
-    nk_zero_struct(*elem);
     return &elem->data.pan;
 }
 NK_LIB void

--- a/src/nuklear_table.c
+++ b/src/nuklear_table.c
@@ -12,7 +12,6 @@ nk_create_table(struct nk_context *ctx)
     struct nk_page_element *elem;
     elem = nk_create_page_element(ctx);
     if (!elem) return 0;
-    nk_zero_struct(*elem);
     return &elem->data.tbl;
 }
 NK_LIB void


### PR DESCRIPTION
Ran into this bug today. I don't have a simple standalone program to reproduce it, but my current project was triggering it consistently.

What happens is that the x and y offsets are split across two different tables and then the table with the y offset gets removed in nk_clear() because table->seq != ctx->seq at some point. Then the next frame, x is found so it assumes y exists and viola, you have a segfault.

Clearly the underlying logic of how it uses seq to determine what is safe to free is flawed but I don't know what the best way to fix it.

I think this is a very rare case that is happening because I have a large number of groups (a single table holds 69 items or 34.5 x/y pairs) in a "tabbed" window so what happens as I click through the tabs more groups get added to the table and eventually we get the x/y table split. Then when you switch to another tab you "touch" at least some of the items in the first table thus updating its seq member to the current ctx->seq, but not the newest table with the y member of the no-longer visible group, so that table gets tossed. Finally, switching back to the that tab it still finds the x offset in the first table and assumes the y must also exist even though it doesn't.

One thing I didn't look deeply into but I should is if we can avoid this code entirely when NK_WINDOW_NO_SCROLLBAR is set. It's just a waste of time/space and most groups are used for simple layouting purposes and so will not need a scrollbar. Complex arrangements require lots of groups, thus making running into this issue more likely. Just a thought.

In the process I noticed a redundant nk_zero() call, so I removed it.

@RobLoach @sleeptightAnsiC 