### PR TITLE
fix: nk_font_config oversampling 3x horizontaly by default

### DIFF
--- a/nuklear.h
+++ b/nuklear.h
@@ -17713,7 +17713,7 @@ nk_font_config(float pixel_height)
     cfg.ttf_size = 0;
     cfg.ttf_data_owned_by_atlas = 0;
     cfg.size = pixel_height;
-    cfg.oversample_h = 3;
+    cfg.oversample_h = 1;
     cfg.oversample_v = 1;
     cfg.pixel_snap = 0;
     cfg.coord_type = NK_COORD_UV;
@@ -18021,9 +18021,14 @@ nk_font_atlas_bake(struct nk_font_atlas *atlas, int *width, int *height,
 
 #ifdef NK_INCLUDE_DEFAULT_FONT
     /* no font added so just use default font */
-    if (!atlas->font_num)
-        atlas->default_font = nk_font_atlas_add_default(atlas, 13.0f, 0);
+    if (!atlas->font_num) {
+        struct nk_font_config config;
+        config = nk_font_config(0);
+        config.oversample_h = 3;
+        atlas->default_font = nk_font_atlas_add_default(atlas, 13.0f, &config);
+    }
 #endif
+
     NK_ASSERT(atlas->font_num);
     if (!atlas->font_num) return 0;
 

--- a/nuklear.h
+++ b/nuklear.h
@@ -18021,6 +18021,13 @@ nk_font_atlas_bake(struct nk_font_atlas *atlas, int *width, int *height,
 
 #ifdef NK_INCLUDE_DEFAULT_FONT
     /* no font added so just use default font */
+    /* FIXME(sleeptightAnsiC): This "fallback" exists for compatibility
+     * with code that creates empty atlas and immediately bakes it.
+     * Several demos do this, but it doesn't make sense for API to allow it.
+     * It was never documented anywhere and it's more of a hack than feature.
+     * App/backend should call nk_font_atlas_add_default() on it's own
+     * with whatever config it wants, and treat it like any other font.
+     * Worth to consider this for removal during next major release... */
     if (!atlas->font_num) {
         struct nk_font_config config;
         config = nk_font_config(0);

--- a/src/nuklear_font.c
+++ b/src/nuklear_font.c
@@ -865,7 +865,7 @@ nk_font_config(float pixel_height)
     cfg.ttf_size = 0;
     cfg.ttf_data_owned_by_atlas = 0;
     cfg.size = pixel_height;
-    cfg.oversample_h = 3;
+    cfg.oversample_h = 1;
     cfg.oversample_v = 1;
     cfg.pixel_snap = 0;
     cfg.coord_type = NK_COORD_UV;
@@ -1173,9 +1173,14 @@ nk_font_atlas_bake(struct nk_font_atlas *atlas, int *width, int *height,
 
 #ifdef NK_INCLUDE_DEFAULT_FONT
     /* no font added so just use default font */
-    if (!atlas->font_num)
-        atlas->default_font = nk_font_atlas_add_default(atlas, 13.0f, 0);
+    if (!atlas->font_num) {
+        struct nk_font_config config;
+        config = nk_font_config(0);
+        config.oversample_h = 3;
+        atlas->default_font = nk_font_atlas_add_default(atlas, 13.0f, &config);
+    }
 #endif
+
     NK_ASSERT(atlas->font_num);
     if (!atlas->font_num) return 0;
 

--- a/src/nuklear_font.c
+++ b/src/nuklear_font.c
@@ -1173,6 +1173,13 @@ nk_font_atlas_bake(struct nk_font_atlas *atlas, int *width, int *height,
 
 #ifdef NK_INCLUDE_DEFAULT_FONT
     /* no font added so just use default font */
+    /* FIXME(sleeptightAnsiC): This "fallback" exists for compatibility
+     * with code that creates empty atlas and immediately bakes it.
+     * Several demos do this, but it doesn't make sense for API to allow it.
+     * It was never documented anywhere and it's more of a hack than feature.
+     * App/backend should call nk_font_atlas_add_default() on it's own
+     * with whatever config it wants, and treat it like any other font.
+     * Worth to consider this for removal during next major release... */
     if (!atlas->font_num) {
         struct nk_font_config config;
         config = nk_font_config(0);


### PR DESCRIPTION
See linked issue for additional information.

According to the commit that introduced this, it was supposed to: _"oversample the default font to make it look better_" but it was oversampling every single font, potentially making it blurry. This fix preserves old behavior for code that may still expect it, but nk_font_config will now use oversample_h=1 by default. Some demos achieve sharp font by scaling their pixel_size and in this case there won't be any difference, but if someone used badly behaving font and didn't notice it only worked because of oversampling, that font may now appear differently (this is unlikely but still possible).

Fixes: https://github.com/Immediate-Mode-UI/Nuklear/issues/855
Refs: https://github.com/Immediate-Mode-UI/Nuklear/commit/1d7f0244f97e2d35a57bc90586863ab89bea9be3

DO NOT SQUASH 