### PR TITLE
images: Change stbi_load() to use 4 chans

### DIFF
--- a/demo/common/file_browser.c
+++ b/demo/common/file_browser.c
@@ -105,7 +105,7 @@ icon_load(const char *filename)
 {
     int x,y,n;
     GLuint tex;
-    unsigned char *data = stbi_load(filename, &x, &y, &n, 0);
+    unsigned char *data = stbi_load(filename, &x, &y, &n, 4);
     if (!data) die("[SDL]: failed to load image: %s", filename);
 
     glGenTextures(1, &tex);

--- a/demo/x11/nuklear_xlib.h
+++ b/demo/x11/nuklear_xlib.h
@@ -556,7 +556,7 @@ nk_xsurf_load_image_from_file(char const *filename)
 {
     int x,y,n;
     unsigned char *data;
-    data = stbi_load(filename, &x, &y, &n, 0);
+    data = stbi_load(filename, &x, &y, &n, 4);
     return nk_stbi_image_to_xsurf(data, x, y, n);
 }
 #endif /* NK_XLIB_INCLUDE_STB_IMAGE */

--- a/example/canvas.c
+++ b/example/canvas.c
@@ -83,7 +83,7 @@ icon_load(const char *filename)
 {
     int x,y,n;
     GLuint tex;
-    unsigned char *data = stbi_load(filename, &x, &y, &n, 0);
+    unsigned char *data = stbi_load(filename, &x, &y, &n, 4);
     if (!data) die("[SDL]: failed to load image: %s", filename);
 
      glGenTextures(1, &tex);

--- a/example/extended.c
+++ b/example/extended.c
@@ -507,7 +507,7 @@ icon_load(const char *filename)
 {
     int x,y,n;
     GLuint tex;
-    unsigned char *data = stbi_load(filename, &x, &y, &n, 0);
+    unsigned char *data = stbi_load(filename, &x, &y, &n, 4);
     if (!data) die("[SDL]: failed to load image: %s", filename);
 
     glGenTextures(1, &tex);

--- a/example/file_browser.c
+++ b/example/file_browser.c
@@ -545,7 +545,7 @@ icon_load(const char *filename)
 {
     int x,y,n;
     GLuint tex;
-    unsigned char *data = stbi_load(filename, &x, &y, &n, 0);
+    unsigned char *data = stbi_load(filename, &x, &y, &n, 4);
     if (!data) die("[SDL]: failed to load image: %s", filename);
 
     glGenTextures(1, &tex);

--- a/example/skinning.c
+++ b/example/skinning.c
@@ -108,7 +108,7 @@ image_load(const char *filename)
 {
     int x,y,n;
     GLuint tex;
-    unsigned char *data = stbi_load(filename, &x, &y, &n, 0);
+    unsigned char *data = stbi_load(filename, &x, &y, &n, 4);
     if (!data) die("failed to load image: %s", filename);
 
     glGenTextures(1, &tex);


### PR DESCRIPTION
Switches the stb image loads to default to 4 channels.

Fixes #950

@TomJGooding Like this?
