### PR TITLE
feat: config inclusion

### DIFF
--- a/.github/ci_compile_sources.sh
+++ b/.github/ci_compile_sources.sh
@@ -13,6 +13,26 @@
 
 set -e
 
+tmpdir="$(mktemp -d)"
+trap 'rm -rf "${tmpdir}"' EXIT INT QUIT TERM
+
+cat <<'EOF' >"${tmpdir}/nuklear_config.h"
+    /*
+     * Intentionally without header guards to test Nuklear handling this case.
+     * The foo/bar below proves you can put arbitrary symbols into the config.
+     */
+    static int foo = 0;
+    static int bar(void) { return 0; }
+    #define NK_INCLUDE_FIXED_TYPES
+    #define NK_INCLUDE_DEFAULT_ALLOCATOR
+    #define NK_INCLUDE_STANDARD_IO
+    #define NK_INCLUDE_STANDARD_VARARGS
+    #define NK_INCLUDE_STANDARD_BOOL
+    #define NK_INCLUDE_VERTEX_BUFFER_OUTPUT
+    #define NK_INCLUDE_DEFAULT_FONT
+    #define NK_INCLUDE_COMMAND_USERDATA
+EOF
+
 CC=cc
 SRCDIR=./src
 
@@ -21,17 +41,12 @@ set -- "$@" -std=c89
 set -- "$@" -Wall
 set -- "$@" -Wextra
 set -- "$@" -pedantic
+set -- "$@" -Wno-unused  # only to silence warnings about static foo/bar
 CFLAGS=$*
 
 set -- ""
-set -- "$@" -DNK_INCLUDE_FIXED_TYPES
-set -- "$@" -DNK_INCLUDE_DEFAULT_ALLOCATOR
-set -- "$@" -DNK_INCLUDE_STANDARD_IO
-set -- "$@" -DNK_INCLUDE_STANDARD_VARARGS
-set -- "$@" -DNK_INCLUDE_STANDARD_BOOL
-set -- "$@" -DNK_INCLUDE_VERTEX_BUFFER_OUTPUT
-set -- "$@" -DNK_INCLUDE_DEFAULT_FONT
-set -- "$@" -DNK_INCLUDE_COMMAND_USERDATA
+set -- "$@" -I"${tmpdir}"
+set -- "$@" -DNK_INCLUDE_CONFIG
 CPPFLAGS=$*
 
 retcode=0

--- a/demo/sdl3_renderer/main.c
+++ b/demo/sdl3_renderer/main.c
@@ -18,98 +18,7 @@
 #define SDL_MAIN_USE_CALLBACKS
 #include <SDL3/SDL_main.h>
 
