### PR TITLE
Increase property button size so you can actually click them

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -28919,7 +28919,7 @@ nk_do_property(nk_flags *ws,
     struct nk_rect empty;
 
     /* left decrement button */
-    left.h = font->height/2;
+    left.h = font->height;
     left.w = left.h;
     left.x = property.x + style->border + style->padding.x;
     left.y = property.y + style->border + property.h/2.0f - left.h/2;

--- a/src/nuklear_property.c
+++ b/src/nuklear_property.c
@@ -162,7 +162,7 @@ nk_do_property(nk_flags *ws,
     struct nk_rect empty;
 
     /* left decrement button */
-    left.h = font->height/2;
+    left.h = font->height;
     left.w = left.h;
     left.x = property.x + style->border + style->padding.x;
     left.y = property.y + style->border + property.h/2.0f - left.h/2;


### PR DESCRIPTION
I've had this change locally in [sdl_img](https://github.com/rswinkle/sdl_img) for years.

Before:
<img width="402" height="315" alt="Screenshot from 2026-03-22 20-38-47" src="https://github.com/user-attachments/assets/ffc772dd-3a97-4b34-b345-89494de4db8d" />

After:
<img width="402" height="315" alt="Screenshot from 2026-03-22 20-39-01" src="https://github.com/user-attachments/assets/6a032d57-5804-4b08-9f2e-2158028d5b33" />

