### PR TITLE
CI: bump ccpp.yml to ubuntu-26.04 and add sdl3_renderer job

### DIFF
--- a/.github/workflows/ccpp.yml
+++ b/.github/workflows/ccpp.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-26.04
 
     steps:
     - uses: actions/checkout@v4
@@ -20,7 +20,7 @@ jobs:
     - name: apt-update
       run: sudo apt-get update -qq
     - name: apt get demo-libs
-      run: sudo apt-get install -y --no-install-recommends glslc liballegro5-dev liballegro-image5-dev liballegro-ttf5-dev libcairo2-dev libglfw3 libglfw3-dev libglew-dev libsdl2-dev libvulkan-dev libwayland-dev libx11-dev libxcb1-dev libxcb-util0-dev libxcb-keysyms1-dev libxft-dev libxkbcommon-x11-dev wayland-protocols
+      run: sudo apt-get install -y --no-install-recommends glslc liballegro5-dev liballegro-image5-dev liballegro-ttf5-dev libcairo2-dev libglfw3 libglfw3-dev libglew-dev libsdl2-dev libsdl3-dev libvulkan-dev libwayland-dev libx11-dev libxcb1-dev libxcb-util0-dev libxcb-keysyms1-dev libxft-dev libxkbcommon-x11-dev wayland-protocols
     - name: build allegro5
       run: make -C demo/allegro5
     - name: build glfw_opengl2
@@ -41,6 +41,8 @@ jobs:
       run: make -C demo/sdl_renderer
     - name: build sdl_vulkan
       run: make -C demo/sdl_vulkan
+    - name: build sdl3_renderer
+      run: make -C demo/sdl3_renderer
     - name: build sdl_rawfb
       run: make -C demo/rawfb/sdl
     - name: build wayland_rawfb


### PR DESCRIPTION
current ubuntu-latest (24.04.3 LTS) doesn't have package for libsdl3-dev
26.04 is still in "preview" but it let's us test demo/sdl3_renderer

Refs: https://github.com/Immediate-Mode-UI/Nuklear/pull/894
Fixes: https://github.com/Immediate-Mode-UI/Nuklear/issues/897
Refs: https://github.com/Immediate-Mode-UI/Nuklear/issues/895