-/* ===============================================================
- *
- *                          CONFIG
- *
- * ===============================================================*/
-
-/* optional: sdl3_renderer does not need any of these defines
- * (but some examples might need them, so be careful) */
-#define NK_INCLUDE_STANDARD_VARARGS
-#define NK_INCLUDE_STANDARD_IO
-
-/* note that sdl3_renderer comes with nk_sdl_style_set_debug_font()
- * so you may wish to use that instead of font baking */
-#define NK_INCLUDE_FONT_BAKING
-#define NK_INCLUDE_DEFAULT_FONT
-
-/* note that sdl3_renderer comes with nk_sdl_allocator()
- * and you probably want to use that allocator instead of the default ones */
-/*#define NK_INCLUDE_DEFAULT_ALLOCATOR*/
-
-/* mandatory: sdl3_renderer depends on those defines */
-#define NK_INCLUDE_COMMAND_USERDATA
-#define NK_INCLUDE_VERTEX_BUFFER_OUTPUT
-
-
-/* We can re-use the types provided by SDL which are extremely portable,
- * so there is no need for Nuklear to detect those on its own */
-/*#define NK_INCLUDE_FIXED_TYPES*/
-#ifndef NK_INCLUDE_FIXED_TYPES
-    #define NK_INT8              Sint8
-    #define NK_UINT8             Uint8
-    #define NK_INT16             Sint16
-    #define NK_UINT16            Uint16
-    #define NK_INT32             Sint32
-    #define NK_UINT32            Uint32
-    /* SDL guarantees 'uintptr_t' typedef */
-    #define NK_SIZE_TYPE         uintptr_t
-    #define NK_POINTER_TYPE      uintptr_t
-#endif
-
-/* We can reuse the `bool` symbol because SDL3 guarantees its existence */
-/*#define NK_INCLUDE_STANDARD_BOOL*/
-#ifndef NK_INCLUDE_STANDARD_BOOL
-    #define NK_BOOL               bool
-#endif
-
-/* We can re-use various portable libc functions provided by SDL */
-#define NK_ASSERT(condition)      SDL_assert(condition)
-#define NK_STATIC_ASSERT(exp)     SDL_COMPILE_TIME_ASSERT(, exp)
-#define NK_MEMSET(dst, c, len)    SDL_memset(dst, c, len)
-#define NK_MEMCPY(dst, src, len)  SDL_memcpy(dst, src, len)
-#define NK_VSNPRINTF(s, n, f, a)  SDL_vsnprintf(s, n, f, a)
-#define NK_STRTOD(str, endptr)    SDL_strtod(str, endptr)
-
-/* SDL3 does not provide "dtoa" (only integer versions)
- * but we can emulate it with SDL_snprintf */
-static char* nk_sdl_dtoa(char *str, double d);
-#define NK_DTOA(str, d) nk_sdl_dtoa(str, d)
-
-/* SDL can also provide us with math functions, but beware that Nuklear's own
- * implementation can be slightly faster at the cost of some precision */
-#define NK_INV_SQRT(f)            (1.0f / SDL_sqrtf(f))
-#define NK_SIN(f)                 SDL_sinf(f)
-#define NK_COS(f)                 SDL_cosf(f)
-
-/* HACK: Nuklear pulls two stb libraries in order to use font baking
- * those libraries pull in some libc headers internally, creating a linkage dependency,
- * so you’ll most likely want to use SDL symbols instead */
-#define STBTT_ifloor(x)       ((int)SDL_floor(x))
-#define STBTT_iceil(x)        ((int)SDL_ceil(x))
-#define STBTT_sqrt(x)         SDL_sqrt(x)
-#define STBTT_pow(x,y)        SDL_pow(x,y)
-#define STBTT_fmod(x,y)       SDL_fmod(x,y)
-#define STBTT_cos(x)          SDL_cosf(x)
-#define STBTT_acos(x)         SDL_acos(x)
-#define STBTT_fabs(x)         SDL_fabs(x)
-#define STBTT_assert(x)       SDL_assert(x)
-#define STBTT_strlen(x)       SDL_strlen(x)
-#define STBTT_memcpy          SDL_memcpy
-#define STBTT_memset          SDL_memset
-#define stbtt_uint8           Uint8
-#define stbtt_int8            Sint8
-#define stbtt_uint16          Uint16
-#define stbtt_int16           Sint16
-#define stbtt_uint32          Uint32
-#define stbtt_int32           Sint32
-#define STBRP_SORT            SDL_qsort
-#define STBRP_ASSERT          SDL_assert
-/* There is no need to define STBTT_malloc/STBTT_free macros
- * Nuklear will define those to user-provided nk_allocator */
-
-
+#include "./nuklear_sdl3_renderer_config.h"
 #define NK_IMPLEMENTATION
 #include "../../nuklear.h"
 #define NK_SDL3_RENDERER_IMPLEMENTATION
@@ -419,14 +328,5 @@ SDL_AppQuit(void* appstate, SDL_AppResult result)
         SDL_DestroyWindow(app->window);
         SDL_free(app);
     }
-}
-
-static char*
-nk_sdl_dtoa(char *str, double d)
-{
-    NK_ASSERT(str);
-    if (!str) return NULL;
-    (void)SDL_snprintf(str, 99999, "%.17g", d);
-    return str;
 }
 

--- a/demo/sdl3_renderer/nuklear_sdl3_renderer_config.h
+++ b/demo/sdl3_renderer/nuklear_sdl3_renderer_config.h
@@ -71,8 +71,8 @@ nk_sdl_dtoa(char *str, double d)
 }
 #define NK_DTOA(str, d) nk_sdl_dtoa(str, d)
 
-/* SDL can also provide us with math functions, but beware that Nuklear's own
- * implementation can be slightly faster at the cost of some precision */
+/* SDL can supply math functions for Nuklear, but beware you may not always want it.
+ * Nuklear internally uses imprecise approximations, which can be slightly faster. */
 #define NK_INV_SQRT(f)            (1.0f / SDL_sqrtf(f))
 #define NK_SIN(f)                 SDL_sinf(f)
 #define NK_COS(f)                 SDL_cosf(f)

