### PR TITLE
fix(demo): remove nuklear math functions

### DIFF
--- a/demo/common/overview.c
+++ b/demo/common/overview.c
@@ -695,7 +695,7 @@ overview(struct nk_context *ctx)
             ctx->style.chart.show_markers = show_markers;
             if (nk_chart_begin(ctx, NK_CHART_LINES, 32, -1.0f, 1.0f)) {
                 for (i = 0; i < 32; ++i) {
-                    nk_flags res = nk_chart_push(ctx, (float)NK_COS(id));
+                    nk_flags res = nk_chart_push(ctx, (float)cos(id));
                     if (res & NK_CHART_HOVERING)
                         index = (int)i;
                     if (res & NK_CHART_CLICKED)
@@ -706,17 +706,17 @@ overview(struct nk_context *ctx)
             }
 
             if (index != -1)
-                nk_tooltipf(ctx, "Value: %.2f", (float)NK_COS((float)index*step));
+                nk_tooltipf(ctx, "Value: %.2f", (float)cos((float)index*step));
             if (line_index != -1) {
                 nk_layout_row_dynamic(ctx, 20, 1);
-                nk_labelf(ctx, NK_TEXT_LEFT, "Selected value: %.2f", (float)NK_COS((float)index*step));
+                nk_labelf(ctx, NK_TEXT_LEFT, "Selected value: %.2f", (float)cos((float)index*step));
             }
 
             /* column chart */
             nk_layout_row_dynamic(ctx, 100, 1);
             if (nk_chart_begin(ctx, NK_CHART_COLUMN, 32, 0.0f, 1.0f)) {
                 for (i = 0; i < 32; ++i) {
-                    nk_flags res = nk_chart_push(ctx, (float)NK_ABS(NK_SIN(id)));
+                    nk_flags res = nk_chart_push(ctx, (float)fabs(sin(id)));
                     if (res & NK_CHART_HOVERING)
                         index = (int)i;
                     if (res & NK_CHART_CLICKED)
@@ -726,10 +726,10 @@ overview(struct nk_context *ctx)
                 nk_chart_end(ctx);
             }
             if (index != -1)
-                nk_tooltipf(ctx, "Value: %.2f", (float)NK_ABS(NK_SIN(step * (float)index)));
+                nk_tooltipf(ctx, "Value: %.2f", (float)fabs(sin(step * (float)index)));
             if (col_index != -1) {
                 nk_layout_row_dynamic(ctx, 20, 1);
-                nk_labelf(ctx, NK_TEXT_LEFT, "Selected value: %.2f", (float)NK_ABS(NK_SIN(step * (float)col_index)));
+                nk_labelf(ctx, NK_TEXT_LEFT, "Selected value: %.2f", (float)fabs(sin(step * (float)col_index)));
             }
 
             /* mixed chart */
@@ -738,9 +738,9 @@ overview(struct nk_context *ctx)
                 nk_chart_add_slot(ctx, NK_CHART_LINES, 32, -1.0f, 1.0f);
                 nk_chart_add_slot(ctx, NK_CHART_LINES, 32, -1.0f, 1.0f);
                 for (id = 0, i = 0; i < 32; ++i) {
-                    nk_chart_push_slot(ctx, (float)NK_ABS(NK_SIN(id)), 0);
-                    nk_chart_push_slot(ctx, (float)NK_COS(id), 1);
-                    nk_chart_push_slot(ctx, (float)NK_SIN(id), 2);
+                    nk_chart_push_slot(ctx, (float)fabs(sin(id)), 0);
+                    nk_chart_push_slot(ctx, (float)cos(id), 1);
+                    nk_chart_push_slot(ctx, (float)sin(id), 2);
                     id += step;
                 }
             }
@@ -752,9 +752,9 @@ overview(struct nk_context *ctx)
                 nk_chart_add_slot_colored(ctx, NK_CHART_LINES, nk_rgb(0,0,255), nk_rgb(0,0,150),32, -1.0f, 1.0f);
                 nk_chart_add_slot_colored(ctx, NK_CHART_LINES, nk_rgb(0,255,0), nk_rgb(0,150,0), 32, -1.0f, 1.0f);
                 for (id = 0, i = 0; i < 32; ++i) {
-                    nk_chart_push_slot(ctx, (float)NK_ABS(NK_SIN(id)), 0);
-                    nk_chart_push_slot(ctx, (float)NK_COS(id), 1);
-                    nk_chart_push_slot(ctx, (float)NK_SIN(id), 2);
+                    nk_chart_push_slot(ctx, (float)fabs(sin(id)), 0);
+                    nk_chart_push_slot(ctx, (float)cos(id), 1);
+                    nk_chart_push_slot(ctx, (float)sin(id), 2);
                     id += step;
                 }
             }
@@ -1120,8 +1120,8 @@ overview(struct nk_context *ctx)
                         if (nk_chart_begin_colored(ctx, NK_CHART_LINES, nk_rgb(255,0,0), nk_rgb(150,0,0), 32, 0.0f, 1.0f)) {
                             nk_chart_add_slot_colored(ctx, NK_CHART_LINES, nk_rgb(0,0,255), nk_rgb(0,0,150),32, -1.0f, 1.0f);
                             for (i = 0, id = 0; i < 32; ++i) {
-                                nk_chart_push_slot(ctx, (float)NK_ABS(NK_SIN(id)), 0);
-                                nk_chart_push_slot(ctx, (float)NK_COS(id), 1);
+                                nk_chart_push_slot(ctx, (float)fabs(sin(id)), 0);
+                                nk_chart_push_slot(ctx, (float)cos(id), 1);
                                 id += step;
                             }
                         }
