### PR TITLE
disable optimizations and other costly CFLAGS from demos

### DIFF
--- a/demo/d3d11/build.bat
+++ b/demo/d3d11/build.bat
@@ -3,7 +3,7 @@
 rem This will use VS2015 for compiler
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
 
-fxc.exe /nologo /T vs_4_0_level_9_0 /E vs /O3 /Zpc /Ges /Fh nuklear_d3d11_vertex_shader.h /Vn nk_d3d11_vertex_shader /Qstrip_reflect /Qstrip_debug /Qstrip_priv nuklear_d3d11.hlsl
-fxc.exe /nologo /T ps_4_0_level_9_0 /E ps /O3 /Zpc /Ges /Fh nuklear_d3d11_pixel_shader.h /Vn nk_d3d11_pixel_shader /Qstrip_reflect /Qstrip_debug /Qstrip_priv nuklear_d3d11.hlsl
+fxc.exe /nologo /T vs_4_0_level_9_0 /E vs /Zpc /Ges /Fh nuklear_d3d11_vertex_shader.h /Vn nk_d3d11_vertex_shader /Qstrip_reflect /Qstrip_debug /Qstrip_priv nuklear_d3d11.hlsl
+fxc.exe /nologo /T ps_4_0_level_9_0 /E ps /Zpc /Ges /Fh nuklear_d3d11_pixel_shader.h /Vn nk_d3d11_pixel_shader /Qstrip_reflect /Qstrip_debug /Qstrip_priv nuklear_d3d11.hlsl
 
-cl /D_CRT_SECURE_NO_DEPRECATE /nologo /W3 /O2 /fp:fast /Gm- /Fedemo.exe main.c user32.lib dxguid.lib d3d11.lib /link /incremental:no
+cl /D_CRT_SECURE_NO_DEPRECATE /nologo /W3 /fp:fast /Gm- /Fedemo.exe main.c user32.lib dxguid.lib d3d11.lib /link /incremental:no

--- a/demo/d3d12/build.bat
+++ b/demo/d3d12/build.bat
@@ -3,7 +3,7 @@
 rem This will use VS2015 for compiler... if you have vs 2015 and it is installed at this / the default path
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
 
-fxc.exe /nologo /T vs_5_1 /E vs /O3 /Zpc /Ges /Fh nuklear_d3d12_vertex_shader.h /Vn nk_d3d12_vertex_shader /Qstrip_reflect /Qstrip_debug /Qstrip_priv nuklear_d3d12.hlsl
-fxc.exe /nologo /T ps_5_1 /E ps /O3 /Zpc /Ges /Fh nuklear_d3d12_pixel_shader.h /Vn nk_d3d12_pixel_shader /Qstrip_reflect /Qstrip_debug /Qstrip_priv /enable_unbounded_descriptor_tables nuklear_d3d12.hlsl
+fxc.exe /nologo /T vs_5_1 /E vs /Zpc /Ges /Fh nuklear_d3d12_vertex_shader.h /Vn nk_d3d12_vertex_shader /Qstrip_reflect /Qstrip_debug /Qstrip_priv nuklear_d3d12.hlsl
+fxc.exe /nologo /T ps_5_1 /E ps /Zpc /Ges /Fh nuklear_d3d12_pixel_shader.h /Vn nk_d3d12_pixel_shader /Qstrip_reflect /Qstrip_debug /Qstrip_priv /enable_unbounded_descriptor_tables nuklear_d3d12.hlsl
 
-cl /D_CRT_SECURE_NO_DEPRECATE /nologo /W3 /O2 /fp:fast /Gm- /Fedemo.exe main.c user32.lib dxguid.lib dxgi.lib d3d12.lib /link /incremental:no
+cl /D_CRT_SECURE_NO_DEPRECATE /nologo /W3 /fp:fast /Gm- /Fedemo.exe main.c user32.lib dxguid.lib dxgi.lib d3d12.lib /link /incremental:no

--- a/demo/d3d9/build.bat
+++ b/demo/d3d9/build.bat
@@ -3,4 +3,4 @@
 rem This will use VS2015 for compiler
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
 
-cl /D_CRT_SECURE_NO_DEPRECATE /nologo /W3 /O2 /fp:fast /Gm- /Fedemo.exe main.c user32.lib d3d9.lib /link /incremental:no
+cl /D_CRT_SECURE_NO_DEPRECATE /nologo /W3 /fp:fast /Gm- /Fedemo.exe main.c user32.lib d3d9.lib /link /incremental:no

--- a/demo/gdi/build.bat
+++ b/demo/gdi/build.bat
@@ -3,4 +3,4 @@
 rem This will use VS2015 for compiler
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
 
-cl /nologo /W3 /O2 /fp:fast /Gm- /Fedemo.exe main.c user32.lib gdi32.lib Msimg32.lib /link /incremental:no
+cl /nologo /W3 /fp:fast /Gm- /Fedemo.exe main.c user32.lib gdi32.lib Msimg32.lib /link /incremental:no

--- a/demo/gdi_native_nuklear/build.bat
+++ b/demo/gdi_native_nuklear/build.bat
@@ -3,4 +3,4 @@
 rem This will use VS2015 for compiler
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
 