--- a/demo/sdl3_renderer/nuklear_sdl3_renderer_config.h
+++ b/demo/sdl3_renderer/nuklear_sdl3_renderer_config.h
@@ -1,0 +1,107 @@
+/* nuklear - public domain */
+
+/* ===============================================================
+ *
+ *                          CONFIG
+ *
+ * ===============================================================*/
+
+#ifndef NK_SDL3_RENDERER_CONFIG_H_
+#define NK_SDL3_RENDERER_CONFIG_H_
+
+#include <SDL3/SDL.h>
+
+/* optional: sdl3_renderer does not need any of these defines
+ * (but some examples might need them, so be careful) */
+#define NK_INCLUDE_STANDARD_VARARGS
+#define NK_INCLUDE_STANDARD_IO
+
+/* note that sdl3_renderer comes with nk_sdl_style_set_debug_font()
+ * so you may wish to use that instead of font baking */
+#define NK_INCLUDE_FONT_BAKING
+#define NK_INCLUDE_DEFAULT_FONT
+
+/* note that sdl3_renderer comes with nk_sdl_allocator()
+ * and you probably want to use that allocator instead of the default ones */
+/*#define NK_INCLUDE_DEFAULT_ALLOCATOR*/
+
+/* mandatory: sdl3_renderer depends on those defines */
+#define NK_INCLUDE_COMMAND_USERDATA
+#define NK_INCLUDE_VERTEX_BUFFER_OUTPUT
+
+
+/* We can re-use the types provided by SDL which are extremely portable,
+ * so there is no need for Nuklear to detect those on its own */
+/*#define NK_INCLUDE_FIXED_TYPES*/
+#ifndef NK_INCLUDE_FIXED_TYPES
+    #define NK_INT8              Sint8
+    #define NK_UINT8             Uint8
+    #define NK_INT16             Sint16
+    #define NK_UINT16            Uint16
+    #define NK_INT32             Sint32
+    #define NK_UINT32            Uint32
+    /* SDL guarantees 'uintptr_t' typedef */
+    #define NK_SIZE_TYPE         uintptr_t
+    #define NK_POINTER_TYPE      uintptr_t
+#endif
+
+/* We can reuse the `bool` symbol because SDL3 guarantees its existence */
+/*#define NK_INCLUDE_STANDARD_BOOL*/
+#ifndef NK_INCLUDE_STANDARD_BOOL
+    #define NK_BOOL               bool
+#endif
+
+/* We can re-use various portable libc functions provided by SDL */
+#define NK_ASSERT(condition)      SDL_assert(condition)
+#define NK_STATIC_ASSERT(exp)     SDL_COMPILE_TIME_ASSERT(, exp)
+#define NK_MEMSET(dst, c, len)    SDL_memset(dst, c, len)
+#define NK_MEMCPY(dst, src, len)  SDL_memcpy(dst, src, len)
+#define NK_VSNPRINTF(s, n, f, a)  SDL_vsnprintf(s, n, f, a)
+#define NK_STRTOD(str, endptr)    SDL_strtod(str, endptr)
+
+/* SDL3 does not provide "dtoa" (only integer versions)
+ * but we can emulate it with SDL_snprintf */
+SDL_FORCE_INLINE char*
+nk_sdl_dtoa(char *str, double d)
+{
+    NK_ASSERT(str);
+    if (!str) return NULL;
+    (void)SDL_snprintf(str, 99999, "%.17g", d);
+    return str;
+}
+#define NK_DTOA(str, d) nk_sdl_dtoa(str, d)
+
+/* SDL can also provide us with math functions, but beware that Nuklear's own
+ * implementation can be slightly faster at the cost of some precision */
+#define NK_INV_SQRT(f)            (1.0f / SDL_sqrtf(f))
+#define NK_SIN(f)                 SDL_sinf(f)
+#define NK_COS(f)                 SDL_cosf(f)
+
+/* HACK: Nuklear pulls two stb libraries in order to use font baking
+ * those libraries pull in some libc headers internally, creating a linkage dependency,
+ * so you’ll most likely want to use SDL symbols instead */
+#define STBTT_ifloor(x)           ((int)SDL_floor(x))
+#define STBTT_iceil(x)            ((int)SDL_ceil(x))
+#define STBTT_sqrt(x)             SDL_sqrt(x)
+#define STBTT_pow(x,y)            SDL_pow(x,y)
+#define STBTT_fmod(x,y)           SDL_fmod(x,y)
+#define STBTT_cos(x)              SDL_cosf(x)
+#define STBTT_acos(x)             SDL_acos(x)
+#define STBTT_fabs(x)             SDL_fabs(x)
+#define STBTT_assert(x)           SDL_assert(x)
+#define STBTT_strlen(x)           SDL_strlen(x)
+#define STBTT_memcpy              SDL_memcpy
+#define STBTT_memset              SDL_memset
+#define stbtt_uint8               Uint8
+#define stbtt_int8                Sint8
+#define stbtt_uint16              Uint16
+#define stbtt_int16               Sint16
+#define stbtt_uint32              Uint32
+#define stbtt_int32               Sint32
+#define STBRP_SORT                SDL_qsort
+#define STBRP_ASSERT              SDL_assert
+/* There is no need to define STBTT_malloc/STBTT_free macros
+ * Nuklear will define those to user-provided nk_allocator */
+
+#endif /* NK_SDL3_RENDERER_CONFIG_H_ */
+

