### PR TITLE
add CI workflow for MSVC and fix GDI demo

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -1,0 +1,36 @@
+name: MSVC CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: windows-2025
+
+    steps:
+
+    - uses: actions/checkout@v4
+    - uses: ilammy/msvc-dev-cmd@v1
+      with:
+        arch: x86
+        toolset: 14.0
+
+    - name: build d3d11
+      working-directory: demo/d3d11
+      run: ./build.bat
+    - name: build d3d12
+      working-directory: demo/d3d12
+      run: ./build.bat
+    - name: build d3d9
+      working-directory: demo/d3d9
+      run: ./build.bat
+    - name: build gdi
+      working-directory: demo/gdi
+      run: ./build.bat
+    - name: build gdi_native_nuklear
+      working-directory: demo/gdi_native_nuklear
+      run: ./build.bat
+    - name: build gdip
+      working-directory: demo/gdip
+      run: ./build.bat
+

--- a/demo/gdi/main.c
+++ b/demo/gdi/main.c
@@ -131,7 +131,7 @@ int main(void)
         if (needs_refresh == 0) {
             if (GetMessageW(&msg, NULL, 0, 0) <= 0) {
                 running = 0;
-            } else if (msg.message == WM_SYSKEYDOWN && msg.wParam == 'Q' && GetKeyState(VK_CONTROL) & (1 << 15))
+            } else if (msg.message == WM_SYSKEYDOWN && msg.wParam == 'Q' && GetKeyState(VK_CONTROL) & (1 << 15)) {
                 running = 0;
             } else {
                 TranslateMessage(&msg);


### PR DESCRIPTION
Notes:
- setting up Windows/MSVC manually would be probably a huge headache. I just reused [ilammy/msvc-dev-cmd@v1](https://github.com/ilammy/msvc-dev-cmd) action which seems to be the most popular one.
- every demo/*/build.bat hardcodes directory to the same VC2015 toolchain. That's why CI uses `arch: x86` and `toolset: 14.0`. Would be nice to clean it up someday but for now I just want to get it in
- the workflow is in separate file. I thought it makes sense since it needs to run under entirely different OS/toolchain and builds entirely different demos
- GDI demo appears to be broken since https://github.com/Immediate-Mode-UI/Nuklear/commit/063968520f7bb8129b7a164906be055da3634cd3. I've patched it in separate commit.
- `build d3d11` step is noticeably slower. I don't have any clear explanation for this. Maybe because it is first to run, maybe because of different shader compilation, I'm not sure...
- there are quite a lot of warnings. I may fix those later as part of https://github.com/Immediate-Mode-UI/Nuklear/issues/958
- I'm a total noob when it comes to Github CI, so maybe there is something obvious I didn't notice

DO NOT SQUASH

Refs: https://github.com/Immediate-Mode-UI/Nuklear/issues/895
Refs: https://github.com/Immediate-Mode-UI/Nuklear/pull/937