-cl /nologo /W3 /O2 /fp:fast /Gm- /D_CRT_SECURE_NO_DEPRECATE /Fedemo.exe main.c user32.lib gdi32.lib Msimg32.lib /link /incremental:no 
+cl /nologo /W3 /fp:fast /Gm- /D_CRT_SECURE_NO_DEPRECATE /Fedemo.exe main.c user32.lib gdi32.lib Msimg32.lib /link /incremental:no

--- a/demo/gdip/build.bat
+++ b/demo/gdip/build.bat
@@ -2,4 +2,4 @@
 
 call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" x86
 
-cl /nologo /W3 /O2 /fp:fast /Gm- /Fedemo.exe /D_CRT_SECURE_NO_DEPRECATE main.c user32.lib gdiplus.lib shlwapi.lib /link /incremental:no
+cl /nologo /W3 /fp:fast /Gm- /Fedemo.exe /D_CRT_SECURE_NO_DEPRECATE main.c user32.lib gdiplus.lib shlwapi.lib /link /incremental:no

--- a/demo/rawfb/wayland/Makefile
+++ b/demo/rawfb/wayland/Makefile
@@ -2,7 +2,8 @@ WAYLAND=`pkg-config wayland-client --cflags --libs`
 WAYLAND_SCANNER=wayland-scanner
 WAYLAND_PROTOCOLS_DIR=/usr/share/wayland-protocols
 
-CFLAGS+=-std=c99 -Wall -Wextra -pedantic -Wno-unused-function -O3 -fvisibility=hidden
+CFLAGS += -std=c99 -Wall -Wextra -pedantic -Wno-unused-function -fvisibility=hidden
+#CFLAGS += -O3
 
 .PHONY: clean
 

--- a/demo/sdl3_renderer/Makefile
+++ b/demo/sdl3_renderer/Makefile
@@ -23,9 +23,9 @@ BINEXT := ${binext_${OSNAME}}
 TEMPDIR := ./bin
 BIN := ${TEMPDIR}/demo${BINEXT}
 
-cflags += -std=c89 -Wall -Wextra -Wpedantic
-cflags += -O2
-#cflags += -O0 -g
+cflags += -std=c89 -Wall -Wextra -pedantic
+#cflags += -O2
+cflags += -O0 -g
 #cflags += -fsanitize=address
 #cflags += -fsanitize=undefined
 cflags += ${CFLAGS}

--- a/demo/sdl_opengles2/Makefile
+++ b/demo/sdl_opengles2/Makefile
@@ -3,6 +3,7 @@ BIN = demo
 
 # Flags
 CFLAGS += -std=c89 -Wall -Wextra -pedantic -DSDL_DISABLE_IMMINTRIN_H
+#CFLAGS += -Os
 
 SRC = main.c
 OBJ = $(SRC:.c=.o)
@@ -18,7 +19,7 @@ $(BIN): prepare
 	$(CC) $(SRC) $(CFLAGS) -o bin/$(BIN) $(LIBS)
 
 web: prepare
-	emcc $(SRC) -Os -s USE_SDL=2 -o bin/index.html
+	emcc $(SRC) $(CFLAGS) -s USE_SDL=2 -o bin/index.html
 
 rpi: prepare
 	$(CC) $(SRC) $(CFLAGS) -o bin/$(BIN) `PKG_CONFIG_PATH=/opt/vc/lib/pkgconfig/ pkg-config --cflags --libs bcm_host brcmglesv2` `/usr/local/bin/sdl2-config --libs --cflags`

--- a/demo/sdl_renderer/Makefile
+++ b/demo/sdl_renderer/Makefile
@@ -2,7 +2,8 @@
 BIN = demo
 
 # Flags
-CFLAGS += -std=c89 -Wall -Wextra -pedantic -O2 -DSDL_DISABLE_IMMINTRIN_H
+CFLAGS += -std=c89 -Wall -Wextra -pedantic -DSDL_DISABLE_IMMINTRIN_H
+#CFLAGS += -O2
 CFLAGS += `sdl2-config --cflags`
 
 SRC = main.c

--- a/demo/sdl_vulkan/Makefile
+++ b/demo/sdl_vulkan/Makefile
@@ -2,7 +2,8 @@
 BIN = demo
 
 # Flags
-CFLAGS += -std=c89 -Wall -Wextra -pedantic -fsanitize=address -O2
+CFLAGS += -std=c89 -Wall -Wextra -pedantic
+#CFLAGS += -fsanitize=address -O2
 CFLAGS += -DSDL_DISABLE_IMMINTRIN_H
 
 SRC = main.c


### PR DESCRIPTION
Demos must compile as fast as possible, in order to be quick to reiterate and retest. Given that each needs to link and recompile amalgamation every time, the difference between -O2 and -O0 is noticeable. This also slightly affects CI times. This topic was discussed under several occasions, for example: https://github.com/Immediate-Mode-UI/Nuklear/pull/894#issuecomment-3880985649 or https://github.com/Immediate-Mode-UI/Nuklear/issues/895#issuecomment-3884228468