--- a/nuklear.h
+++ b/nuklear.h
@@ -199,6 +199,17 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#ifdef NK_INCLUDE_CONFIG
+  #ifndef NK_CONFIG_FILE
+    #define NK_CONFIG_FILE "nuklear_config.h"
+  #endif
+  #ifndef NK_NUKLEAR_CONFIG_H_
+    #include NK_CONFIG_FILE
+    #define NK_NUKLEAR_CONFIG_H_
+  #endif
+#endif
+
 /*
  * ==============================================================
  *
@@ -6074,6 +6085,16 @@ template<typename T> struct nk_alignof{struct Big {T x; char c;}; enum {
 
 #ifndef NK_INTERNAL_H
 #define NK_INTERNAL_H
+
+#ifdef NK_INCLUDE_CONFIG
+  #ifndef NK_CONFIG_FILE
+    #define NK_CONFIG_FILE "nuklear_config.h"
+  #endif
+  #ifndef NK_NUKLEAR_CONFIG_H_
+    #include NK_CONFIG_FILE
+    #define NK_NUKLEAR_CONFIG_H_
+  #endif
+#endif
 
 #ifndef NK_POOL_DEFAULT_CAPACITY
 #define NK_POOL_DEFAULT_CAPACITY 16

--- a/src/nuklear.h
+++ b/src/nuklear.h
@@ -9,6 +9,17 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#ifdef NK_INCLUDE_CONFIG
+  #ifndef NK_CONFIG_FILE
+    #define NK_CONFIG_FILE "nuklear_config.h"
+  #endif
+  #ifndef NK_NUKLEAR_CONFIG_H_
+    #include NK_CONFIG_FILE
+    #define NK_NUKLEAR_CONFIG_H_
+  #endif
+#endif
+
 /*
  * ==============================================================
  *

--- a/src/nuklear_internal.h
+++ b/src/nuklear_internal.h
@@ -1,6 +1,16 @@
 #ifndef NK_INTERNAL_H
 #define NK_INTERNAL_H
 
+#ifdef NK_INCLUDE_CONFIG
+  #ifndef NK_CONFIG_FILE
+    #define NK_CONFIG_FILE "nuklear_config.h"
+  #endif
+  #ifndef NK_NUKLEAR_CONFIG_H_
+    #include NK_CONFIG_FILE
+    #define NK_NUKLEAR_CONFIG_H_
+  #endif
+#endif
+
 #ifndef NK_POOL_DEFAULT_CAPACITY
 #define NK_POOL_DEFAULT_CAPACITY 16
 #endif


### PR DESCRIPTION
Resolves: https://github.com/Immediate-Mode-UI/Nuklear/issues/886

See linked issue and commit message for more details and reasoning.

I found this to be a rather good moment to submit this feature as I was updating some of my private repos with it. Also I'm planning to share some code that reuses `demo/sdl3_renderer` with different `main.c` for the purpose of https://github.com/Immediate-Mode-UI/Nuklear/issues/726#issuecomment-3504593874 and https://github.com/Immediate-Mode-UI/Nuklear/issues/888#issuecomment-3855140005, and having its config split into another file will be helpful there.