### PR TITLE
fix(overview): custom tooltip position was impossible to select + use proper nk_edit

### DIFF
--- a/demo/common/overview.c
+++ b/demo/common/overview.c
@@ -904,7 +904,6 @@ overview(struct nk_context *ctx)
             /* editor for custom tooltip */
             {
                 static char text_buf[64] = {0};
-                static int text_len = 0;
                 static int text_initialized = 0;
                 static struct nk_vec2 offset = {0};
                 static const char* tooltip_positions[] =
@@ -921,13 +920,12 @@ overview(struct nk_context *ctx)
                     "BOTTOM_CENTER",
                     "BOTTOM_RIGHT"
                 };
-                int cur_pos = NK_TOP_LEFT;
+                static int cur_pos = NK_TOP_LEFT;
 
                 if (!text_initialized) {
                     const char text_default[] = "you can customize this!";
                     NK_ASSERT(sizeof(text_default) < sizeof(text_buf));
                     memcpy(text_buf, text_default, sizeof(text_default));
-                    text_len = sizeof(text_default) - 1;
                     text_initialized = 1;
                 }
                 bounds = nk_widget_bounds(ctx);
@@ -939,17 +937,16 @@ overview(struct nk_context *ctx)
                 nk_rule_horizontal(ctx, nk_white, nk_true);
                 nk_layout_row_dynamic(ctx, 30, 2);
                 nk_label(ctx, "custom tooltip text:", NK_TEXT_LEFT);
-                nk_edit_string(ctx, NK_EDIT_FIELD, text_buf, &text_len, sizeof(text_buf), nk_filter_default);
-                text_buf[text_len] = '\0';  /* TODO: why nk_edit_string is NOT setting this on its own? */
+                nk_edit_string_zero_terminated(ctx, NK_EDIT_SIMPLE, text_buf, sizeof(text_buf), nk_filter_default);
                 nk_layout_row_dynamic(ctx, 30, 1);
                 cur_pos = nk_combo(ctx, tooltip_positions, NK_LEN(tooltip_positions), cur_pos, 25, nk_vec2(200, 200));
 
 
                 nk_layout_row_dynamic(ctx, 30, 2);
                 nk_label(ctx, "custom tooltip offset", NK_TEXT_LEFT);
-                nk_property_float(ctx, "x", -100.0f, &offset.x, 100.0f, 5.0f, 0.5f);
+                nk_property_float(ctx, "#x", -100.0f, &offset.x, 100.0f, 5.0f, 0.5f);
                 nk_label(ctx, "custom tooltip offset", NK_TEXT_LEFT);
-                nk_property_float(ctx, "y", -100.0f, &offset.y, 100.0f, 5.0f, 0.5f);
+                nk_property_float(ctx, "#y", -100.0f, &offset.y, 100.0f, 5.0f, 0.5f);
             }
 
             nk_tree_pop(ctx);


### PR DESCRIPTION
For some reason the 'static' was missing from cur_pos preventing selection of custom tooltip position. This was broken since: https://github.com/Immediate-Mode-UI/Nuklear/commit/063968520f7bb8129b7a164906be055da3634cd3

Also fixed TODO note by using nk_edit_string_zero_terminated rather than reimplementing the wheel with text_len and '\0'

(I also tried fixing https://github.com/Immediate-Mode-UI/Nuklear/issues/974 by using # in the properties and NK_EDIT_SIMPLE in nk_edit_, but that bug is a bigger problem than I thought... I decided to keep those changes in order to rule out all possibilities)

Refs: https://github.com/Immediate-Mode-UI/Nuklear/pull/900
Refs: https://github.com/Immediate-Mode-UI/Nuklear/pull/937