### PR TITLE
doc: replace dead/outdated links + use doxygen comment in src/nuklear_math.c

### DIFF
--- a/demo/allegro5/Readme.md
+++ b/demo/allegro5/Readme.md
@@ -1,6 +1,6 @@
 # Allegro v5 nuklear backend
 
-This backend provides support for [Allegro version 5](https://liballeg.github.io). It works on on all supported platforms with an OpenGL backend, including iOS and Android.
+This backend provides support for [Allegro version 5](https://liballeg.org/). It works on on all supported platforms with an OpenGL backend, including iOS and Android.
 
 Touch support is provided by handling the first touch (ignoring any extra simultaneous touches) and emitting nuklear mouse events. nuklear will handle only the first touch like a single left-mouse click. Dragging the touch screen emits mouse-move events.
 
@@ -13,7 +13,8 @@ Like every nuklear backend, handling many different resolutions and resolution d
 
 ## Soft Keyboard for Touch Screen Devices
 
-Information on how to implement soft keyboard callbacks for Android can be on the Allegro community wiki: https://wiki.allegro.cc/index.php?title=Running_Allegro_applications_on_Android#Displaying_the_Android_keyboard
+Information on how to implement soft keyboard callbacks for Android can be on the Allegro community wiki:
+https://web.archive.org/web/20160722031953/https://wiki.allegro.cc/index.php?title=Running_Allegro_applications_on_Android#Displaying_the_Android_keyboard
 
 To display a soft keyboard on iOS, you must create a `UIView` subclass that implements the `UIKeyInput` interface. See `KeyboardHandleriOS.h` and `KeyboardHandleriOS.m` Objective-C source code files for an example on how to do this. As the Allegro keyboard driver does not currently listen for iOS events, we use a custom event emitter to emit keyboard events, which is passed in after initialization with `(void)setCustomKeyboardEventSource:(ALLEGRO_EVENT_SOURCE *)ev_src`. This causes normal keyboard events to be emitted and properly caught by the nuklear backend. The provided `main.c` demo file does not implement this, but with the provided source code files it is not difficult to do. See this Allegro community forum thread for more information: https://www.allegro.cc/forums/thread/616672
 

--- a/nuklear.h
+++ b/nuklear.h
@@ -6474,35 +6474,34 @@ nk_stbtt_free(void *ptr, void *user_data) {
  *                              MATH
  *
  * ===============================================================*/
-/*/// ### Math
-///  Since nuklear is supposed to work on all systems providing floating point
-///  math without any dependencies I also had to implement my own math functions
-///  for sqrt, sin and cos. Since the actual highly accurate implementations for
-///  the standard library functions are quite complex and I do not need high
-///  precision for my use cases I use approximations.
-///
-///  Sqrt
-///  ----
-///  For square root nuklear uses the famous fast inverse square root:
-///  https://en.wikipedia.org/wiki/Fast_inverse_square_root with
-///  slightly tweaked magic constant. While on today's hardware it is
-///  probably not faster it is still fast and accurate enough for
-///  nuklear's use cases. IMPORTANT: this requires float format IEEE 754
-///
-///  Sine/Cosine
-///  -----------
-///  All constants inside both function are generated Remez's minimax
-///  approximations for value range 0...2*PI. The reason why I decided to
-///  approximate exactly that range is that nuklear only needs sine and
-///  cosine to generate circles which only requires that exact range.
-///  In addition I used Remez instead of Taylor for additional precision:
-///  https://web.archive.org/web/20220629122951/www.lolengine.net/blog/2011/12/21/better-function-approximations
-///
-///  The tool I used to generate constants for both sine and cosine
-///  (it can actually approximate a lot more functions) can be found here:
-///  https://github.com/samhocevar/lolremez
-///  https://web.archive.org/web/20160306205304/www.lolengine.net/wiki/oss/lolremez
-*/
+/**
+ * \page Math
+ * Since nuklear is supposed to work on all systems providing floating point
+ * math without any dependencies I also had to implement my own math functions
+ * for sqrt, sin and cos. Since the actual highly accurate implementations for
+ * the standard library functions are quite complex and I do not need high
+ * precision for my use cases I use approximations.
+ *
+ * # Sqrt
+ * For square root nuklear uses the famous fast inverse square root:
+ * https://en.wikipedia.org/wiki/Fast_inverse_square_root with
+ * slightly tweaked magic constant. While on today's hardware it is
+ * probably not faster it is still fast and accurate enough for
+ * nuklear's use cases. IMPORTANT: this requires float format IEEE 754
+ *
+ * # Sine/Cosine
+ * All constants inside both function are generated Remez's minimax
+ * approximations for value range 0...2*PI. The reason why I decided to
+ * approximate exactly that range is that nuklear only needs sine and
+ * cosine to generate circles which only requires that exact range.
+ * In addition I used Remez instead of Taylor for additional precision:
+ * https://web.archive.org/web/20220629122951/www.lolengine.net/blog/2011/12/21/better-function-approximations
+ *
+ * The tool I used to generate constants for both sine and cosine
+ * (it can actually approximate a lot more functions) can be found here:
+ * https://github.com/samhocevar/lolremez
+ * https://web.archive.org/web/20160306205304/www.lolengine.net/wiki/oss/lolremez
+ */
 #ifdef NK_INV_SQRT_NEEDED
 NK_LIB float
 nk_inv_sqrt(float n)

--- a/nuklear.h
+++ b/nuklear.h
@@ -6496,11 +6496,12 @@ nk_stbtt_free(void *ptr, void *user_data) {
 ///  approximate exactly that range is that nuklear only needs sine and
 ///  cosine to generate circles which only requires that exact range.
 ///  In addition I used Remez instead of Taylor for additional precision:
-///  www.lolengine.net/blog/2011/12/21/better-function-approximations.
+///  https://web.archive.org/web/20220629122951/www.lolengine.net/blog/2011/12/21/better-function-approximations
 ///
 ///  The tool I used to generate constants for both sine and cosine
-///  (it can actually approximate a lot more functions) can be
-///  found here: www.lolengine.net/wiki/oss/lolremez
+///  (it can actually approximate a lot more functions) can be found here:
+///  https://github.com/samhocevar/lolremez
+///  https://web.archive.org/web/20160306205304/www.lolengine.net/wiki/oss/lolremez
 */
 #ifdef NK_INV_SQRT_NEEDED
 NK_LIB float
@@ -7744,7 +7745,10 @@ nk_strfmt(char *buf, int buf_size, const char *fmt, va_list args)
 NK_API nk_hash
 nk_murmur_hash(const void * key, int len, nk_hash seed)
 {
-    /* 32-Bit MurmurHash3: https://code.google.com/p/smhasher/wiki/MurmurHash3*/
+    /* 32-Bit MurmurHash3: https://github.com/aappleby/smhasher
+     * https://github.com/aappleby/smhasher/blob/07bb4de10a63e8cc2e1724865454eba635742383/src/MurmurHash3.cpp#L94-L146
+     * https://web.archive.org/web/20150906085947/https://code.google.com/p/smhasher/wiki/MurmurHash3 */
+
     #define NK_ROTL(x,r) ((x) << (r) | ((x) >> (32 - r)))
 
     nk_uint h1 = seed;

--- a/src/nuklear_math.c
+++ b/src/nuklear_math.c
@@ -28,11 +28,12 @@
 ///  approximate exactly that range is that nuklear only needs sine and
 ///  cosine to generate circles which only requires that exact range.
 ///  In addition I used Remez instead of Taylor for additional precision:
-///  www.lolengine.net/blog/2011/12/21/better-function-approximations.
+///  https://web.archive.org/web/20220629122951/www.lolengine.net/blog/2011/12/21/better-function-approximations
 ///
 ///  The tool I used to generate constants for both sine and cosine
-///  (it can actually approximate a lot more functions) can be
-///  found here: www.lolengine.net/wiki/oss/lolremez
+///  (it can actually approximate a lot more functions) can be found here:
+///  https://github.com/samhocevar/lolremez
+///  https://web.archive.org/web/20160306205304/www.lolengine.net/wiki/oss/lolremez
 */
 #ifdef NK_INV_SQRT_NEEDED
 NK_LIB float

--- a/src/nuklear_math.c
+++ b/src/nuklear_math.c
@@ -6,35 +6,34 @@
  *                              MATH
  *
  * ===============================================================*/
-/*/// ### Math
-///  Since nuklear is supposed to work on all systems providing floating point
-///  math without any dependencies I also had to implement my own math functions
-///  for sqrt, sin and cos. Since the actual highly accurate implementations for
-///  the standard library functions are quite complex and I do not need high
-///  precision for my use cases I use approximations.
-///
-///  Sqrt
-///  ----
-///  For square root nuklear uses the famous fast inverse square root:
-///  https://en.wikipedia.org/wiki/Fast_inverse_square_root with
-///  slightly tweaked magic constant. While on today's hardware it is
-///  probably not faster it is still fast and accurate enough for
-///  nuklear's use cases. IMPORTANT: this requires float format IEEE 754
-///
-///  Sine/Cosine
-///  -----------
-///  All constants inside both function are generated Remez's minimax
-///  approximations for value range 0...2*PI. The reason why I decided to
-///  approximate exactly that range is that nuklear only needs sine and
-///  cosine to generate circles which only requires that exact range.
-///  In addition I used Remez instead of Taylor for additional precision:
-///  https://web.archive.org/web/20220629122951/www.lolengine.net/blog/2011/12/21/better-function-approximations
-///
-///  The tool I used to generate constants for both sine and cosine
-///  (it can actually approximate a lot more functions) can be found here:
-///  https://github.com/samhocevar/lolremez
-///  https://web.archive.org/web/20160306205304/www.lolengine.net/wiki/oss/lolremez
-*/
+/**
+ * \page Math
+ * Since nuklear is supposed to work on all systems providing floating point
+ * math without any dependencies I also had to implement my own math functions
+ * for sqrt, sin and cos. Since the actual highly accurate implementations for
+ * the standard library functions are quite complex and I do not need high
+ * precision for my use cases I use approximations.
+ *
+ * # Sqrt
+ * For square root nuklear uses the famous fast inverse square root:
+ * https://en.wikipedia.org/wiki/Fast_inverse_square_root with
+ * slightly tweaked magic constant. While on today's hardware it is
+ * probably not faster it is still fast and accurate enough for
+ * nuklear's use cases. IMPORTANT: this requires float format IEEE 754
+ *
+ * # Sine/Cosine
+ * All constants inside both function are generated Remez's minimax
+ * approximations for value range 0...2*PI. The reason why I decided to
+ * approximate exactly that range is that nuklear only needs sine and
+ * cosine to generate circles which only requires that exact range.
+ * In addition I used Remez instead of Taylor for additional precision:
+ * https://web.archive.org/web/20220629122951/www.lolengine.net/blog/2011/12/21/better-function-approximations
+ *
+ * The tool I used to generate constants for both sine and cosine
+ * (it can actually approximate a lot more functions) can be found here:
+ * https://github.com/samhocevar/lolremez
+ * https://web.archive.org/web/20160306205304/www.lolengine.net/wiki/oss/lolremez
+ */
 #ifdef NK_INV_SQRT_NEEDED
 NK_LIB float
 nk_inv_sqrt(float n)

--- a/src/nuklear_util.c
+++ b/src/nuklear_util.c
@@ -920,7 +920,10 @@ nk_strfmt(char *buf, int buf_size, const char *fmt, va_list args)
 NK_API nk_hash
 nk_murmur_hash(const void * key, int len, nk_hash seed)
 {
-    /* 32-Bit MurmurHash3: https://code.google.com/p/smhasher/wiki/MurmurHash3*/
+    /* 32-Bit MurmurHash3: https://github.com/aappleby/smhasher
+     * https://github.com/aappleby/smhasher/blob/07bb4de10a63e8cc2e1724865454eba635742383/src/MurmurHash3.cpp#L94-L146
+     * https://web.archive.org/web/20150906085947/https://code.google.com/p/smhasher/wiki/MurmurHash3 */
+
     #define NK_ROTL(x,r) ((x) << (r) | ((x) >> (32 - r)))
 
     nk_uint h1 = seed;


### PR DESCRIPTION
Some time ago, I've noticed that several links are completely dead, and finally decided to clean this up a bit: 1st commit goes through all dead/outdated links and replaces them with archived/newer ones; 2nd commit updates the section under src/nuklear_math.c to proper Doxygen comment.

Having section about internal details in public documentation is probably not the best but I guess it's a useful information too. If someone gets confused about that page, I'll try improving it later. For now I just want to preserve old stuff.

DO NOT SQUASH