@@ -1131,7 +1131,7 @@ overview(struct nk_context *ctx)
                         nk_layout_row_dynamic(ctx, 100, 1);
                         if (nk_chart_begin_colored(ctx, NK_CHART_COLUMN, nk_rgb(255,0,0), nk_rgb(150,0,0), 32, 0.0f, 1.0f)) {
                             for (i = 0, id = 0; i < 32; ++i) {
-                                nk_chart_push_slot(ctx, (float)NK_ABS(NK_SIN(id)), 0);
+                                nk_chart_push_slot(ctx, (float)fabs(sin(id)), 0);
                                 id += step;
                             }
                         }
@@ -1143,9 +1143,9 @@ overview(struct nk_context *ctx)
                             nk_chart_add_slot_colored(ctx, NK_CHART_LINES, nk_rgb(0,0,255), nk_rgb(0,0,150),32, -1.0f, 1.0f);
                             nk_chart_add_slot_colored(ctx, NK_CHART_COLUMN, nk_rgb(0,255,0), nk_rgb(0,150,0), 32, 0.0f, 1.0f);
                             for (i = 0, id = 0; i < 32; ++i) {
-                                nk_chart_push_slot(ctx, (float)NK_ABS(NK_SIN(id)), 0);
-                                nk_chart_push_slot(ctx, (float)NK_ABS(NK_COS(id)), 1);
-                                nk_chart_push_slot(ctx, (float)NK_ABS(NK_SIN(id)), 2);
+                                nk_chart_push_slot(ctx, (float)fabs(sin(id)), 0);
+                                nk_chart_push_slot(ctx, (float)fabs(cos(id)), 1);
+                                nk_chart_push_slot(ctx, (float)fabs(sin(id)), 2);
                                 id += step;
                             }
                         }

--- a/demo/common/overview.c
+++ b/demo/common/overview.c
@@ -864,8 +864,8 @@ overview(struct nk_context *ctx)
                 static double accum_time_seconds = 0.0;
                 const double speed = 3.0, radius = 50.0;
                 struct nk_vec2 offset;
-                offset.x = radius * NK_COS(accum_time_seconds * speed);
-                offset.y = radius * NK_SIN(accum_time_seconds * speed);
+                offset.x = radius * cos(accum_time_seconds * speed);
+                offset.y = radius * sin(accum_time_seconds * speed);
                 nk_tooltip_offset(ctx, "WOW!", NK_MIDDLE_CENTER, offset);
                 accum_time_seconds += (double)(ctx->delta_time_seconds);
             }

--- a/example/extended.c
+++ b/example/extended.c
@@ -127,8 +127,8 @@ ui_piemenu(struct nk_context *ctx, struct nk_vec2 pos, float radius,
 
                 /* separator line */
                 rx = bounds.w/2.0f; ry = 0;
-                dx = rx * (float)NK_COS(a_min) - ry * (float)NK_SIN(a_min);
-                dy = rx * (float)NK_SIN(a_min) + ry * (float)NK_COS(a_min);
+                dx = rx * (float)cos(a_min) - ry * (float)sin(a_min);
+                dy = rx * (float)sin(a_min) + ry * (float)cos(a_min);
                 nk_stroke_line(out, center.x, center.y,
                     center.x + dx, center.y + dy, 1.0f, nk_rgb(50,50,50));
 
@@ -136,8 +136,8 @@ ui_piemenu(struct nk_context *ctx, struct nk_vec2 pos, float radius,
                 a = a_min + (a_max - a_min)/2.0f;
                 rx = bounds.w/2.5f; ry = 0;
                 content.w = 30; content.h = 30;
-                content.x = center.x + ((rx * (float)NK_COS(a) - ry * (float)NK_SIN(a)) - content.w/2.0f);
-                content.y = center.y + (rx * (float)NK_SIN(a) + ry * (float)NK_COS(a) - content.h/2.0f);
+                content.x = center.x + ((rx * (float)cos(a) - ry * (float)sin(a)) - content.w/2.0f);
+                content.y = center.y + (rx * (float)sin(a) + ry * (float)cos(a) - content.h/2.0f);
                 nk_draw_image(out, content, &icons[i], nk_rgb(255,255,255));
                 a_min = a_max; a_max += step;
             }

--- a/example/skinning.c
+++ b/example/skinning.c
@@ -774,9 +774,9 @@ int main(int argc, char *argv[])
                 nk_chart_add_slot_colored(&ctx, NK_CHART_LINES, nk_rgb(0,0,255), nk_rgb(0,0,150),32, -1.0f, 1.0f);
                 nk_chart_add_slot_colored(&ctx, NK_CHART_LINES, nk_rgb(0,255,0), nk_rgb(0,150,0), 32, -1.0f, 1.0f);
                 for (id = 0, i = 0; i < 32; ++i) {
-                    nk_chart_push_slot(&ctx, (float)NK_ABS(NK_SIN(id)), 0);
-                    nk_chart_push_slot(&ctx, (float)NK_COS(id), 1);
-                    nk_chart_push_slot(&ctx, (float)NK_SIN(id), 2);
+                    nk_chart_push_slot(&ctx, (float)fabs(sin(id)), 0);
+                    nk_chart_push_slot(&ctx, (float)cos(id), 1);
+                    nk_chart_push_slot(&ctx, (float)sin(id), 2);
                     id += step;
                 }
             }


### PR DESCRIPTION
This reverts commit 07941526ccb9d4197f00ea92967ca68cfb1fc36e and removes the remaining nuklear sin/cos functions in the examples.

These nuklear math functions were tailored for internal use only, since "nuklear only needs sine and cosine to generate circles" as documented in `nuklear_math.c`.

Replacing the standard math library functions with nuklear's approximation implementations breaks the examples in multiple places.

Fixes https://github.com/Immediate-Mode-UI/Nuklear/issues/959